### PR TITLE
BGF-11 Report task

### DIFF
--- a/frontend/src/app/tasks/page.js
+++ b/frontend/src/app/tasks/page.js
@@ -247,7 +247,6 @@ function TasksPageContent() {
       requiredFields: [
         "title",
         "owner_id",
-        "report_template_id",
         "slice_config.csv_file_path",
       ],
       getPayload: (createdTask) => {
@@ -327,10 +326,6 @@ function TasksPageContent() {
     },
     owner_id: (value) => {
       if (!value || value.trim() === "") return "Owner ID is required";
-      return "";
-    },
-    report_template_id: (value) => {
-      if (!value || value.trim() === "") return "Template ID is required";
       return "";
     },
     "slice_config.csv_file_path": (value) => {

--- a/frontend/src/components/tasks/NewReportForm.tsx
+++ b/frontend/src/components/tasks/NewReportForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ReportAPI } from '@/lib/api/reportApi';
 
 export default function NewReportForm({
@@ -18,6 +18,24 @@ export default function NewReportForm({
   const [error, setError] = useState<string | null>(null);
   const [created, setCreated] = useState(false);
   const [reportId, setReportId] = useState<string | null>(null);
+  const [templates, setTemplates] = useState<any[]>([]);
+  const [loadingTemplates, setLoadingTemplates] = useState(false);
+
+  useEffect(() => {
+    const loadTemplates = async () => {
+      setLoadingTemplates(true);
+      try {
+        const res = await ReportAPI.getTemplates();
+        setTemplates(res.data || []);
+      } catch (err) {
+        console.error('Failed to load report templates', err);
+      } finally {
+        setLoadingTemplates(false);
+      }
+    };
+
+    loadTemplates();
+  }, []);
 
   const handleInputChange = (field: string, value: string) => {
     onReportDataChange({
@@ -82,7 +100,9 @@ export default function NewReportForm({
       const payload = {
         title: reportData.title.trim(),
         owner_id: reportData.owner_id.trim(),
-        report_template_id: reportData.report_template_id.trim(),
+        report_template_id: reportData.report_template_id?.trim()
+          ? reportData.report_template_id.trim()
+          : null,
         slice_config: {
           csv_file_path: reportData.slice_config?.csv_file_path || '',
         },
@@ -140,15 +160,21 @@ export default function NewReportForm({
 
       {/* Template ID */}
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">Template ID *</label>
-        <input
-          type="text"
+        <label className="block text-sm font-medium text-gray-700 mb-1">Template (optional)</label>
+        <select
           value={reportData.report_template_id}
           onChange={(e) => handleInputChange('report_template_id', e.target.value)}
           className="w-full px-3 py-2 border border-gray-300 rounded-md"
-        />
-        {validation.errors.report_template_id && (
-          <p className="text-sm text-red-600 mt-1">{String(validation.errors.report_template_id)}</p>
+        >
+          <option value="">-- None --</option>
+          {templates.map((tpl) => (
+            <option key={tpl.id} value={tpl.id}>
+              {tpl.name || tpl.id}
+            </option>
+          ))}
+        </select>
+        {loadingTemplates && (
+          <p className="text-sm text-gray-500 mt-1">Loading templates...</p>
         )}
       </div>
 

--- a/frontend/src/lib/api/reportApi.ts
+++ b/frontend/src/lib/api/reportApi.ts
@@ -32,6 +32,8 @@ export const ReportAPI = {
     }
   },
 
+  getTemplates: () => api.get('/api/reports/report-templates/'),
+
   getReportById: (id: string | number) => api.get(`/api/reports/reports/${id}/`),
 
   submitReport: (id: string | number) => api.post(`/api/reports/reports/${id}/submit/`),


### PR DESCRIPTION
Front-end removes mandatory field for template:
Remove the mandatory validation and requiredFields restriction for the report template, allowing it to be empty.
Add a dropdown list for template selection: Fetch the template list from the backend /api/reports/report-templates/. In the form, it will be selectable via a dropdown, supporting None.
Request load adjustment: When creating a report, if no template is selected, pass null (backend allows it).
Modify file:
frontend/src/lib/api/reportApi.ts: Add getTemplates
frontend/src/components/tasks/NewReportForm.tsx: Load template list and dropdown selection. Template can be empty in the payload.
frontend/src/app/tasks/page.js: Remove mandatory field validation and requiredFields constraint in the form.