### PR TITLE
Add Chromatic visual testing to CI/CD pipeline

### DIFF
--- a/.github/workflows/mediajira-ci.yml
+++ b/.github/workflows/mediajira-ci.yml
@@ -278,6 +278,51 @@ jobs:
           echo "Cleaning up unused Docker resources..."
           docker system prune -f
 
+  # Visual Testing with Chromatic
+  chromatic:
+    name: Chromatic Visual Tests
+    runs-on: ubuntu-latest
+    # Only run on pull requests and pushes to main
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for Chromatic to detect changes
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dir: ./frontend/node_modules
+
+      - name: Install dependencies
+        working-directory: ./frontend
+        run: npm ci
+
+      - name: Build Storybook
+        working-directory: ./frontend
+        run: npm run build-storybook
+
+      - name: Publish to Chromatic
+        working-directory: ./frontend
+        id: chromatic
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          buildScriptName: build-storybook
+          exitZeroOnChanges: true  # Don't fail CI on visual changes
+          exitOnceUploaded: true   # Exit after upload, don't wait for results
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+
+      - name: Show Chromatic links
+        if: always()
+        run: |
+          echo "View your Storybook: ${{ steps.chromatic.outputs.storybookUrl }}"
+          echo "View changes: ${{ steps.chromatic.outputs.changesUrl }}"
+
   deploy:
     needs: build_and_test
     runs-on: ubuntu-latest

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "test:ci": "jest --ci --coverage --watchAll=false",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "chromatic": "chromatic --project-token=${CHROMATIC_PROJECT_TOKEN:-chpt_80afe1fb279b248}",
+    "chromatic": "chromatic --exit-zero-on-changes",
     "chromatic:ci": "chromatic --exit-zero-on-changes --project-token=${CHROMATIC_PROJECT_TOKEN}"
   },
   "lint-staged": {


### PR DESCRIPTION
- Add Chromatic job to GitHub Actions workflow
- Configure Chromatic to run on PRs and pushes to main
- Use official chromaui/action@v1 for Chromatic integration
- Update package.json chromatic script for CI compatibility
- Visual tests will run automatically on every PR