### PR TITLE
Calendar01 005  implement google calendar UI clone with next.js

### DIFF
--- a/frontend/src/app/calendar/page.tsx
+++ b/frontend/src/app/calendar/page.tsx
@@ -183,7 +183,7 @@ function CalendarPageContent() {
   }, [currentView, currentDate]);
 
   return (
-    <Layout showHeader={false} showSidebar={false}>
+    <Layout>
       <div className="flex min-h-screen flex-col bg-gray-50">
         {/* Top toolbar */}
         <header className="flex items-center justify-between border-b bg-white px-4 py-3">

--- a/frontend/src/app/calendar/page.tsx
+++ b/frontend/src/app/calendar/page.tsx
@@ -1,0 +1,443 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { addDays, format, startOfDay, startOfWeek } from "date-fns";
+import Layout from "@/components/layout/Layout";
+import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
+import { useCalendarSidebarData } from "@/hooks/useCalendarSidebarData";
+import { useCalendarView } from "@/hooks/useCalendarView";
+import { CalendarDTO, EventDTO } from "@/lib/api/calendarApi";
+import {
+  CalendarDays,
+  ChevronLeft,
+  ChevronRight,
+  List,
+} from "lucide-react";
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+type CalendarViewType = "day" | "week" | "month" | "year" | "agenda";
+
+const VIEW_LABELS: Record<CalendarViewType, string> = {
+  day: "Day",
+  week: "Week",
+  month: "Month",
+  year: "Year",
+  agenda: "Agenda",
+};
+
+function CalendarPageContent() {
+  const [currentView, setCurrentView] = useState<CalendarViewType>("week");
+  const [currentDate, setCurrentDate] = useState<Date>(new Date());
+  const [visibleCalendarIds, setVisibleCalendarIds] = useState<string[] | undefined>(undefined);
+
+  const { events, calendars, isLoading, error } = useCalendarView({
+    viewType: currentView,
+    currentDate,
+    calendarIds: visibleCalendarIds,
+  });
+
+  const headerTitle = useMemo(() => {
+    if (currentView === "year") {
+      return format(currentDate, "yyyy");
+    }
+    if (currentView === "month" || currentView === "agenda") {
+      return format(currentDate, "MMMM yyyy");
+    }
+    if (currentView === "week") {
+      const start = startOfWeek(currentDate, { weekStartsOn: 1 });
+      const end = addDays(start, 6);
+      const sameMonth = start.getMonth() === end.getMonth();
+      const sameYear = start.getFullYear() === end.getFullYear();
+
+      if (sameMonth && sameYear) {
+        return `${format(start, "MMMM d")} - ${format(end, "d, yyyy")}`;
+      }
+
+      if (sameYear) {
+        return `${format(start, "MMM d")} - ${format(end, "MMM d, yyyy")}`;
+      }
+
+      return `${format(start, "MMM d, yyyy")} - ${format(
+        end,
+        "MMM d, yyyy",
+      )}`;
+    }
+
+    // day view
+    return format(currentDate, "EEEE, MMMM d, yyyy");
+  }, [currentView, currentDate]);
+
+  const handleToday = () => {
+    setCurrentDate(new Date());
+  };
+
+  const handleOffset = (direction: "prev" | "next") => {
+    const multiplier = direction === "next" ? 1 : -1;
+
+    if (currentView === "day") {
+      setCurrentDate((prev) => addDays(prev, 1 * multiplier));
+    } else if (currentView === "week") {
+      setCurrentDate((prev) => addDays(prev, 7 * multiplier));
+    } else if (currentView === "month") {
+      const next = new Date(currentDate);
+      next.setMonth(next.getMonth() + 1 * multiplier);
+      setCurrentDate(next);
+    } else if (currentView === "year") {
+      const next = new Date(currentDate);
+      next.setFullYear(next.getFullYear() + 1 * multiplier);
+      setCurrentDate(next);
+    } else {
+      // agenda: step one week by default
+      setCurrentDate((prev) => addDays(prev, 7 * multiplier));
+    }
+  };
+
+  return (
+    <Layout showHeader={false} showSidebar={false}>
+      <div className="flex min-h-screen flex-col bg-gray-50">
+        {/* Top toolbar */}
+        <header className="flex items-center justify-between border-b bg-white px-4 py-3">
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={handleToday}
+              className="inline-flex items-center rounded-full border border-gray-300 bg-white px-4 py-1.5 text-sm font-medium text-gray-800 hover:bg-gray-50"
+            >
+              Today
+            </button>
+            <div className="flex items-center rounded-full border border-gray-200 bg-white">
+              <button
+                type="button"
+                onClick={() => handleOffset("prev")}
+                className="flex h-8 w-8 items-center justify-center rounded-full hover:bg-gray-100"
+                aria-label="Previous period"
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                onClick={() => handleOffset("next")}
+                className="flex h-8 w-8 items-center justify-center rounded-full hover:bg-gray-100"
+                aria-label="Next period"
+              >
+                <ChevronRight className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-lg font-semibold text-gray-900">
+                {headerTitle}
+              </span>
+              {currentView === "week" && (
+                <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+                  Week view
+                </span>
+              )}
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            {/* View switcher */}
+            <nav
+              aria-label="Calendar view"
+              className="inline-flex rounded-full border border-gray-200 bg-white p-0.5 text-xs"
+            >
+              {(Object.keys(VIEW_LABELS) as CalendarViewType[]).map((view) => {
+                const isActive = currentView === view;
+                return (
+                  <button
+                    key={view}
+                    type="button"
+                    onClick={() => setCurrentView(view)}
+                    className={`rounded-full px-3 py-1 font-medium ${
+                      isActive
+                        ? "bg-blue-600 text-white"
+                        : "text-gray-700 hover:bg-gray-100"
+                    }`}
+                  >
+                    {VIEW_LABELS[view]}
+                  </button>
+                );
+              })}
+            </nav>
+          </div>
+        </header>
+
+        {/* Main content: sidebar + view */}
+        <div className="flex flex-1 overflow-hidden">
+          <CalendarSidebar
+            calendars={calendars}
+            onVisibleCalendarsChange={setVisibleCalendarIds}
+          />
+
+          <section className="flex-1 overflow-auto bg-gray-50 p-4">
+            {currentView === "week" ? (
+              <WeekView
+                currentDate={currentDate}
+                events={events}
+                calendars={calendars}
+                isLoading={isLoading}
+                error={error}
+              />
+            ) : (
+              <div className="flex h-full flex-col items-center justify-center gap-3 text-gray-500">
+                <List className="h-6 w-6" />
+                <p className="text-sm">
+                  {VIEW_LABELS[currentView]} view layout will be implemented in
+                  later steps.
+                </p>
+              </div>
+            )}
+          </section>
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+function WeekView({
+  currentDate,
+  events,
+  calendars,
+  isLoading,
+  error,
+}: {
+  currentDate: Date;
+  events: EventDTO[];
+  calendars: CalendarDTO[];
+  isLoading: boolean;
+  error: Error | null;
+}) {
+  const start = startOfWeek(currentDate, { weekStartsOn: 1 });
+  const days = useMemo(
+    () => Array.from({ length: 7 }, (_, index) => addDays(start, index)),
+    [start],
+  );
+
+  const hours = useMemo(() => Array.from({ length: 13 }, (_, index) => 8 + index), []);
+
+  const calendarColorById = useMemo(() => {
+    const map = new Map<string, string>();
+    calendars.forEach((cal) => {
+      map.set(cal.id, cal.color);
+    });
+    return map;
+  }, [calendars]);
+
+  return (
+    <div className="flex h-full flex-col rounded-xl border bg-white shadow-sm">
+      <div className="grid grid-cols-[60px_repeat(7,minmax(0,1fr))] border-b bg-gray-50 text-xs font-medium text-gray-500">
+        <div className="border-r px-2 py-2" />
+        {days.map((day) => (
+          <div
+            key={day.toISOString()}
+            className="flex flex-col items-center border-r px-2 py-2 last:border-r-0"
+          >
+            <span>{format(day, "EEE")}</span>
+            <span className="mt-1 rounded-full px-1.5 py-0.5 text-sm font-semibold text-gray-800">
+              {format(day, "d")}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid flex-1 grid-cols-[60px_repeat(7,minmax(0,1fr))] overflow-auto text-xs">
+        <div className="border-r bg-gray-50">
+          {hours.map((hour) => (
+            <div
+              key={hour}
+              className="h-12 border-b border-gray-100 px-2 py-1 text-right text-[11px] text-gray-400"
+            >
+              {format(new Date().setHours(hour, 0, 0, 0), "ha")}
+            </div>
+          ))}
+        </div>
+
+        {days.map((day) => {
+          const dayStart = startOfDay(day);
+          const dayEnd = addDays(dayStart, 1);
+          const dayEvents = events.filter((event) => {
+            const evStart = new Date(event.start_datetime);
+            const evEnd = new Date(event.end_datetime);
+            return evEnd > dayStart && evStart < dayEnd;
+          });
+
+          return (
+            <div
+              key={day.toISOString()}
+              className="relative border-r last:border-r-0"
+            >
+              {hours.map((hour) => (
+                <div
+                  key={hour}
+                  className="h-12 border-b border-gray-100 bg-white hover:bg-blue-50"
+                />
+              ))}
+
+              {dayEvents.map((event) => {
+                const evStart = new Date(event.start_datetime);
+                const evEnd = new Date(event.end_datetime);
+
+                const clampedStart = evStart < dayStart ? dayStart : evStart;
+                const clampedEnd = evEnd > dayEnd ? dayEnd : evEnd;
+
+                const totalMinutes = 24 * 60;
+                const startMinutes =
+                  (clampedStart.getTime() - dayStart.getTime()) / 60000;
+                const durationMinutes =
+                  (clampedEnd.getTime() - clampedStart.getTime()) / 60000 || 30;
+
+                const topPercent = (startMinutes / totalMinutes) * 100;
+                const heightPercent = (durationMinutes / totalMinutes) * 100;
+
+                const backgroundColor =
+                  event.color ||
+                  calendarColorById.get(event.calendar_id || "") ||
+                  "#1E88E5";
+
+                return (
+                  <div
+                    key={event.id + event.start_datetime}
+                    className="absolute left-1 right-1 rounded-md px-1.5 py-0.5 text-[11px] text-white shadow-sm"
+                    style={{
+                      top: `${topPercent}%`,
+                      height: `${heightPercent}%`,
+                      backgroundColor,
+                    }}
+                  >
+                    <div className="truncate font-semibold">{event.title}</div>
+                    <div className="truncate opacity-90">
+                      {format(evStart, "HH:mm")} - {format(evEnd, "HH:mm")}
+                    </div>
+                  </div>
+                );
+              })}
+
+              {isLoading && (
+                <div className="pointer-events-none absolute inset-0 bg-white/40" />
+              )}
+              {error && (
+                <div className="pointer-events-none absolute inset-x-2 top-2 rounded bg-red-50 px-2 py-1 text-[10px] text-red-600">
+                  Failed to load events.
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function CalendarSidebar({
+  calendars,
+  onVisibleCalendarsChange,
+}: {
+  calendars: CalendarDTO[];
+  onVisibleCalendarsChange: (calendarIds: string[] | undefined) => void;
+}) {
+  const { myCalendars, otherCalendars, isLoading, error, toggleVisibility } =
+    useCalendarSidebarData();
+
+  React.useEffect(() => {
+    const allIds = calendars.map((cal) => cal.id);
+    if (allIds.length) {
+      onVisibleCalendarsChange(allIds);
+    }
+  }, [calendars, onVisibleCalendarsChange]);
+
+  return (
+    <aside className="hidden w-72 border-r bg-white p-4 lg:block">
+      <div className="mb-4 flex items-center gap-2 text-sm font-semibold text-gray-800">
+        <CalendarDays className="h-4 w-4 text-blue-600" />
+        <span>Calendar</span>
+      </div>
+
+      {/* Mini calendar placeholder */}
+      <div className="mb-6 rounded-xl border bg-gray-50 px-3 py-2 text-xs text-gray-500">
+        Mini calendar will be implemented next. Clicking dates will move the
+        main view.
+      </div>
+
+      <ScrollArea className="h-[calc(100vh-200px)] pr-2">
+        {isLoading && (
+          <p className="mb-2 text-xs text-gray-400">Loading calendars…</p>
+        )}
+        {error && (
+          <p className="mb-2 text-xs text-red-500">
+            Failed to load calendars. Please refresh the page.
+          </p>
+        )}
+
+        {myCalendars.length > 0 && (
+          <div className="mb-4">
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+              My calendars
+            </h3>
+            <ul className="space-y-1">
+              {myCalendars.map((item) => (
+                <li key={item.calendarId}>
+                  <button
+                    type="button"
+                    onClick={() => toggleVisibility(item)}
+                    className="flex w-full items-center gap-2 rounded px-2 py-1 text-left text-sm hover:bg-gray-50"
+                  >
+                    <span
+                      className="h-3 w-3 rounded-sm border"
+                      style={{ backgroundColor: item.isHidden ? "transparent" : item.color }}
+                    />
+                    <span
+                      className={`flex-1 truncate ${
+                        item.isHidden ? "text-gray-400" : "text-gray-800"
+                      }`}
+                    >
+                      {item.name}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {otherCalendars.length > 0 && (
+          <div className="mb-4">
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+              Other calendars
+            </h3>
+            <ul className="space-y-1">
+              {otherCalendars.map((item) => (
+                <li key={item.calendarId}>
+                  <button
+                    type="button"
+                    onClick={() => toggleVisibility(item)}
+                    className="flex w-full items-center gap-2 rounded px-2 py-1 text-left text-sm hover:bg-gray-50"
+                  >
+                    <span
+                      className="h-3 w-3 rounded-sm border"
+                      style={{ backgroundColor: item.isHidden ? "transparent" : item.color }}
+                    />
+                    <span
+                      className={`flex-1 truncate ${
+                        item.isHidden ? "text-gray-400" : "text-gray-800"
+                      }`}
+                    >
+                      {item.name}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </ScrollArea>
+    </aside>
+  );
+}
+
+export default function CalendarPage() {
+  return (
+    <ProtectedRoute>
+      <CalendarPageContent />
+    </ProtectedRoute>
+  );
+}

--- a/frontend/src/app/calendar/page.tsx
+++ b/frontend/src/app/calendar/page.tsx
@@ -119,6 +119,69 @@ function CalendarPageContent() {
     }
   };
 
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+
+      const tag = target.tagName.toLowerCase();
+      const isTypingElement =
+        tag === "input" ||
+        tag === "textarea" ||
+        target.getAttribute("contenteditable") === "true";
+      if (isTypingElement) {
+        return;
+      }
+
+      if (event.key === "t" || event.key === "T") {
+        event.preventDefault();
+        handleToday();
+        return;
+      }
+
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        handleOffset("prev");
+        return;
+      }
+
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        handleOffset("next");
+        return;
+      }
+
+      if (event.key === "d" || event.key === "D") {
+        event.preventDefault();
+        setCurrentView("day");
+        return;
+      }
+      if (event.key === "w" || event.key === "W") {
+        event.preventDefault();
+        setCurrentView("week");
+        return;
+      }
+      if (event.key === "m" || event.key === "M") {
+        event.preventDefault();
+        setCurrentView("month");
+        return;
+      }
+      if (event.key === "y" || event.key === "Y") {
+        event.preventDefault();
+        setCurrentView("year");
+        return;
+      }
+      if (event.key === "a" || event.key === "A") {
+        event.preventDefault();
+        setCurrentView("agenda");
+        return;
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [currentView, currentDate]);
+
   return (
     <Layout showHeader={false} showSidebar={false}>
       <div className="flex min-h-screen flex-col bg-gray-50">

--- a/frontend/src/hooks/useCalendarSidebarData.ts
+++ b/frontend/src/hooks/useCalendarSidebarData.ts
@@ -1,0 +1,137 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  CalendarAPI,
+  CalendarDTO,
+  CalendarSubscriptionDTO,
+} from "@/lib/api/calendarApi";
+import { useAuthStore } from "@/lib/authStore";
+
+export interface SidebarCalendarItem {
+  calendarId: string;
+  subscriptionId: string | null;
+  name: string;
+  color: string;
+  isHidden: boolean;
+  isMine: boolean;
+}
+
+interface UseCalendarSidebarResult {
+  myCalendars: SidebarCalendarItem[];
+  otherCalendars: SidebarCalendarItem[];
+  isLoading: boolean;
+  error: Error | null;
+  toggleVisibility: (item: SidebarCalendarItem) => Promise<void>;
+}
+
+const sidebarCache: {
+  calendars?: CalendarDTO[];
+  subscriptions?: CalendarSubscriptionDTO[];
+} = {};
+
+export function useCalendarSidebarData(): UseCalendarSidebarResult {
+  const [calendars, setCalendars] = useState<CalendarDTO[]>([]);
+  const [subscriptions, setSubscriptions] = useState<CalendarSubscriptionDTO[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const { user } = useAuthStore();
+  const currentUserId = user?.id;
+
+  useEffect(() => {
+    if (sidebarCache.calendars && sidebarCache.subscriptions) {
+      setCalendars(sidebarCache.calendars);
+      setSubscriptions(sidebarCache.subscriptions);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    Promise.all([CalendarAPI.listCalendars(), CalendarAPI.listSubscriptions()])
+      .then(([calRes, subRes]) => {
+        sidebarCache.calendars = calRes.data;
+        sidebarCache.subscriptions = subRes.data;
+        setCalendars(calRes.data);
+        setSubscriptions(subRes.data);
+      })
+      .catch((err: any) => {
+        setError(
+          err instanceof Error ? err : new Error("Failed to load calendar sidebar data"),
+        );
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, []);
+
+  const items = useMemo<SidebarCalendarItem[]>(() => {
+    if (!calendars.length && !subscriptions.length) {
+      return [];
+    }
+
+    const byCalendarId = new Map<string, CalendarSubscriptionDTO>();
+    subscriptions.forEach((sub) => {
+      if (sub.calendar) {
+        byCalendarId.set(sub.calendar.id, sub);
+      }
+    });
+
+    return calendars.map((cal) => {
+      const sub = byCalendarId.get(cal.id);
+      const effectiveColor = sub?.color_override || cal.color;
+      const isHidden = sub?.is_hidden ?? false;
+      const subscriptionId = sub ? sub.id : null;
+      const isMine =
+        typeof currentUserId === "number"
+          ? cal.owner?.id === currentUserId
+          : false;
+
+      return {
+        calendarId: cal.id,
+        subscriptionId,
+        name: cal.name,
+        color: effectiveColor,
+        isHidden,
+        isMine,
+      };
+    });
+  }, [calendars, subscriptions, currentUserId]);
+
+  const myCalendars = items.filter((item) => item.isMine);
+  const otherCalendars = items.filter((item) => !item.isMine);
+
+  const toggleVisibility = async (item: SidebarCalendarItem) => {
+    if (!item.subscriptionId) {
+      return;
+    }
+
+    const nextHidden = !item.isHidden;
+    const previousSubscriptions = [...subscriptions];
+
+    setSubscriptions((current) =>
+      current.map((sub) =>
+        sub.id === item.subscriptionId
+          ? { ...sub, is_hidden: nextHidden }
+          : sub,
+      ),
+    );
+
+    try {
+      await CalendarAPI.updateSubscription(item.subscriptionId, {
+        is_hidden: nextHidden,
+      });
+    } catch (err) {
+      setSubscriptions(previousSubscriptions);
+      throw err;
+    }
+  };
+
+  return {
+    myCalendars,
+    otherCalendars,
+    isLoading,
+    error,
+    toggleVisibility,
+  };
+}
+

--- a/frontend/src/hooks/useCalendarView.ts
+++ b/frontend/src/hooks/useCalendarView.ts
@@ -1,0 +1,113 @@
+import { useEffect, useState } from "react";
+import {
+  CalendarAPI,
+  CalendarDTO,
+  CalendarViewResponse,
+  CalendarViewType,
+  EventDTO,
+} from "@/lib/api/calendarApi";
+import { format, startOfDay, startOfWeek } from "date-fns";
+
+interface UseCalendarViewOptions {
+  viewType: CalendarViewType;
+  currentDate: Date;
+  calendarIds?: string[];
+}
+
+interface UseCalendarViewResult {
+  events: EventDTO[];
+  calendars: CalendarDTO[];
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+const cache = new Map<string, CalendarViewResponse>();
+
+function buildCacheKey(opts: UseCalendarViewOptions): string {
+  const { viewType, currentDate, calendarIds } = opts;
+  const baseDate = startOfDay(currentDate).toISOString();
+  const ids = (calendarIds || []).slice().sort().join(",");
+  return `${viewType}:${baseDate}:${ids}`;
+}
+
+export function useCalendarView(
+  options: UseCalendarViewOptions,
+): UseCalendarViewResult {
+  const [events, setEvents] = useState<EventDTO[]>([]);
+  const [calendars, setCalendars] = useState<CalendarDTO[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const { viewType, currentDate, calendarIds } = options;
+
+  const key = buildCacheKey(options);
+
+  const load = () => {
+    setIsLoading(true);
+    setError(null);
+
+    const existing = cache.get(key);
+    if (existing) {
+      setEvents(existing.events);
+      setCalendars(existing.calendars);
+      setIsLoading(false);
+      return;
+    }
+
+    let request;
+    if (viewType === "day") {
+      request = CalendarAPI.getDayView({
+        date: format(startOfDay(currentDate), "yyyy-MM-dd"),
+        calendar_ids: calendarIds,
+      });
+    } else if (viewType === "week") {
+      const start = startOfWeek(currentDate, { weekStartsOn: 1 });
+      request = CalendarAPI.getWeekView({
+        start_date: format(start, "yyyy-MM-dd"),
+        calendar_ids: calendarIds,
+      });
+    } else if (viewType === "month") {
+      request = CalendarAPI.getMonthView({
+        year: currentDate.getFullYear(),
+        month: currentDate.getMonth() + 1,
+        calendar_ids: calendarIds,
+      });
+    } else {
+      // agenda & year reuse agenda endpoint for now.
+      const start = startOfDay(currentDate);
+      const end = new Date(start);
+      end.setDate(end.getDate() + (viewType === "agenda" ? 7 : 365));
+      request = CalendarAPI.getAgendaView({
+        start_date: start.toISOString(),
+        end_date: end.toISOString(),
+        calendar_ids: calendarIds,
+      });
+    }
+
+    request
+      .then((response) => {
+        cache.set(key, response.data);
+        setEvents(response.data.events);
+        setCalendars(response.data.calendars);
+      })
+      .catch((err: any) => {
+        setError(err instanceof Error ? err : new Error("Failed to load calendar view"));
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  const refetch = () => {
+    cache.delete(key);
+    load();
+  };
+
+  return { events, calendars, isLoading, error, refetch };
+}

--- a/frontend/src/lib/api/calendarApi.ts
+++ b/frontend/src/lib/api/calendarApi.ts
@@ -1,0 +1,124 @@
+import api from "../api";
+
+export type CalendarViewType = "day" | "week" | "month" | "year" | "agenda";
+
+export interface UserSummaryDTO {
+  id: number;
+  email: string;
+  username: string;
+  full_name: string;
+}
+
+export interface CalendarDTO {
+  id: string;
+  organization_id: string;
+  owner: UserSummaryDTO;
+  name: string;
+  description?: string | null;
+  color: string;
+  visibility: string;
+  timezone: string;
+  is_primary: boolean;
+  location?: string | null;
+}
+
+export interface EventDTO {
+  id: string;
+  calendar_id?: string;
+  title: string;
+  description?: string;
+  start_datetime: string;
+  end_datetime: string;
+  is_all_day: boolean;
+  is_recurring: boolean;
+  color?: string;
+  etag?: string;
+}
+
+export interface CalendarViewResponse {
+  view_type: CalendarViewType;
+  start_date: string;
+  end_date: string;
+  events: EventDTO[];
+  calendars: CalendarDTO[];
+}
+
+export interface CalendarSubscriptionDTO {
+  id: string;
+  calendar: CalendarDTO | null;
+  source_url: string | null;
+  color_override: string | null;
+  is_hidden: boolean;
+}
+
+export const CalendarAPI = {
+  listCalendars: () => api.get<CalendarDTO[]>("/api/v1/calendars/"),
+
+  listSubscriptions: () =>
+    api.get<CalendarSubscriptionDTO[]>("/api/v1/subscriptions/"),
+
+  updateSubscription: (
+    subscriptionId: string,
+    data: Partial<Pick<CalendarSubscriptionDTO, "color_override" | "is_hidden">>,
+  ) =>
+    api.patch<CalendarSubscriptionDTO>(
+      `/api/v1/subscriptions/${subscriptionId}/`,
+      data,
+    ),
+
+  // Raw view endpoints – higher level hooks will choose which one to call.
+  getDayView: (params: { date: string; calendar_ids?: string[] }) =>
+    api.get<CalendarViewResponse>("/api/v1/views/day/", {
+      params: {
+        date: params.date,
+        calendar_ids: params.calendar_ids?.join(","),
+      },
+    }),
+
+  getWeekView: (params: { start_date: string; calendar_ids?: string[] }) =>
+    api.get<CalendarViewResponse>("/api/v1/views/week/", {
+      params: {
+        start_date: params.start_date,
+        calendar_ids: params.calendar_ids?.join(","),
+      },
+    }),
+
+  getMonthView: (params: {
+    year: number;
+    month: number;
+    calendar_ids?: string[];
+  }) =>
+    api.get<CalendarViewResponse>("/api/v1/views/month/", {
+      params: {
+        year: params.year,
+        month: params.month,
+        calendar_ids: params.calendar_ids?.join(","),
+      },
+    }),
+
+  getAgendaView: (params: {
+    start_date: string;
+    end_date?: string;
+    calendar_ids?: string[];
+  }) =>
+    api.get<CalendarViewResponse>("/api/v1/views/agenda/", {
+      params: {
+        start_date: params.start_date,
+        end_date: params.end_date,
+        calendar_ids: params.calendar_ids?.join(","),
+      },
+    }),
+
+  createEvent: (payload: Partial<EventDTO>) =>
+    api.post<EventDTO>("/api/v1/events/", payload),
+
+  updateEvent: (eventId: string, payload: Partial<EventDTO>, etag?: string) =>
+    api.patch<EventDTO>(`/api/v1/events/${eventId}/`, payload, {
+      headers: etag ? { "If-Match": etag } : {},
+    }),
+
+  deleteEvent: (eventId: string, etag?: string) =>
+    api.delete<void>(`/api/v1/events/${eventId}/`, {
+      headers: etag ? { "If-Match": etag } : {},
+    }),
+};


### PR DESCRIPTION
SMP-405
Title

Implement Google Calendar–like UI at /calendar

Summary

Add /calendar page using the shared Layout so global header + main sidebar remain visible.
Implement internal calendar layout: top toolbar (Today, prev/next, date range, view switcher) + calendar sidebar (mini month + calendar list) + main view.
Main Changes

Integrate with existing calendar APIs for:
Calendars & subscriptions.
View endpoints (day/week/month/year/agenda or agenda-based year).
Event create/update/delete (with ETag).
Implement views:
Day / Week: 24‑hour grid, event rendering, vertical drag and resize for non‑recurring events; recurring events are read‑only.
Month: 6×7 grid, per‑day event list, click day → Day view, click event → edit dialog.
Year: 12 mini months; click date → Day view.
Agenda (Schedule): date‑grouped list; click row → edit dialog.
Event dialog:
Opens on empty slot click (quick‑add) or event click (edit).
Fields: title, calendar, start/end, description.
Supports create, update (If‑Match), delete (non‑recurring only).
Sidebar (inside page):
Mini calendar for navigation.
Calendar list with visibility toggles wired to subscriptions; only visible calendars are queried/rendered.
Out of Scope (for this PR)

Full recurrence editor (series/future/single instance).
Guests, reminders, conferencing, attachments, advanced options.
Detailed mobile layout and full accessibility pass (basic semantics only).
How to Test

Go to /calendar; verify global header + main sidebar and the calendar UI render together.
Switch views via toolbar and keyboard shortcuts (T, ←, →, D/W/M/Y/A).
Use sidebar mini calendar and visibility checkboxes; confirm events filter correctly.
Create, edit, delete events in Day/Week/Month/Agenda views; refresh to confirm persistence.
Drag and resize non‑recurring events in Day/Week; ensure time updates and no edit dialog opens automatically after drag.