### PR TITLE
chore: ignore local mediaJira repo; add OpenAPI spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dev.sh
 DOCKER_README.md
 env.example
 setup_local_db.sh
+mediaJira/

--- a/openapi/openapi_spec/notion_drafts.yaml
+++ b/openapi/openapi_spec/notion_drafts.yaml
@@ -1,0 +1,120 @@
+openapi: 3.0.3
+info:
+  title: Notion Drafts API
+  description: API for managing Notion drafts
+  version: 1.0.0
+
+servers:
+  - url: http://127.0.0.1:8000/api
+    description: Development server
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+paths:
+  /notion-drafts/:
+    post:
+      summary: Create a new Notion draft
+      tags:
+        - Notion Drafts
+      security:
+        - bearerAuth: []
+      responses:
+        '201':
+          description: Draft created successfully
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal server error
+
+    get:
+      summary: List all Notion drafts
+      tags:
+        - Notion Drafts
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: List of drafts retrieved successfully
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal server error
+
+  /notion-drafts/{id}/:
+    get:
+      summary: Retrieve a specific Notion draft
+      tags:
+        - Notion Drafts
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: The ID of the draft to retrieve
+      responses:
+        '200':
+          description: Draft retrieved successfully
+        '404':
+          description: Draft not found
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal server error
+
+    put:
+      summary: Update a specific Notion draft
+      tags:
+        - Notion Drafts
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: The ID of the draft to update
+      responses:
+        '200':
+          description: Draft updated successfully
+        '400':
+          description: Bad request
+        '404':
+          description: Draft not found
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal server error
+
+    delete:
+      summary: Delete a specific Notion draft
+      tags:
+        - Notion Drafts
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: The ID of the draft to delete
+      responses:
+        '204':
+          description: Draft deleted successfully
+        '404':
+          description: Draft not found
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal server error


### PR DESCRIPTION
# Pull Request: Add OpenAPI Specification for Notion Drafts API

## Summary
This PR introduces the OpenAPI specification for the Notion Drafts API endpoints, establishing the foundation for future backend implementation of Notion integration features within the MediaJira application.

## Changes Made
- **Created** `openapi/openapi_spec/notion_drafts.yaml` with complete OpenAPI 3.0.3 specification
- **Defined** five RESTful endpoints following project standards:
  - `POST /notion-drafts/` - Create new draft
  - `GET /notion-drafts/` - List all drafts  
  - `GET /notion-drafts/{id}/` - Retrieve specific draft
  - `PUT /notion-drafts/{id}/` - Update existing draft
  - `DELETE /notion-drafts/{id}/` - Delete draft
- **Implemented** consistent authentication using Bearer token scheme
- **Applied** standard HTTP status codes and error handling patterns
- **Maintained** project conventions matching existing API specifications

## Technical Details
The specification follows the established project patterns observed in other OpenAPI files (`auth.openapi.yaml`, `teams.openapi.yaml`) and provides a clean contract for future Django REST framework implementation. The endpoints are designed to support full CRUD operations for Notion draft management, enabling seamless integration with Notion's database API as documented in the provided Notion API reference.

## Acceptance Criteria
✅ OpenAPI YAML file exists with endpoints only (no request/response examples)  
✅ Saved under `/openapi/openapi_spec/` directory  
✅ Matches planned Django views for backend implementation  
✅ Follows project OpenAPI specification standards  

This specification serves as the foundation for implementing the notion_editor Django app and enables frontend teams to begin integration work while backend development proceeds.
