### PR TITLE
Implement WF-105: add a new /workflows page that lists workflows and …

### DIFF
--- a/frontend/src/app/workflows/page.tsx
+++ b/frontend/src/app/workflows/page.tsx
@@ -1,0 +1,6 @@
+import WorkflowListPage from "@/components/workflows/WorkflowListPage";
+
+export default function WorkflowsPage() {
+  return <WorkflowListPage />;
+}
+

--- a/frontend/src/components/workflows/WorkflowListPage.tsx
+++ b/frontend/src/components/workflows/WorkflowListPage.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
+import Layout from "@/components/layout/Layout";
+import { WorkflowAPI, WorkflowSummary } from "@/lib/api/workflowApi";
+import WorkflowToolbar from "./WorkflowToolbar";
+import WorkflowViews, { WorkflowViewMode } from "./WorkflowViews";
+import type { WorkflowStatus } from "@/lib/api/workflowApi";
+import { AlertCircle, GitBranch, X } from "lucide-react";
+import Modal from "@/components/ui/Modal";
+import toast from "react-hot-toast";
+
+const DEFAULT_PAGE_SIZE = 10;
+
+export default function WorkflowListPage() {
+  const [workflows, setWorkflows] = useState<WorkflowSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [search, setSearch] = useState("");
+  const [status, setStatus] = useState<WorkflowStatus | "all">("all");
+  const [viewMode, setViewMode] = useState<WorkflowViewMode>("table");
+  const [page, setPage] = useState(1);
+
+  const [createModalOpen, setCreateModalOpen] = useState(false);
+  const [newWorkflowName, setNewWorkflowName] = useState("");
+  const [newWorkflowStatus, setNewWorkflowStatus] =
+    useState<WorkflowStatus>("draft");
+
+  const pageSize = DEFAULT_PAGE_SIZE;
+
+  const fetchWorkflows = useCallback(
+    async (opts?: { resetPage?: boolean }) => {
+      setLoading(true);
+      try {
+        const params: any = {
+          search: search || undefined,
+          status: status === "all" ? undefined : status,
+          ordering: "-created_at",
+        };
+        const data = await WorkflowAPI.list(params);
+        setWorkflows(data.results);
+        setError(null);
+        if (opts?.resetPage !== false) {
+          setPage(1);
+        }
+      } catch (err: any) {
+        const message =
+          err?.response?.data?.detail ||
+          err?.message ||
+          "Failed to load workflows.";
+        setError(message);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [search, status]
+  );
+
+  useEffect(() => {
+    fetchWorkflows();
+  }, [fetchWorkflows]);
+
+  const handlePageChange = async (nextPage: number) => {
+    setPage(nextPage);
+  };
+
+  const handleCreateWorkflow = async () => {
+    if (!newWorkflowName.trim()) {
+      toast.error("Please enter a workflow name.");
+      return;
+    }
+    setCreating(true);
+    try {
+      await WorkflowAPI.create({
+        name: newWorkflowName.trim(),
+        status: newWorkflowStatus,
+      });
+      toast.success("Workflow created.");
+      setCreateModalOpen(false);
+      await fetchWorkflows();
+    } catch (err: any) {
+      const message =
+        err?.response?.data?.detail ||
+        err?.message ||
+        "Failed to create workflow.";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleEditWorkflow = (workflow: WorkflowSummary) => {
+    // Placeholder editor route; real implementation can replace this later.
+    window.location.href = `/workflows/${workflow.id}/edit`;
+  };
+
+  const handleDuplicateWorkflow = async (workflow: WorkflowSummary) => {
+    const confirmed = window.confirm(
+      `Create a copy of workflow "${workflow.name}"?`
+    );
+    if (!confirmed) return;
+    setLoading(true);
+    try {
+      await WorkflowAPI.duplicate(workflow.id);
+      await fetchWorkflows({ resetPage: false });
+    } catch (err: any) {
+      const message =
+        err?.response?.data?.detail ||
+        err?.message ||
+        "Failed to duplicate workflow.";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDeleteWorkflow = async (workflow: WorkflowSummary) => {
+    const confirmed = window.confirm(
+      `Delete workflow "${workflow.name}"?`
+    );
+    if (!confirmed) return;
+    setLoading(true);
+    try {
+      await WorkflowAPI.delete(workflow.id);
+      await fetchWorkflows({ resetPage: false });
+      toast.success("Workflow deleted.");
+    } catch (err: any) {
+      const message =
+        err?.response?.data?.detail ||
+        err?.message ||
+        "Failed to delete workflow.";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const headerTotals = useMemo(
+    () => ({
+      total: workflows.length,
+    }),
+    [workflows.length]
+  );
+
+  const paginatedWorkflows = useMemo(() => {
+    const start = (page - 1) * pageSize;
+    const end = start + pageSize;
+    return workflows.slice(start, end);
+  }, [workflows, page, pageSize]);
+
+  return (
+    <ProtectedRoute>
+      <Layout>
+        <div className="min-h-screen bg-gray-50">
+          <div className="mx-auto max-w-6xl px-4 py-10">
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-3 text-sm uppercase tracking-wide text-blue-700">
+                <div className="flex h-6 w-6 items-center justify-center rounded-lg bg-blue-100 text-blue-700">
+                  <GitBranch className="h-4 w-4" />
+                </div>
+                Workflows
+              </div>
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                <div className="space-y-1">
+                  <h1 className="text-3xl font-bold text-gray-900">
+                    Workflows
+                  </h1>
+                  <p className="text-gray-600">
+                    Manage reusable workflows for your projects, similar to the
+                    Jira workflow list.
+                  </p>
+                </div>
+                <div className="flex gap-2 text-sm text-gray-600">
+                  <div className="rounded-lg bg-white px-4 py-2 shadow-sm ring-1 ring-gray-200">
+                    <span className="text-xs uppercase text-gray-500">
+                      Total
+                    </span>
+                    <div className="text-base font-semibold text-gray-900">
+                      {headerTotals.total}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {error && (
+              <div className="mt-4 flex items-center gap-2 rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                <AlertCircle className="h-4 w-4" />
+                <span>{error}</span>
+              </div>
+            )}
+
+            <Modal
+              isOpen={createModalOpen}
+              onClose={() => {
+                if (!creating) {
+                  setCreateModalOpen(false);
+                }
+              }}
+            >
+              <div className="w-full max-w-md rounded-2xl bg-white p-5 shadow-lg">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <h2 className="text-lg font-semibold text-gray-900">
+                      Add Workflow
+                    </h2>
+                    <p className="mt-1 text-sm text-gray-500">
+                      Create a new workflow by specifying a name and status.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => !creating && setCreateModalOpen(false)}
+                    className="rounded-full p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </div>
+
+                <div className="mt-5 space-y-4">
+                  <div className="space-y-1">
+                    <label className="block text-sm font-medium text-gray-700">
+                      Workflow name
+                    </label>
+                    <input
+                      type="text"
+                      value={newWorkflowName}
+                      onChange={(e) => setNewWorkflowName(e.target.value)}
+                      placeholder="e.g. Budget approval flow"
+                      className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <label className="block text-sm font-medium text-gray-700">
+                      Status
+                    </label>
+                    <select
+                      value={newWorkflowStatus}
+                      onChange={(e) =>
+                        setNewWorkflowStatus(
+                          e.target.value as WorkflowStatus
+                        )
+                      }
+                      className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                    >
+                      <option value="draft">Draft</option>
+                      <option value="published">Published</option>
+                      <option value="archived">Archived</option>
+                    </select>
+                  </div>
+                </div>
+
+                <div className="mt-6 flex justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={() => !creating && setCreateModalOpen(false)}
+                    className="rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                    disabled={creating}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleCreateWorkflow}
+                    className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-70"
+                    disabled={creating}
+                  >
+                    {creating && (
+                      <span className="inline-flex items-center">
+                        <span className="mr-1 h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                      </span>
+                    )}
+                    Add Workflow
+                  </button>
+                </div>
+              </div>
+            </Modal>
+
+            <WorkflowToolbar
+              search={search}
+              status={status}
+              onSearchChange={(value) => {
+                setSearch(value);
+              }}
+              onStatusChange={(value) => {
+                setStatus(value);
+              }}
+              onRefresh={() => fetchWorkflows({ resetPage: false })}
+              onCreate={() => {
+                setNewWorkflowName("");
+                setNewWorkflowStatus("draft");
+                setCreateModalOpen(true);
+              }}
+              loading={creating}
+            />
+
+            <WorkflowViews
+              workflows={paginatedWorkflows}
+              loading={loading}
+              error={error}
+              page={page}
+              pageSize={pageSize}
+              total={workflows.length}
+              viewMode={viewMode}
+              onViewModeChange={setViewMode}
+              onPageChange={handlePageChange}
+              onEdit={handleEditWorkflow}
+              onDuplicate={handleDuplicateWorkflow}
+              onDelete={handleDeleteWorkflow}
+            />
+          </div>
+        </div>
+      </Layout>
+    </ProtectedRoute>
+  );
+}

--- a/frontend/src/components/workflows/WorkflowStatusBadge.tsx
+++ b/frontend/src/components/workflows/WorkflowStatusBadge.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import StatusBadge from "@/components/ui/StatusBadge";
+import type { WorkflowStatus } from "@/lib/api/workflowApi";
+
+const STATUS_LABELS: Record<WorkflowStatus, string> = {
+  draft: "Draft",
+  published: "Published",
+  archived: "Archived",
+};
+
+const STATUS_MAPPING: Record<WorkflowStatus, string> = {
+  draft: "draft",
+  published: "active",
+  archived: "completed",
+};
+
+interface WorkflowStatusBadgeProps {
+  status: WorkflowStatus;
+}
+
+export function WorkflowStatusBadge({ status }: WorkflowStatusBadgeProps) {
+  const mapped = STATUS_MAPPING[status] ?? "default";
+  return <StatusBadge status={mapped}>{STATUS_LABELS[status] ?? status}</StatusBadge>;
+}
+
+export default WorkflowStatusBadge;
+

--- a/frontend/src/components/workflows/WorkflowToolbar.tsx
+++ b/frontend/src/components/workflows/WorkflowToolbar.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { WorkflowStatus } from "@/lib/api/workflowApi";
+import { Loader2, Plus, RefreshCw, Search } from "lucide-react";
+
+interface WorkflowToolbarProps {
+  search: string;
+  status: WorkflowStatus | "all";
+  onSearchChange: (value: string) => void;
+  onStatusChange: (value: WorkflowStatus | "all") => void;
+  onRefresh: () => void;
+  onCreate: () => void;
+  loading: boolean;
+}
+
+const STATUS_OPTIONS: { value: WorkflowStatus | "all"; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "draft", label: "Draft" },
+  { value: "published", label: "Published" },
+  { value: "archived", label: "Archived" },
+];
+
+export function WorkflowToolbar({
+  search,
+  status,
+  onSearchChange,
+  onStatusChange,
+  onRefresh,
+  onCreate,
+  loading,
+}: WorkflowToolbarProps) {
+  return (
+    <div className="mt-6 flex flex-col gap-3 rounded-2xl bg-white p-4 shadow-sm ring-1 ring-gray-200 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-1 items-center gap-3">
+        <div className="flex flex-1 items-center gap-2 rounded-xl border border-gray-200 bg-gray-50 px-3 py-2">
+          <Search className="h-4 w-4 text-gray-400" />
+          <input
+            type="search"
+            value={search}
+            onChange={(event) => onSearchChange(event.target.value)}
+            placeholder="Search workflows by name or description"
+            className="w-full bg-transparent text-sm text-gray-800 outline-none placeholder:text-gray-500"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <label className="text-xs font-medium text-gray-500">Status</label>
+          <select
+            value={status}
+            onChange={(event) =>
+              onStatusChange(event.target.value as WorkflowStatus | "all")
+            }
+            className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 shadow-sm"
+          >
+            {STATUS_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <div className="flex items-center justify-end gap-2">
+        <button
+          onClick={onRefresh}
+          className="inline-flex items-center gap-2 rounded-lg border border-gray-200 px-3 py-2 text-sm font-semibold text-gray-700 transition hover:bg-gray-50"
+        >
+          <RefreshCw
+            className={`h-4 w-4 ${
+              loading ? "animate-spin text-blue-600" : "text-gray-400"
+            }`}
+          />
+          Refresh
+        </button>
+        <button
+          onClick={onCreate}
+          className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-700"
+        >
+          <Plus className="h-4 w-4" />
+          {loading ? (
+            <span className="inline-flex items-center gap-1">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Adding…
+            </span>
+          ) : (
+            "Add Workflow"
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default WorkflowToolbar;

--- a/frontend/src/components/workflows/WorkflowViews.tsx
+++ b/frontend/src/components/workflows/WorkflowViews.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import { useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { WorkflowSummary } from "@/lib/api/workflowApi";
+import WorkflowStatusBadge from "./WorkflowStatusBadge";
+import {
+  ArrowRight,
+  Copy,
+  Edit2,
+  LayoutGrid,
+  List as ListIcon,
+  Trash2,
+} from "lucide-react";
+
+export type WorkflowViewMode = "table" | "grid";
+
+interface WorkflowViewsProps {
+  workflows: WorkflowSummary[];
+  loading: boolean;
+  error: string | null;
+  page: number;
+  pageSize: number;
+  total: number;
+  viewMode: WorkflowViewMode;
+  onViewModeChange: (mode: WorkflowViewMode) => void;
+  onPageChange: (page: number) => void;
+  onEdit: (workflow: WorkflowSummary) => void;
+  onDuplicate: (workflow: WorkflowSummary) => void;
+  onDelete: (workflow: WorkflowSummary) => void;
+}
+
+const EMPTY_COLUMNS =
+  "grid place-items-center rounded-2xl border border-dashed border-gray-200 bg-white p-10 text-center text-gray-600";
+
+export function WorkflowViews({
+  workflows,
+  loading,
+  error,
+  page,
+  pageSize,
+  total,
+  viewMode,
+  onViewModeChange,
+  onPageChange,
+  onEdit,
+  onDuplicate,
+  onDelete,
+}: WorkflowViewsProps) {
+  const router = useRouter();
+
+  const totalPages = useMemo(() => {
+    if (!pageSize) return 1;
+    return Math.max(1, Math.ceil(total / pageSize));
+  }, [total, pageSize]);
+
+  const renderPagination = () => {
+    if (totalPages <= 1) return null;
+
+    return (
+      <div className="mt-4 flex items-center justify-between border-t border-gray-200 pt-4 text-sm text-gray-600">
+        <div>
+          Page <span className="font-semibold">{page}</span> of{" "}
+          <span className="font-semibold">{totalPages}</span>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={() => onPageChange(Math.max(1, page - 1))}
+            disabled={page <= 1}
+            className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Previous
+          </button>
+          <button
+            onClick={() => onPageChange(Math.min(totalPages, page + 1))}
+            disabled={page >= totalPages}
+            className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    );
+  };
+
+  const renderTable = () => {
+    if (loading) {
+      return (
+        <div className={EMPTY_COLUMNS}>
+          <p className="font-medium text-gray-900">Loading workflows…</p>
+          <p className="mt-1 text-sm text-gray-500">
+            Fetching workflow list from the backend.
+          </p>
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <div className={EMPTY_COLUMNS}>
+          <p className="font-semibold text-red-600">Failed to load workflows</p>
+          <p className="mt-1 text-sm text-red-500">{error}</p>
+        </div>
+      );
+    }
+
+    if (!workflows.length) {
+      return (
+        <div className={EMPTY_COLUMNS}>
+          <p className="mt-3 font-semibold text-gray-900">
+            No workflows to show
+          </p>
+          <p className="mt-1 text-sm text-gray-500">
+            Create your first workflow or adjust filters/search.
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Workflow
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Status
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Description
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Version
+              </th>
+              <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 bg-white">
+            {workflows.map((workflow) => (
+              <tr
+                key={workflow.id}
+                className="hover:bg-gray-50 cursor-pointer"
+                onClick={() =>
+                  router.push(`/workflows/${workflow.id}/edit`)
+                }
+              >
+                <td className="px-4 py-3 text-sm font-medium text-gray-900">
+                  {workflow.name}
+                </td>
+                <td className="px-4 py-3 text-sm">
+                  <WorkflowStatusBadge status={workflow.status} />
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-600">
+                  {workflow.description || "—"}
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-600">
+                  v{workflow.version}
+                </td>
+                <td
+                  className="px-4 py-3 text-right text-sm text-gray-600"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <div className="inline-flex items-center gap-1">
+                    <button
+                      onClick={() => onEdit(workflow)}
+                      className="inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium text-blue-700 hover:bg-blue-50"
+                    >
+                      <Edit2 className="h-3 w-3" />
+                      Edit workflow
+                    </button>
+                    <button
+                      onClick={() => onDuplicate(workflow)}
+                      className="inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50"
+                    >
+                      <Copy className="h-3 w-3" />
+                      Copy
+                    </button>
+                    <button
+                      onClick={() => onDelete(workflow)}
+                      className="inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-50"
+                    >
+                      <Trash2 className="h-3 w-3" />
+                      Remove workflow
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="px-4 pb-4">{renderPagination()}</div>
+      </div>
+    );
+  };
+
+  const renderGrid = () => {
+    if (loading || error || !workflows.length) {
+      return renderTable();
+    }
+
+    return (
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {workflows.map((workflow) => (
+          <div
+            key={workflow.id}
+            className="flex flex-col rounded-2xl border border-gray-200 bg-white p-4 shadow-sm hover:border-blue-200 hover:shadow-md"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                <h3 className="text-base font-semibold text-gray-900">
+                  {workflow.name}
+                </h3>
+                <p className="mt-1 line-clamp-2 text-xs text-gray-600">
+                  {workflow.description || "No description provided."}
+                </p>
+              </div>
+              <WorkflowStatusBadge status={workflow.status} />
+            </div>
+            <div className="mt-3 flex items-center justify-between text-xs text-gray-500">
+              <span>Version {workflow.version}</span>
+              <button
+                onClick={() => onEdit(workflow)}
+                className="inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium text-blue-700 hover:bg-blue-50"
+              >
+                Edit workflow
+                <ArrowRight className="h-3 w-3" />
+              </button>
+            </div>
+            <div className="mt-3 flex items-center gap-2 text-xs text-gray-600">
+              <button
+                onClick={() => onDuplicate(workflow)}
+                className="inline-flex items-center gap-1 rounded-full bg-gray-50 px-2 py-1 font-medium hover:bg-gray-100"
+              >
+                <Copy className="h-3 w-3" />
+                Copy
+              </button>
+              <button
+                onClick={() => onDelete(workflow)}
+                className="inline-flex items-center gap-1 rounded-full bg-red-50 px-2 py-1 font-medium text-red-700 hover:bg-red-100"
+              >
+                <Trash2 className="h-3 w-3" />
+                Remove workflow
+              </button>
+            </div>
+          </div>
+        ))}
+        <div className="sm:col-span-2 lg:col-span-3">{renderPagination()}</div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="mt-5">
+      <div className="mb-3 flex items-center justify-end gap-2 text-xs text-gray-600">
+        <span className="hidden sm:inline">View</span>
+        <button
+          onClick={() => onViewModeChange("table")}
+          className={`inline-flex items-center gap-1 rounded-full px-3 py-1 ${
+            viewMode === "table"
+              ? "bg-slate-900 text-white"
+              : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+          }`}
+        >
+          <ListIcon className="h-3.5 w-3.5" />
+          Table
+        </button>
+        <button
+          onClick={() => onViewModeChange("grid")}
+          className={`inline-flex items-center gap-1 rounded-full px-3 py-1 ${
+            viewMode === "grid"
+              ? "bg-slate-900 text-white"
+              : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+          }`}
+        >
+          <LayoutGrid className="h-3.5 w-3.5" />
+          Grid
+        </button>
+      </div>
+      {viewMode === "table" ? renderTable() : renderGrid()}
+    </div>
+  );
+}
+
+export default WorkflowViews;

--- a/frontend/src/lib/api/workflowApi.ts
+++ b/frontend/src/lib/api/workflowApi.ts
@@ -1,0 +1,85 @@
+import api from "../api";
+
+export type WorkflowStatus = "draft" | "published" | "archived";
+
+export interface WorkflowSummary {
+  id: number;
+  name: string;
+  description?: string | null;
+  project_id?: number | null;
+  organization_id?: number | null;
+  created_by_id?: number | null;
+  status: WorkflowStatus;
+  version: number;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface WorkflowListParams {
+  search?: string;
+  status?: WorkflowStatus;
+  ordering?: string;
+  project_id?: number;
+  creator?: number;
+  page?: number;
+  page_size?: number;
+}
+
+export interface WorkflowListResponse {
+  results: WorkflowSummary[];
+  count: number;
+}
+
+const normalizeWorkflowList = (data: any): WorkflowListResponse => {
+  if (Array.isArray(data)) {
+    return { results: data, count: data.length };
+  }
+  if (data && Array.isArray(data.results)) {
+    return { results: data.results, count: data.count ?? data.results.length };
+  }
+  return { results: [], count: 0 };
+};
+
+export const WorkflowAPI = {
+  list: async (params?: WorkflowListParams): Promise<WorkflowListResponse> => {
+    const response = await api.get("/api/workflows/", { params });
+    return normalizeWorkflowList(response.data);
+  },
+
+  retrieve: async (id: number): Promise<WorkflowSummary> => {
+    const response = await api.get(`/api/workflows/${id}/`);
+    return response.data as WorkflowSummary;
+  },
+
+  create: async (payload: Partial<WorkflowSummary> & { name?: string }): Promise<WorkflowSummary> => {
+    const body: any = {
+      name: payload.name ?? "New Workflow",
+      description: payload.description ?? "",
+      project_id: payload.project_id ?? null,
+      status: payload.status ?? "draft",
+    };
+    const response = await api.post("/api/workflows/", body);
+    return response.data as WorkflowSummary;
+  },
+
+  update: async (id: number, payload: Partial<WorkflowSummary>): Promise<WorkflowSummary> => {
+    const response = await api.patch(`/api/workflows/${id}/`, payload);
+    return response.data as WorkflowSummary;
+  },
+
+  duplicate: async (id: number): Promise<WorkflowSummary> => {
+    const original = await WorkflowAPI.retrieve(id);
+    const response = await api.post("/api/workflows/", {
+      name: `${original.name} (copy)`,
+      description: original.description ?? "",
+      project_id: original.project_id ?? null,
+      status: original.status ?? "draft",
+    });
+    return response.data as WorkflowSummary;
+  },
+
+  delete: async (id: number): Promise<void> => {
+    await api.delete(`/api/workflows/${id}/`);
+  },
+};
+


### PR DESCRIPTION
Related Jira: SMP-272

- Summary
- 
- Implement WF-105: add a new /workflows page that lists workflows and allows basic management (create, search/filter, paginate, duplicate, delete) using the existing backend workflow APIs.
- 
- Scope
- 
1. Add workflow API client:
- workflowApi.ts
- Wrap /api/workflows/… for list, retrieve, create, duplicate, delete, with basic type definitions.
2. New workflow list UI (App Router):
- page.tsx → entry page.
- WorkflowListPage.tsx
- Top header: “Workflows” + total count.
- Client-side search (search), status filter (draft/published/archived).
- Client-side pagination (page size 10) over the in-memory workflow list.
- “Add Workflow” modal (lets user input name and choose status).
- Row/card actions: Edit (navigate to /workflows/{id}/edit), Copy (duplicate), Remove (delete).
- Toast feedback on create/duplicate/delete.
- WorkflowToolbar.tsx
- Search box, status dropdown, Refresh, “Add Workflow” trigger.
- WorkflowViews.tsx
- Table view (default) + grid/card view toggle.
- Status badges, description, version, actions column.
- Pagination footer (Page X of Y; previous/next).
- WorkflowStatusBadge.tsx
- Map workflow status → existing StatusBadge styles (draft/published/archived).

3. Out of scope
- 
- No backend changes.
- Workflow editor itself (/workflows/{id}/edit) and graph state management are not implemented here (only navigation to the editor route).
- How to test
- 
- Log in and open /workflows.
- Verify:
- Page renders with table view by default; grid toggle works.
- Search filters by name/description (backend search param).
- Status filter shows correct subsets for All/Draft/Published/Archived.
- Click “Add Workflow”:
- Modal appears, allows entering name + selecting status.
- On submit, workflow is created via POST /api/workflows/ and appears in the list; toast shows success.
- Row/card actions:
- Edit workflow navigates to /workflows/{id}/edit (placeholder route).
- Copy creates a duplicated workflow (name with suffix) and keeps current page.
- Remove workflow deletes the item and removes it from the list; toast shows success.
- Pagination:
- With >10 workflows, Page 1 shows first 10 items; Page 2 shows the next items.
- Empty state:
- When there are no workflows (or search/filter yields none), an empty-state message is shown instead of the table.