### PR TITLE
Bgf 10 task start date

### DIFF
--- a/frontend/src/__tests__/integration/TaskCreationFlow.test.tsx
+++ b/frontend/src/__tests__/integration/TaskCreationFlow.test.tsx
@@ -243,6 +243,7 @@ describe('TaskCreationFlow - Budget Task', () => {
           summary: 'Test Budget Task',
           description: 'Test description',
           current_approver_id: 2,
+          start_date: null,
           due_date: null
         });
       });

--- a/frontend/src/app/tasks/page.js
+++ b/frontend/src/app/tasks/page.js
@@ -469,6 +469,7 @@ function TasksPageContent() {
       summary: "",
       description: "",
       current_approver_id: null,
+      start_date: "",
       due_date: "",
     });
     setBudgetData({
@@ -550,6 +551,7 @@ function TasksPageContent() {
         // For report tasks, set the current user as the approver
         current_approver_id:
           taskData.type === "report" ? user?.id : taskData.current_approver_id,
+        start_date: taskData.start_date || null,
         due_date: taskData.due_date || null,
       };
 

--- a/frontend/src/app/tasks/page.js
+++ b/frontend/src/app/tasks/page.js
@@ -513,6 +513,13 @@ function TasksPageContent() {
     retrospectiveValidation.clearErrors();
   };
 
+  // Open create task modal with fresh form state
+  const handleOpenCreateTaskModal = () => {
+    resetFormData();
+    clearAllValidationErrors();
+    setCreateModalOpen(true);
+  };
+
   // Submit method to create task and related objects
   const handleSubmit = async () => {
     console.log("Submitting task creation form with data11:", isSubmitting, taskData);
@@ -819,7 +826,7 @@ function TasksPageContent() {
           <div className="flex flex-row gap-4 mb-8">
             <h1 className="text-3xl font-bold text-gray-900">Tasks</h1>
             <button
-              onClick={() => setCreateModalOpen(true)}
+              onClick={handleOpenCreateTaskModal}
               className="px-3 py-1.5 rounded text-white bg-indigo-600 hover:bg-indigo-700"
             >
               Create Task

--- a/frontend/src/components/tasks/NewTaskForm.tsx
+++ b/frontend/src/components/tasks/NewTaskForm.tsx
@@ -290,6 +290,24 @@ export default function NewTaskForm({
         )}
       </div>
 
+      {/* Start Date */}
+      <div>
+        <label
+          htmlFor="task-start-date"
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          Start Date
+        </label>
+        <input
+          id="task-start-date"
+          name="start_date"
+          type="date"
+          value={taskData.start_date || ""}
+          onChange={(e) => handleInputChange("start_date", e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        />
+      </div>
+
       {/* Due Date */}
       <div>
         <label


### PR DESCRIPTION
Related Jira: SMP-372
Allow users to set a task start_date when creating a new task, using the same date format and UX as due_date, with start_date displayed above due_date.

Details

Frontend:

Updated NewTaskForm (NewTaskForm.tsx) to add a Start Date field (type="date") above the existing Due Date field, bound to taskData.start_date.
Updated the task creation payload in Tasks page (page.js) to send start_date (start_date: taskData.start_date || null) along with due_date.
Ensured resetFormData also clears start_date so the form state is consistent after closing/re-opening the modal.
Backend:

Reused existing support for start_date on the Task model and TaskSerializer; no schema or serializer changes were required.
Tests:

Updated the integration test TaskCreationFlow (TaskCreationFlow.test.tsx) to assert that start_date is included in the createTask payload (currently start_date: null when not set).
Impact

Task creation now has consistent date handling with Task Detail: both start_date and due_date can be edited and are persisted via the same API model.