### PR TITLE
Refine calendar event dialog and drag behavior

### DIFF
--- a/frontend/src/hooks/useCalendarView.ts
+++ b/frontend/src/hooks/useCalendarView.ts
@@ -6,7 +6,7 @@ import {
   CalendarViewType,
   EventDTO,
 } from "@/lib/api/calendarApi";
-import { format, startOfDay, startOfWeek } from "date-fns";
+import { addDays, format, startOfDay, startOfWeek } from "date-fns";
 
 interface UseCalendarViewOptions {
   viewType: CalendarViewType;
@@ -57,14 +57,19 @@ export function useCalendarView(
 
     let request;
     if (viewType === "day") {
-      request = CalendarAPI.getDayView({
-        date: format(startOfDay(currentDate), "yyyy-MM-dd"),
+      const start = startOfDay(currentDate);
+      const end = addDays(start, 1);
+      request = CalendarAPI.getAgendaView({
+        start_date: start.toISOString(),
+        end_date: end.toISOString(),
         calendar_ids: calendarIds,
       });
     } else if (viewType === "week") {
       const start = startOfWeek(currentDate, { weekStartsOn: 1 });
-      request = CalendarAPI.getWeekView({
-        start_date: format(start, "yyyy-MM-dd"),
+      const end = addDays(start, 7);
+      request = CalendarAPI.getAgendaView({
+        start_date: start.toISOString(),
+        end_date: end.toISOString(),
         calendar_ids: calendarIds,
       });
     } else if (viewType === "month") {

--- a/frontend/src/lib/api/calendarApi.ts
+++ b/frontend/src/lib/api/calendarApi.ts
@@ -29,6 +29,7 @@ export interface EventDTO {
   description?: string;
   start_datetime: string;
   end_datetime: string;
+  timezone?: string;
   is_all_day: boolean;
   is_recurring: boolean;
   color?: string;
@@ -112,13 +113,11 @@ export const CalendarAPI = {
   createEvent: (payload: Partial<EventDTO>) =>
     api.post<EventDTO>("/api/v1/events/", payload),
 
-  updateEvent: (eventId: string, payload: Partial<EventDTO>, etag?: string) =>
-    api.patch<EventDTO>(`/api/v1/events/${eventId}/`, payload, {
-      headers: etag ? { "If-Match": etag } : {},
-    }),
+  // For now we do not send If-Match headers to avoid 412 conflicts
+  // when the same user updates an event multiple times quickly.
+  updateEvent: (eventId: string, payload: Partial<EventDTO>, _etag?: string) =>
+    api.patch<EventDTO>(`/api/v1/events/${eventId}/`, payload),
 
-  deleteEvent: (eventId: string, etag?: string) =>
-    api.delete<void>(`/api/v1/events/${eventId}/`, {
-      headers: etag ? { "If-Match": etag } : {},
-    }),
+  deleteEvent: (eventId: string, _etag?: string) =>
+    api.delete<void>(`/api/v1/events/${eventId}/`),
 };


### PR DESCRIPTION
Summary

Add two-step event UX:
Click event → small view card next to the event (title/time/description/calendar).
Click pencil on the card → open full Google Calendar–style edit panel.
Keep full edit panel for create/edit with title, date/time, description and calendar; create uses dropdown, edit shows read-only calendar name + color.
Position both view card and edit panel as floating panels near the clicked event/time slot (no gray background overlay).
Make Week view drag behavior more natural:
Vertical drag moves event in time.
Horizontal drag moves event across days while preserving time-of-day and duration.
Resize handle adjusts only end time with a minimum duration.
Fix time editing and backend errors:
Use local localStart/localEnd state in the dialog so changing date/time actually updates start_datetime/end_datetime.
Include calendar_id and timezone when updating.
Stop sending If-Match headers to avoid 412 ETag conflicts in normal single-user editing.
How to Test

Edit an event via the small view card + pencil, change date/time, Save → event moves correctly and persists.
Create an event from an empty slot via the full panel → appears at correct time/date.
In Week view, drag events up/down (time changes) and across days (date changes, duration stays the same) without “Failed to update event time” or backend errors.