### PR TITLE
Add path filters to Chromatic workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,7 +4,23 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'frontend/src/**/*.stories.*'
+      - 'frontend/.storybook/**'
+      - 'frontend/src/**/*.js'
+      - 'frontend/src/**/*.tsx'
+      - 'frontend/src/**/*.ts'
+      - 'frontend/package.json'
+      - '.github/workflows/chromatic.yml'
   pull_request:
+    paths:
+      - 'frontend/src/**/*.stories.*'
+      - 'frontend/.storybook/**'
+      - 'frontend/src/**/*.js'
+      - 'frontend/src/**/*.tsx'
+      - 'frontend/src/**/*.ts'
+      - 'frontend/package.json'
+      - '.github/workflows/chromatic.yml'
 
 jobs:
   chromatic:


### PR DESCRIPTION
Only run Chromatic CI/CD when Storybook-related files are changed:
- Story files (*.stories.*)
- Storybook config (.storybook/**)
- Frontend components (js/tsx/ts)
- package.json (dependencies)
- Workflow file itself

Prevents unnecessary runs for unrelated PRs