### PR TITLE
Feat/chromatic workflow clean

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -39,7 +39,7 @@ jobs:
         continue-on-error: true
         working-directory: ./frontend
         run: |
-          npx chromatic --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }} --exit-zero-on-changes --exit-once-uploaded
+          npx chromatic --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }} --build-script-name=build-storybook --exit-zero-on-changes --exit-once-uploaded
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -21,8 +21,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18'
-          cache: 'npm'
-          cache-dir: ./frontend/node_modules
+
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: ./frontend/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - name: Install dependencies
         working-directory: ./frontend

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -33,13 +33,13 @@ jobs:
         run: npm run build-storybook
 
       - name: Publish to Chromatic
-        working-directory: ./frontend
         id: chromatic
         continue-on-error: true  # Don't block other checks if Chromatic fails
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           buildScriptName: build-storybook
+          workingDirectory: ./frontend
           exitZeroOnChanges: true  # Don't fail CI on visual changes
           exitOnceUploaded: true   # Exit after upload, don't wait for results
         env:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
 
 jobs:
@@ -34,7 +33,19 @@ jobs:
         working-directory: ./frontend
         run: npm ci
 
-      - name: Publish to Chromatic
+      - name: Run Chromatic Tests (PR only - patch build, no baseline update)
+        if: github.event_name == 'pull_request'
+        id: chromatic-pr
+        continue-on-error: true
+        working-directory: ./frontend
+        run: |
+          npx chromatic --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }} --build-script-name=build-storybook --exit-zero-on-changes --exit-once-uploaded --only-changed
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          CHROMATIC_BRANCH: ${{ github.head_ref }}
+
+      - name: Publish to Chromatic (main branch only - creates baseline)
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         id: chromatic
         continue-on-error: true
         working-directory: ./frontend

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -28,25 +28,16 @@ jobs:
         working-directory: ./frontend
         run: npm ci
 
-      - name: Build Storybook
-        working-directory: ./frontend
-        run: npm run build-storybook
-
       - name: Publish to Chromatic
         id: chromatic
-        continue-on-error: true  # Don't block other checks if Chromatic fails
-        uses: chromaui/action@v1
-        with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          buildScriptName: build-storybook
-          workingDirectory: ./frontend
-          exitZeroOnChanges: true  # Don't fail CI on visual changes
-          exitOnceUploaded: true   # Exit after upload, don't wait for results
+        continue-on-error: true
+        working-directory: ./frontend
+        run: |
+          npx chromatic --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }} --exit-zero-on-changes --exit-once-uploaded
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
 
-      - name: Show Chromatic links
+      - name: Chromatic completed
         if: always()
         run: |
-          echo "View your Storybook: ${{ steps.chromatic.outputs.storybookUrl }}"
-          echo "View changes: ${{ steps.chromatic.outputs.changesUrl }}"
+          echo "Chromatic visual testing completed. Check the logs above for Storybook and changes URLs."


### PR DESCRIPTION
Fixes the Chromatic workflow YAML validation errors by using Chromatic CLI directly instead of the GitHub Action, which allows proper use of `working-directory` for monorepo setups.