### PR TITLE
MED-23 add Jira ticket detail layout (header, content, sidebar composition)

### DIFF
--- a/frontend/src/components/jira-ticket/TicketDetailContent.tsx
+++ b/frontend/src/components/jira-ticket/TicketDetailContent.tsx
@@ -1,0 +1,81 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import JiraTicketCard, {
+    JiraTicketCardBody,
+    JiraTicketCardHeader,
+} from "./JiraTicketCard"
+
+export interface TicketDetailContentProps
+    extends React.HTMLAttributes<HTMLDivElement> {}
+
+const TicketDetailContent = React.forwardRef<
+    HTMLDivElement,
+    TicketDetailContentProps
+>(({ className, ...props }, ref) => (
+    <div
+        ref={ref}
+        className={cn("flex w-full flex-col gap-4", className)}
+        {...props}
+    >
+        {/* Placeholder blocks for layout-only preview. */}
+        <JiraTicketCard>
+            <JiraTicketCardHeader>Description</JiraTicketCardHeader>
+            <JiraTicketCardBody>
+                <div className="text-sm text-slate-600">
+                    Add a detailed description of the ticket, goals, and expected
+                    outcomes. Use this space for context and acceptance criteria.
+                </div>
+            </JiraTicketCardBody>
+        </JiraTicketCard>
+
+        <JiraTicketCard>
+            <JiraTicketCardHeader>Linked work items</JiraTicketCardHeader>
+            <JiraTicketCardBody>
+                <div className="space-y-2 text-sm text-slate-600">
+                    <div className="flex items-center justify-between rounded-md border border-slate-200 px-3 py-2">
+                        <span className="font-medium text-slate-800">WEB-114</span>
+                        <span className="text-xs text-slate-500">Blocked by</span>
+                    </div>
+                    <div className="flex items-center justify-between rounded-md border border-slate-200 px-3 py-2">
+                        <span className="font-medium text-slate-800">API-332</span>
+                        <span className="text-xs text-slate-500">Relates to</span>
+                    </div>
+                </div>
+            </JiraTicketCardBody>
+        </JiraTicketCard>
+
+        <JiraTicketCard>
+            <JiraTicketCardHeader>Activity</JiraTicketCardHeader>
+            <JiraTicketCardBody>
+                <div className="space-y-3">
+                    {/* Static tabs to illustrate layout only. */}
+                    <div className="flex flex-wrap gap-2 text-xs font-medium text-slate-600">
+                        <button
+                            type="button"
+                            className="rounded-full border border-slate-200 bg-slate-100 px-3 py-1 text-slate-900"
+                        >
+                            All
+                        </button>
+                        {["Comments", "History", "Work log"].map((tab) => (
+                            <button
+                                key={tab}
+                                type="button"
+                                className="rounded-full border border-slate-200 px-3 py-1 hover:bg-slate-50"
+                            >
+                                {tab}
+                            </button>
+                        ))}
+                    </div>
+                    <div className="text-sm text-slate-600">
+                        Recent updates, comments, and work logs will appear here. Use this
+                        space for collaboration notes and progress tracking.
+                    </div>
+                </div>
+            </JiraTicketCardBody>
+        </JiraTicketCard>
+    </div>
+))
+
+TicketDetailContent.displayName = "TicketDetailContent"
+
+export default TicketDetailContent

--- a/frontend/src/components/jira-ticket/TicketDetailHeader.tsx
+++ b/frontend/src/components/jira-ticket/TicketDetailHeader.tsx
@@ -1,0 +1,34 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface TicketDetailHeaderProps
+    extends React.HTMLAttributes<HTMLDivElement> {
+    left?: React.ReactNode
+    right?: React.ReactNode
+}
+
+const TicketDetailHeader = React.forwardRef<
+    HTMLDivElement,
+    TicketDetailHeaderProps
+>(({ left, right, className, ...props }, ref) => (
+    // Layout-only header shell with left/right slots.
+    <header
+        ref={ref}
+        className={cn(
+            "w-full border-b border-slate-200 bg-white px-6 py-4",
+            className
+        )}
+        {...props}
+    >
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="min-w-0 flex-1">{left}</div>
+            {right ? (
+                <div className="flex shrink-0 items-center gap-2">{right}</div>
+            ) : null}
+        </div>
+    </header>
+))
+
+TicketDetailHeader.displayName = "TicketDetailHeader"
+
+export default TicketDetailHeader

--- a/frontend/src/components/jira-ticket/TicketDetailLayout.tsx
+++ b/frontend/src/components/jira-ticket/TicketDetailLayout.tsx
@@ -1,0 +1,32 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface TicketDetailLayoutProps
+    extends React.HTMLAttributes<HTMLDivElement> {
+    header?: React.ReactNode
+    content?: React.ReactNode
+    sidebar?: React.ReactNode
+}
+
+const TicketDetailLayout = React.forwardRef<
+    HTMLDivElement,
+    TicketDetailLayoutProps
+>(({ header, content, sidebar, className, ...props }, ref) => (
+    <div
+        ref={ref}
+        className={cn("flex w-full flex-col gap-4 bg-slate-50", className)}
+        {...props}
+    >
+        {/* Each region can be rendered independently for Storybook. */}
+        {header}
+        {/* Stack on mobile, split into two columns on desktop. */}
+        <div className="flex flex-col gap-4 px-6 pb-8 md:flex-row md:items-start">
+            <div className="min-w-0 flex-1">{content}</div>
+            <div className="w-full md:w-auto">{sidebar}</div>
+        </div>
+    </div>
+))
+
+TicketDetailLayout.displayName = "TicketDetailLayout"
+
+export default TicketDetailLayout

--- a/frontend/src/components/jira-ticket/TicketDetailSidebar.tsx
+++ b/frontend/src/components/jira-ticket/TicketDetailSidebar.tsx
@@ -1,0 +1,168 @@
+import * as React from "react"
+import { ChevronDown } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+export interface TicketDetailSidebarProps
+    extends React.HTMLAttributes<HTMLElement> {
+    defaultCollapsed?: boolean
+    defaultWidth?: number
+    minWidth?: number
+    maxWidth?: number
+}
+
+const clamp = (value: number, min: number, max: number) =>
+    Math.min(Math.max(value, min), max)
+
+const TicketDetailSidebar = React.forwardRef<
+    HTMLElement,
+    TicketDetailSidebarProps
+>(
+    (
+        {
+            defaultCollapsed = false,
+            defaultWidth = 320,
+            minWidth = 260,
+            maxWidth = 420,
+            className,
+            ...props
+        },
+        ref
+    ) => {
+        const [isCollapsed, setIsCollapsed] = React.useState(defaultCollapsed)
+        const [width, setWidth] = React.useState(() =>
+            clamp(defaultWidth, minWidth, maxWidth)
+        )
+        const [isDragging, setIsDragging] = React.useState(false)
+        const dragState = React.useRef({
+            startX: 0,
+            startWidth: clamp(defaultWidth, minWidth, maxWidth),
+        })
+
+        // Track global pointer moves while resizing the sidebar.
+        React.useEffect(() => {
+            if (!isDragging) {
+                return
+            }
+
+            const handleMouseMove = (event: MouseEvent) => {
+                const deltaX = event.clientX - dragState.current.startX
+                const nextWidth = clamp(
+                    dragState.current.startWidth - deltaX,
+                    minWidth,
+                    maxWidth
+                )
+                setWidth(nextWidth)
+            }
+
+            const handleMouseUp = () => {
+                setIsDragging(false)
+            }
+
+            window.addEventListener("mousemove", handleMouseMove)
+            window.addEventListener("mouseup", handleMouseUp)
+
+            return () => {
+                window.removeEventListener("mousemove", handleMouseMove)
+                window.removeEventListener("mouseup", handleMouseUp)
+            }
+        }, [isDragging, minWidth, maxWidth])
+
+        // Prevent text selection and show resize cursor during drag.
+        React.useEffect(() => {
+            if (!isDragging) {
+                return
+            }
+            const body = document.body
+            const previousUserSelect = body.style.userSelect
+            const previousCursor = body.style.cursor
+            body.style.userSelect = "none"
+            body.style.cursor = "col-resize"
+            return () => {
+                body.style.userSelect = previousUserSelect
+                body.style.cursor = previousCursor
+            }
+        }, [isDragging])
+
+        const handleMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+            event.preventDefault()
+            dragState.current = {
+                startX: event.clientX,
+                startWidth: width,
+            }
+            setIsDragging(true)
+        }
+
+        // Placeholder details for the sidebar body.
+        const details = [
+            { label: "Assignee", value: "Unassigned" },
+            { label: "Labels", value: "design, ux" },
+            { label: "Parent", value: "EPIC-18" },
+            { label: "Sprint", value: "Sprint 24" },
+            { label: "Reporter", value: "Taylor Reid" },
+            { label: "Priority", value: "Medium" },
+        ]
+
+        // Use a CSS custom property so the width can be used in Tailwind classes.
+        const style = {
+            "--sidebar-width": `${width}px`,
+        } as React.CSSProperties
+
+        return (
+            <aside
+                ref={ref}
+                style={style}
+                className={cn(
+                    "relative flex w-full flex-col gap-4 border-l border-slate-200 bg-white px-5 py-4",
+                    "md:w-[var(--sidebar-width)]",
+                    className
+                )}
+                {...props}
+            >
+                {/* Left-edge drag handle for resizing. */}
+                <div
+                    onMouseDown={handleMouseDown}
+                    className="group absolute left-0 top-0 h-full w-2 cursor-col-resize"
+                    aria-hidden="true"
+                >
+                    <span className="absolute left-1/2 top-0 h-full w-px -translate-x-1/2 bg-slate-200 transition-colors group-hover:bg-slate-400" />
+                </div>
+
+                <div className="space-y-3">
+                    <button
+                        type="button"
+                        onClick={() => setIsCollapsed((prev) => !prev)}
+                        className="flex w-full items-center justify-between rounded-md px-1 py-1 text-left text-sm font-semibold text-slate-800 hover:bg-slate-50"
+                        aria-expanded={!isCollapsed}
+                    >
+                        <span>Details</span>
+                        <ChevronDown
+                            className={cn(
+                                "h-4 w-4 transition-transform",
+                                isCollapsed ? "-rotate-90" : "rotate-0"
+                            )}
+                            aria-hidden="true"
+                        />
+                    </button>
+
+                    {!isCollapsed ? (
+                        <div className="space-y-2">
+                            {details.map((detail) => (
+                                <div
+                                    key={detail.label}
+                                    className="grid grid-cols-[120px_1fr] gap-3 text-sm"
+                                >
+                                    <span className="text-slate-500">{detail.label}</span>
+                                    <span className="text-slate-800">{detail.value}</span>
+                                </div>
+                            ))}
+                        </div>
+                    ) : null}
+                </div>
+            </aside>
+        )
+    }
+)
+
+TicketDetailSidebar.displayName = "TicketDetailSidebar"
+
+export default TicketDetailSidebar

--- a/frontend/src/stories/JiraTicketDetailLayout.stories.tsx
+++ b/frontend/src/stories/JiraTicketDetailLayout.stories.tsx
@@ -1,0 +1,142 @@
+import React from "react"
+import { MoreHorizontal, Share2 } from "lucide-react"
+import JiraTicketKey from "../components/jira-ticket/JiraTicketKey"
+import JiraTicketSummary from "../components/jira-ticket/JiraTicketSummary"
+import JiraTicketTypeIcon from "../components/jira-ticket/JiraTicketTypeIcon"
+import TicketDetailContent from "../components/jira-ticket/TicketDetailContent"
+import TicketDetailHeader from "../components/jira-ticket/TicketDetailHeader"
+import TicketDetailLayout from "../components/jira-ticket/TicketDetailLayout"
+import TicketDetailSidebar from "../components/jira-ticket/TicketDetailSidebar"
+
+const meta = {
+    title: "Ticket Detail",
+    parameters: {
+        layout: "fullscreen",
+        chromatic: {
+            disableSnapshot: false,
+            viewports: [360, 768, 1200],
+        },
+        docs: {
+            description: {
+                component:
+                    "Storybook-first Jira ticket detail layout pieces: header, content, sidebar, and the composed layout.",
+            },
+        },
+    },
+    tags: ["autodocs"],
+}
+export default meta
+
+// Shared wrapper to mimic app page spacing in stories.
+const StoryShell = ({ children }: { children: React.ReactNode }) => (
+    <div className="min-h-screen bg-slate-50 p-6">{children}</div>
+)
+
+// Mock identity block used across header and layout stories.
+const TicketIdentity = () => {
+    const [summary, setSummary] = React.useState(
+        "Create the ticket detail layout components"
+    )
+
+    return (
+        <div className="space-y-3">
+            <div className="flex items-center gap-2 text-sm text-slate-600">
+                <JiraTicketTypeIcon type="task" />
+                <JiraTicketKey jiraTicketKey="SCRUM-42" onClick={() => {}} />
+                <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
+          In progress
+        </span>
+            </div>
+            <JiraTicketSummary value={summary} onSave={setSummary} />
+        </div>
+    )
+}
+
+// Placeholder action group for the header right slot.
+const HeaderActions = () => (
+    <div className="flex items-center gap-2">
+        <button
+            type="button"
+            className="inline-flex items-center gap-2 rounded-md border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 hover:bg-slate-50"
+        >
+            <Share2 className="h-4 w-4" />
+            Share
+        </button>
+        <button
+            type="button"
+            className="rounded-md border border-slate-200 bg-white p-2 text-slate-600 hover:bg-slate-50"
+            aria-label="More actions"
+        >
+            <MoreHorizontal className="h-4 w-4" />
+        </button>
+    </div>
+)
+
+const header = (
+    <TicketDetailHeader left={<TicketIdentity />} right={<HeaderActions />} />
+)
+const content = <TicketDetailContent />
+const sidebar = <TicketDetailSidebar />
+
+export const Primary = {
+    name: "Layout / Default",
+    render: () => (
+        <TicketDetailLayout header={header} content={content} sidebar={sidebar} />
+    ),
+}
+
+export const HeaderDefault = {
+    name: "Header / Default",
+    render: () => (
+        <StoryShell>
+            <TicketDetailHeader left={<TicketIdentity />} right={<HeaderActions />} />
+        </StoryShell>
+    ),
+}
+
+export const ContentDefault = {
+    name: "Content / Default",
+    render: () => (
+        <StoryShell>
+            <div className="max-w-[840px]">
+                <TicketDetailContent />
+            </div>
+        </StoryShell>
+    ),
+}
+
+export const SidebarDefault = {
+    name: "Sidebar / Default",
+    render: () => (
+        <StoryShell>
+            <div className="max-w-[360px]">
+                <TicketDetailSidebar />
+            </div>
+        </StoryShell>
+    ),
+}
+
+export const SidebarCollapsed = {
+    name: "Sidebar / Collapsed",
+    render: () => (
+        <StoryShell>
+            <div className="max-w-[360px]">
+                <TicketDetailSidebar defaultCollapsed />
+            </div>
+        </StoryShell>
+    ),
+}
+
+export const SidebarResizable = {
+    name: "Sidebar / Resizable",
+    render: () => (
+        <StoryShell>
+            <div className="flex min-h-[420px] rounded-lg border border-slate-200 bg-white">
+                <div className="flex-1 border-r border-slate-200 p-6 text-sm text-slate-500">
+                    Drag the sidebar handle to resize the Jira ticket details panel.
+                </div>
+                <TicketDetailSidebar />
+            </div>
+        </StoryShell>
+    ),
+}


### PR DESCRIPTION
### Summary

This PR implements **Task 5.3 — Jira ticket detail layout** by introducing a set of
**composable layout components** and corresponding Storybook stories.

---

### What’s included

#### Standalone layout components
Each component is designed to work independently and is demonstrated with its own Storybook stories:

- **TicketDetailHeader**
  - Header container for the ticket page
  - Slot-based layout for ticket identity and optional actions
  - Layout-only, no business logic

- **TicketDetailContent**
  - Main content column container
  - Renders Jira-style placeholder sections (Description, Linked work items, Activity tabs)
  - Uses compositional Card patterns from previous tickets

- **TicketDetailSidebar**
  - Sidebar container with Jira-like “Details” panel
  - Supports:
    - Collapsible Details section
    - Horizontally resizable sidebar width via drag handle
  - UI-only key/value placeholders (Assignee, Labels, Parent, Sprint, etc.)

#### Composed layout
- **TicketDetailLayout**
  - Composes Header + Content + Sidebar into a full ticket detail page
  - Desktop: two-column layout (content + resizable sidebar)
  - Narrow screens: sidebar stacks below content
  - No additional logic beyond layout composition

---

### Storybook coverage

Storybook stories are structured to reflect the compositional approach:

- Header / Content / Sidebar are each showcased **independently**
- Sidebar stories demonstrate collapse and resize behavior
- Layout stories show the full composed ticket detail view and responsive behavior

This makes each part reusable and easier to reason about before combining them into the final layout.

---

### Notes

- Scope is intentionally limited to **layout and UI interaction only**.
- No data fetching or business logic is introduced.
- This PR builds on the foundations from Tickets 5.1 and 5.2.
