### PR TITLE
Fix Chromatic workflow: remove invalid job-level if condition

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -11,8 +11,6 @@ jobs:
   chromatic:
     name: Chromatic Visual Tests
     runs-on: ubuntu-latest
-    # Only run if secret is available
-    if: ${{ secrets.CHROMATIC_PROJECT_TOKEN != '' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
- Remove job-level if condition (secrets not available in that context)
- Rely on continue-on-error for graceful failure handling
- Workflow will run and fail gracefully if secret is missing