### PR TITLE
Feat/chromatic ci

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,51 @@
+name: Chromatic Visual Tests
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+
+jobs:
+  chromatic:
+    name: Chromatic Visual Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for Chromatic to detect changes
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dir: ./frontend/node_modules
+
+      - name: Install dependencies
+        working-directory: ./frontend
+        run: npm ci
+
+      - name: Build Storybook
+        working-directory: ./frontend
+        run: npm run build-storybook
+
+      - name: Publish to Chromatic
+        working-directory: ./frontend
+        id: chromatic
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          buildScriptName: build-storybook
+          exitZeroOnChanges: true  # Don't fail CI on visual changes
+          exitOnceUploaded: true   # Exit after upload, don't wait for results
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+
+      - name: Show Chromatic links
+        if: always()
+        run: |
+          echo "View your Storybook: ${{ steps.chromatic.outputs.storybookUrl }}"
+          echo "View changes: ${{ steps.chromatic.outputs.changesUrl }}"

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -11,6 +11,8 @@ jobs:
   chromatic:
     name: Chromatic Visual Tests
     runs-on: ubuntu-latest
+    # Only run if secret is available
+    if: ${{ secrets.CHROMATIC_PROJECT_TOKEN != '' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -35,6 +37,7 @@ jobs:
       - name: Publish to Chromatic
         working-directory: ./frontend
         id: chromatic
+        continue-on-error: true  # Don't block other checks if Chromatic fails
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/mediajira-ci.yml
+++ b/.github/workflows/mediajira-ci.yml
@@ -278,51 +278,6 @@ jobs:
           echo "Cleaning up unused Docker resources..."
           docker system prune -f
 
-  # Visual Testing with Chromatic
-  chromatic:
-    name: Chromatic Visual Tests
-    runs-on: ubuntu-latest
-    # Only run on pull requests and pushes to main
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Required for Chromatic to detect changes
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-          cache: 'npm'
-          cache-dir: ./frontend/node_modules
-
-      - name: Install dependencies
-        working-directory: ./frontend
-        run: npm ci
-
-      - name: Build Storybook
-        working-directory: ./frontend
-        run: npm run build-storybook
-
-      - name: Publish to Chromatic
-        working-directory: ./frontend
-        id: chromatic
-        uses: chromaui/action@v1
-        with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          buildScriptName: build-storybook
-          exitZeroOnChanges: true  # Don't fail CI on visual changes
-          exitOnceUploaded: true   # Exit after upload, don't wait for results
-        env:
-          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-
-      - name: Show Chromatic links
-        if: always()
-        run: |
-          echo "View your Storybook: ${{ steps.chromatic.outputs.storybookUrl }}"
-          echo "View changes: ${{ steps.chromatic.outputs.changesUrl }}"
-
   deploy:
     needs: build_and_test
     runs-on: ubuntu-latest

--- a/.github/workflows/mediajira-ci.yml
+++ b/.github/workflows/mediajira-ci.yml
@@ -278,6 +278,51 @@ jobs:
           echo "Cleaning up unused Docker resources..."
           docker system prune -f
 
+  # Visual Testing with Chromatic
+  chromatic:
+    name: Chromatic Visual Tests
+    runs-on: ubuntu-latest
+    # Only run on pull requests and pushes to main
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for Chromatic to detect changes
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dir: ./frontend/node_modules
+
+      - name: Install dependencies
+        working-directory: ./frontend
+        run: npm ci
+
+      - name: Build Storybook
+        working-directory: ./frontend
+        run: npm run build-storybook
+
+      - name: Publish to Chromatic
+        working-directory: ./frontend
+        id: chromatic
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          buildScriptName: build-storybook
+          exitZeroOnChanges: true  # Don't fail CI on visual changes
+          exitOnceUploaded: true   # Exit after upload, don't wait for results
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+
+      - name: Show Chromatic links
+        if: always()
+        run: |
+          echo "View your Storybook: ${{ steps.chromatic.outputs.storybookUrl }}"
+          echo "View changes: ${{ steps.chromatic.outputs.changesUrl }}"
+
   deploy:
     needs: build_and_test
     runs-on: ubuntu-latest

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "test:ci": "jest --ci --coverage --watchAll=false",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "chromatic": "chromatic --project-token=${CHROMATIC_PROJECT_TOKEN:-chpt_80afe1fb279b248}",
+    "chromatic": "chromatic --exit-zero-on-changes",
     "chromatic:ci": "chromatic --exit-zero-on-changes --project-token=${CHROMATIC_PROJECT_TOKEN}"
   },
   "lint-staged": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,8 +13,7 @@
     "test:ci": "jest --ci --coverage --watchAll=false",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "chromatic": "chromatic --exit-zero-on-changes",
-    "chromatic:ci": "chromatic --exit-zero-on-changes --project-token=${CHROMATIC_PROJECT_TOKEN}"
+    "chromatic": "chromatic --exit-zero-on-changes"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
New File: `.github/workflows/chromatic.yml`**
- Dedicated workflow for Chromatic visual testing
- Runs on PRs and pushes to `main`/`develop`
- Uses official `chromaui/action@v1`
- Includes error handling to prevent blocking other checks
- Conditional execution based on secret availability

**Updated: `.github/workflows/mediajira-ci.yml`**
- Removed Chromatic job (now in separate file)
- Main CI pipeline focuses on build, test, and security
- Cleaner separation of concerns