### PR TITLE
draft: feat(miro): backend implementation

### DIFF
--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -58,6 +58,7 @@ urlpatterns = [
     path('api/chat/', include('chat.urls')),
     path('api/experiment/', include('experiment.urls')),
     path('api/v1/', include('calendars.urls')),
+    path('api/miro/', include('miro.urls')),
     path("", include("django_prometheus.urls")),
 ]
 

--- a/backend/miro/apps.py
+++ b/backend/miro/apps.py
@@ -6,3 +6,4 @@ class MiroConfig(AppConfig):
     name = 'miro'
     verbose_name = 'MIRO Board'
 
+

--- a/backend/miro/permissions.py
+++ b/backend/miro/permissions.py
@@ -1,0 +1,44 @@
+from rest_framework import permissions
+from core.models import Project, ProjectMember
+from miro.models import Board
+
+
+class IsBoardProjectMember(permissions.BasePermission):
+    """Allow access only to users with active membership on the board's project."""
+
+    def has_object_permission(self, request, view, obj):
+        project = self._resolve_project(obj)
+        if not project:
+            return False
+
+        return ProjectMember.objects.filter(
+            user=request.user,
+            project=project,
+            is_active=True,
+        ).exists()
+
+    def _resolve_project(self, obj):
+        """Resolve project from object"""
+        if isinstance(obj, Project):
+            return obj
+        if isinstance(obj, Board):
+            return obj.project
+        # For BoardItem and BoardRevision, get project via board
+        if hasattr(obj, 'board'):
+            return obj.board.project
+        # Fallback: try project attribute
+        return getattr(obj, 'project', None)
+
+
+class HasValidShareToken(permissions.BasePermission):
+    """Allow access via valid share token (no authentication required)."""
+
+    def has_permission(self, request, view):
+        """Check if share_token is valid"""
+        share_token = view.kwargs.get('share_token')
+        if not share_token:
+            return False
+        
+        # Check if board exists with this share token
+        return Board.objects.filter(share_token=share_token).exists()
+

--- a/backend/miro/serializers.py
+++ b/backend/miro/serializers.py
@@ -1,0 +1,252 @@
+import base64
+import uuid
+from rest_framework import serializers
+from django.db.models import Max
+from django.shortcuts import get_object_or_404
+from core.models import Project, ProjectMember
+from miro.models import Board, BoardItem, BoardRevision
+
+
+def generate_share_token():
+    """Generate a 24-character share token from UUID base64 encoded"""
+    uuid_bytes = uuid.uuid4().bytes
+    token = base64.urlsafe_b64encode(uuid_bytes).decode('utf-8').rstrip('=')
+    # Ensure exactly 24 chars (UUID base64 = 22 chars, pad if needed)
+    return token[:24].ljust(24, 'A')
+
+
+class BoardSerializer(serializers.ModelSerializer):
+    """Serializer for Board model"""
+    project_id = serializers.UUIDField(write_only=True, required=False)
+
+    class Meta:
+        model = Board
+        fields = [
+            'id', 'project_id', 'title', 'share_token', 'viewport',
+            'is_archived', 'created_at', 'updated_at'
+        ]
+        read_only_fields = ['id', 'share_token', 'created_at', 'updated_at']
+
+    def to_representation(self, instance):
+        """Convert project FK to project_id in response"""
+        data = super().to_representation(instance)
+        data['project_id'] = str(instance.project_id)
+        return data
+
+
+class BoardCreateSerializer(BoardSerializer):
+    """Serializer for creating a new board"""
+
+    def validate_project_id(self, value):
+        """Validate project exists and user has access"""
+        request = self.context.get('request')
+        if not request or not request.user.is_authenticated:
+            raise serializers.ValidationError("Authentication required")
+        
+        project = get_object_or_404(Project, id=value)
+        
+        # Check if user is a member of the project
+        has_membership = ProjectMember.objects.filter(
+            user=request.user,
+            project=project,
+            is_active=True
+        ).exists()
+        
+        if not has_membership:
+            raise serializers.ValidationError("You do not have access to this project")
+        
+        return value
+
+    def create(self, validated_data):
+        """Create board with auto-generated share token"""
+        project_id = validated_data.pop('project_id')
+        project = get_object_or_404(Project, id=project_id)
+        
+        # Generate unique share token
+        share_token = generate_share_token()
+        while Board.objects.filter(share_token=share_token).exists():
+            share_token = generate_share_token()
+        
+        validated_data['project'] = project
+        validated_data['share_token'] = share_token
+        
+        return super().create(validated_data)
+
+
+class BoardUpdateSerializer(serializers.ModelSerializer):
+    """Serializer for updating a board (PATCH)"""
+
+    class Meta:
+        model = Board
+        fields = ['title', 'viewport', 'is_archived']
+        read_only_fields = []
+
+
+class BoardItemSerializer(serializers.ModelSerializer):
+    """Serializer for BoardItem model"""
+    board_id = serializers.UUIDField(write_only=True, required=False)
+    parent_item_id = serializers.UUIDField(required=False, allow_null=True)
+
+    class Meta:
+        model = BoardItem
+        fields = [
+            'id', 'board_id', 'type', 'parent_item_id', 'x', 'y',
+            'width', 'height', 'rotation', 'style', 'content',
+            'z_index', 'is_deleted', 'created_at', 'updated_at'
+        ]
+        read_only_fields = ['id', 'is_deleted', 'created_at', 'updated_at']
+
+    def to_representation(self, instance):
+        """Convert FKs to IDs in response"""
+        data = super().to_representation(instance)
+        data['board_id'] = str(instance.board_id)
+        if instance.parent_item_id:
+            data['parent_item_id'] = str(instance.parent_item_id)
+        return data
+
+
+class BoardItemCreateSerializer(BoardItemSerializer):
+    """Serializer for creating a board item"""
+
+    def validate_type(self, value):
+        """Validate item type is in allowed choices"""
+        valid_types = [choice[0] for choice in BoardItem.ItemType.choices]
+        if value not in valid_types:
+            raise serializers.ValidationError(
+                f"Invalid type. Must be one of: {', '.join(valid_types)}"
+            )
+        return value
+
+    def create(self, validated_data):
+        """Create item with board from context"""
+        board = self.context.get('board')
+        if not board:
+            raise serializers.ValidationError("Board context is required")
+        
+        validated_data['board'] = board
+        
+        # Handle parent_item_id
+        parent_item_id = validated_data.pop('parent_item_id', None)
+        if parent_item_id:
+            try:
+                parent_item = BoardItem.objects.get(id=parent_item_id, board=board)
+                validated_data['parent_item'] = parent_item
+            except BoardItem.DoesNotExist:
+                raise serializers.ValidationError({
+                    'parent_item_id': 'Parent item not found'
+                })
+        
+        return super().create(validated_data)
+
+
+class BoardItemUpdateSerializer(serializers.ModelSerializer):
+    """Serializer for updating a board item (PATCH)"""
+    parent_item_id = serializers.UUIDField(required=False, allow_null=True)
+
+    class Meta:
+        model = BoardItem
+        fields = [
+            'type', 'parent_item_id', 'x', 'y', 'width', 'height',
+            'rotation', 'style', 'content', 'z_index'
+        ]
+
+    def validate_type(self, value):
+        """Validate item type is in allowed choices"""
+        valid_types = [choice[0] for choice in BoardItem.ItemType.choices]
+        if value not in valid_types:
+            raise serializers.ValidationError(
+                f"Invalid type. Must be one of: {', '.join(valid_types)}"
+            )
+        return value
+
+    def update(self, instance, validated_data):
+        """Update item with parent_item handling"""
+        parent_item_id = validated_data.pop('parent_item_id', None)
+        
+        if parent_item_id is not None:
+            if parent_item_id:
+                try:
+                    parent_item = BoardItem.objects.get(
+                        id=parent_item_id,
+                        board=instance.board
+                    )
+                    validated_data['parent_item'] = parent_item
+                except BoardItem.DoesNotExist:
+                    raise serializers.ValidationError({
+                        'parent_item_id': 'Parent item not found'
+                    })
+            else:
+                validated_data['parent_item'] = None
+        
+        return super().update(instance, validated_data)
+
+
+class BoardItemBatchUpdateSerializer(serializers.Serializer):
+    """Serializer for batch updating board items"""
+    items = serializers.ListField(
+        child=serializers.DictField(),
+        required=True
+    )
+
+    def validate_items(self, value):
+        """Validate each item has an id field"""
+        for item in value:
+            if 'id' not in item:
+                raise serializers.ValidationError("Each item must have an 'id' field")
+        return value
+
+
+class BoardRevisionSerializer(serializers.ModelSerializer):
+    """Serializer for BoardRevision model"""
+    board_id = serializers.UUIDField(write_only=True, required=False)
+
+    class Meta:
+        model = BoardRevision
+        fields = [
+            'id', 'board_id', 'version', 'snapshot', 'note', 'created_at'
+        ]
+        read_only_fields = ['id', 'version', 'created_at']
+
+    def to_representation(self, instance):
+        """Convert board FK to board_id in response"""
+        data = super().to_representation(instance)
+        data['board_id'] = str(instance.board_id)
+        return data
+
+
+class BoardRevisionCreateSerializer(serializers.ModelSerializer):
+    """Serializer for creating a board revision"""
+
+    class Meta:
+        model = BoardRevision
+        fields = ['snapshot', 'note']
+
+    def validate_snapshot(self, value):
+        """Validate snapshot is a dictionary"""
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("Snapshot must be a dictionary")
+        return value
+
+    def create(self, validated_data):
+        """Create revision with auto-incremented version"""
+        board = self.context.get('board')
+        if not board:
+            raise serializers.ValidationError("Board context is required")
+        
+        # Get next version number
+        max_version = BoardRevision.objects.filter(
+            board=board
+        ).aggregate(Max('version'))['version__max'] or 0
+        next_version = max_version + 1
+        
+        validated_data['board'] = board
+        validated_data['version'] = next_version
+        
+        return super().create(validated_data)
+
+
+class ShareBoardResponseSerializer(serializers.Serializer):
+    """Serializer for share board response (board + items)"""
+    board = BoardSerializer()
+    items = BoardItemSerializer(many=True)
+

--- a/backend/miro/tests/test_views.py
+++ b/backend/miro/tests/test_views.py
@@ -1,0 +1,1185 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+from rest_framework import status
+import uuid
+
+from core.models import Project, ProjectMember, Organization
+from miro.models import Board, BoardItem, BoardRevision
+
+User = get_user_model()
+
+
+class BoardAPITest(TestCase):
+    """Test Board API endpoints"""
+
+    def setUp(self):
+        """Set up test data"""
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="miro_user",
+            email="miro@example.com",
+            password="testpass123",
+        )
+        self.other_user = User.objects.create_user(
+            username="other_user",
+            email="other@example.com",
+            password="testpass123",
+        )
+        self.organization = Organization.objects.create(name="MIRO Org")
+        self.project = Project.objects.create(
+            name="MIRO Project",
+            organization=self.organization,
+            owner=self.user,
+        )
+        ProjectMember.objects.create(
+            user=self.user, project=self.project, is_active=True
+        )
+        self.client.force_authenticate(user=self.user)
+
+    def _results(self, response):
+        """
+        DRF may paginate list endpoints. Normalize to a list of items.
+        """
+        data = response.data
+        if isinstance(data, dict) and "results" in data:
+            return data["results"]
+        return data
+
+    def _assert_has_error_key(self, response, key: str):
+        """
+        Validation errors in this codebase are typically returned as top-level
+        field keys (e.g. {'project_id': ['...']}) rather than nested under 'detail'.
+        """
+        data = response.data
+        if isinstance(data, dict) and isinstance(data.get("detail"), dict):
+            data = data["detail"]
+        self.assertIsInstance(data, dict)
+        self.assertIn(key, data)
+
+    def test_create_board(self):
+        """Create board with valid project_id, verify share_token generation"""
+        url = "/api/miro/boards/"
+        payload = {
+            "project_id": self.project.id,
+            "title": "Test Board",
+            "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        }
+
+        response = self.client.post(url, payload, format="json")
+        if response.status_code != status.HTTP_201_CREATED:
+            # Debug: print error response
+            print(f"Response status: {response.status_code}")
+            print(f"Response data: {response.data}")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["title"], "Test Board")
+        self.assertIn("share_token", response.data)
+        self.assertEqual(len(response.data["share_token"]), 24)
+        
+        # Verify in DB
+        board = Board.objects.get(id=response.data["id"])
+        self.assertEqual(board.share_token, response.data["share_token"])
+
+    def test_create_board_invalid_project(self):
+        """Create board with non-existent project_id (400)"""
+        url = "/api/miro/boards/"
+        # Use a very large integer that doesn't exist
+        invalid_id = 999999999
+        payload = {
+            "project_id": invalid_id,
+            "title": "Test Board",
+        }
+
+        response = self.client.post(url, payload, format="json")
+        # Should return 400 with validation error, not 404
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self._assert_has_error_key(response, "project_id")
+
+    def test_create_board_non_member(self):
+        """Create board for project user is not member of (400)"""
+        other_project = Project.objects.create(
+            name="Other Project",
+            organization=self.organization,
+            owner=self.other_user,
+        )
+        
+        url = "/api/miro/boards/"
+        payload = {
+            "project_id": str(other_project.id),
+            "title": "Test Board",
+        }
+
+        response = self.client.post(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self._assert_has_error_key(response, "project_id")
+
+    def test_list_boards(self):
+        """List boards, verify only user's project boards returned"""
+        board1 = Board.objects.create(
+            project=self.project,
+            title="Board 1",
+            share_token="token123456789012345678",
+        )
+        
+        # Create board in another project
+        other_project = Project.objects.create(
+            name="Other Project",
+            organization=self.organization,
+            owner=self.other_user,
+        )
+        board2 = Board.objects.create(
+            project=other_project,
+            title="Board 2",
+            share_token="token223456789012345678",
+        )
+
+        url = "/api/miro/boards/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = self._results(response)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(str(results[0]["id"]), str(board1.id))
+
+    def test_list_boards_filtered(self):
+        """List boards excludes boards from other projects"""
+        board1 = Board.objects.create(
+            project=self.project,
+            title="Board 1",
+            share_token="token123456789012345678",
+        )
+        
+        other_project = Project.objects.create(
+            name="Other Project",
+            organization=self.organization,
+            owner=self.other_user,
+        )
+        Board.objects.create(
+            project=other_project,
+            title="Board 2",
+            share_token="token223456789012345678",
+        )
+
+        url = "/api/miro/boards/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = self._results(response)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(str(results[0]["id"]), str(board1.id))
+
+    def test_get_board_detail(self):
+        """Retrieve board detail (200)"""
+        board = Board.objects.create(
+            project=self.project,
+            title="Test Board",
+            share_token="token123456789012345678",
+        )
+
+        url = f"/api/miro/boards/{board.id}/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(str(response.data["id"]), str(board.id))
+        self.assertEqual(response.data["title"], "Test Board")
+
+    def test_get_board_detail_non_member(self):
+        """Retrieve board detail for non-member (404)"""
+        other_project = Project.objects.create(
+            name="Other Project",
+            organization=self.organization,
+            owner=self.other_user,
+        )
+        board = Board.objects.create(
+            project=other_project,
+            title="Test Board",
+            share_token="token123456789012345678",
+        )
+
+        url = f"/api/miro/boards/{board.id}/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_update_board(self):
+        """PATCH board with valid data (200)"""
+        board = Board.objects.create(
+            project=self.project,
+            title="Original Title",
+            share_token="token123456789012345678",
+        )
+
+        url = f"/api/miro/boards/{board.id}/"
+        payload = {
+            "title": "Updated Title",
+            "is_archived": True,
+        }
+
+        response = self.client.patch(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["title"], "Updated Title")
+        self.assertEqual(response.data["is_archived"], True)
+
+        # Verify in DB
+        board.refresh_from_db()
+        self.assertEqual(board.title, "Updated Title")
+        self.assertEqual(board.is_archived, True)
+
+    def test_update_board_non_member(self):
+        """PATCH board as non-member (404)"""
+        other_project = Project.objects.create(
+            name="Other Project",
+            organization=self.organization,
+            owner=self.other_user,
+        )
+        board = Board.objects.create(
+            project=other_project,
+            title="Test Board",
+            share_token="token123456789012345678",
+        )
+
+        url = f"/api/miro/boards/{board.id}/"
+        payload = {"title": "Updated Title"}
+
+        response = self.client.patch(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class BoardItemAPITest(TestCase):
+    """Test BoardItem API endpoints"""
+
+    def setUp(self):
+        """Set up test data"""
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="miro_user",
+            email="miro@example.com",
+            password="testpass123",
+        )
+        self.other_user = User.objects.create_user(
+            username="other_user",
+            email="other@example.com",
+            password="testpass123",
+        )
+        self.organization = Organization.objects.create(name="MIRO Org")
+        self.project = Project.objects.create(
+            name="MIRO Project",
+            organization=self.organization,
+            owner=self.user,
+        )
+        ProjectMember.objects.create(
+            user=self.user, project=self.project, is_active=True
+        )
+        self.board = Board.objects.create(
+            project=self.project,
+            title="Test Board",
+            share_token="token123456789012345678",
+        )
+        self.client.force_authenticate(user=self.user)
+
+    def test_list_board_items(self):
+        """GET /boards/{board_id}/items/ returns items (200)"""
+        item1 = BoardItem.objects.create(
+            board=self.board,
+            type="text",
+            x=10.0,
+            y=20.0,
+            width=100.0,
+            height=50.0,
+        )
+        item2 = BoardItem.objects.create(
+            board=self.board,
+            type="shape",
+            x=30.0,
+            y=40.0,
+            width=80.0,
+            height=60.0,
+        )
+
+        url = f"/api/miro/boards/{self.board.id}/items/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        item_ids = [str(item["id"]) for item in response.data]
+        self.assertIn(str(item1.id), item_ids)
+        self.assertIn(str(item2.id), item_ids)
+
+    def test_list_board_items_exclude_deleted(self):
+        """List items excludes soft-deleted items by default"""
+        item1 = BoardItem.objects.create(
+            board=self.board,
+            type="text",
+            x=10.0,
+            y=20.0,
+            width=100.0,
+            height=50.0,
+            is_deleted=False,
+        )
+        item2 = BoardItem.objects.create(
+            board=self.board,
+            type="shape",
+            x=30.0,
+            y=40.0,
+            width=80.0,
+            height=60.0,
+            is_deleted=True,
+        )
+
+        url = f"/api/miro/boards/{self.board.id}/items/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(str(response.data[0]["id"]), str(item1.id))
+
+    def test_list_board_items_include_deleted(self):
+        """List items with include_deleted=true includes soft-deleted"""
+        item1 = BoardItem.objects.create(
+            board=self.board,
+            type="text",
+            x=10.0,
+            y=20.0,
+            width=100.0,
+            height=50.0,
+            is_deleted=False,
+        )
+        item2 = BoardItem.objects.create(
+            board=self.board,
+            type="shape",
+            x=30.0,
+            y=40.0,
+            width=80.0,
+            height=60.0,
+            is_deleted=True,
+        )
+
+        url = f"/api/miro/boards/{self.board.id}/items/?include_deleted=true"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+
+    def test_create_board_item(self):
+        """POST /boards/{board_id}/items/ creates item (201)"""
+        url = f"/api/miro/boards/{self.board.id}/items/"
+        payload = {
+            "type": "text",
+            "x": 10.0,
+            "y": 20.0,
+            "width": 100.0,
+            "height": 50.0,
+            "content": "Hello World",
+        }
+
+        response = self.client.post(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["type"], "text")
+        self.assertEqual(response.data["content"], "Hello World")
+        
+        # Verify in DB
+        item = BoardItem.objects.get(id=response.data["id"])
+        self.assertEqual(item.board, self.board)
+
+    def test_create_board_item_invalid_type(self):
+        """Create item with invalid type enum (400)"""
+        url = f"/api/miro/boards/{self.board.id}/items/"
+        payload = {
+            "type": "invalid_type",
+            "x": 10.0,
+            "y": 20.0,
+            "width": 100.0,
+            "height": 50.0,
+        }
+
+        response = self.client.post(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_board_item_with_parent(self):
+        """Create item with parent_item_id (201)"""
+        parent_item = BoardItem.objects.create(
+            board=self.board,
+            type="frame",
+            x=0.0,
+            y=0.0,
+            width=200.0,
+            height=200.0,
+        )
+
+        url = f"/api/miro/boards/{self.board.id}/items/"
+        payload = {
+            "type": "text",
+            "parent_item_id": str(parent_item.id),
+            "x": 10.0,
+            "y": 20.0,
+            "width": 100.0,
+            "height": 50.0,
+        }
+
+        response = self.client.post(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["parent_item_id"], str(parent_item.id))
+        
+        # Verify in DB
+        item = BoardItem.objects.get(id=response.data["id"])
+        self.assertEqual(item.parent_item, parent_item)
+
+    def test_update_board_item(self):
+        """PATCH /items/{item_id}/ updates item (200)"""
+        item = BoardItem.objects.create(
+            board=self.board,
+            type="text",
+            x=10.0,
+            y=20.0,
+            width=100.0,
+            height=50.0,
+        )
+
+        url = f"/api/miro/items/{item.id}/"
+        payload = {
+            "x": 50.0,
+            "y": 60.0,
+            "content": "Updated content",
+        }
+
+        response = self.client.patch(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["x"], 50.0)
+        self.assertEqual(response.data["y"], 60.0)
+        self.assertEqual(response.data["content"], "Updated content")
+
+        # Verify in DB
+        item.refresh_from_db()
+        self.assertEqual(item.x, 50.0)
+        self.assertEqual(item.y, 60.0)
+        self.assertEqual(item.content, "Updated content")
+
+    def test_update_board_item_non_member(self):
+        """PATCH item as non-member (404)"""
+        other_project = Project.objects.create(
+            name="Other Project",
+            organization=self.organization,
+            owner=self.other_user,
+        )
+        other_board = Board.objects.create(
+            project=other_project,
+            title="Other Board",
+            share_token="token223456789012345678",
+        )
+        item = BoardItem.objects.create(
+            board=other_board,
+            type="text",
+            x=10.0,
+            y=20.0,
+            width=100.0,
+            height=50.0,
+        )
+
+        url = f"/api/miro/items/{item.id}/"
+        payload = {"x": 50.0}
+
+        response = self.client.patch(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_delete_board_item_soft_delete(self):
+        """DELETE /items/{item_id}/ performs soft delete, returns specific format (200)"""
+        item = BoardItem.objects.create(
+            board=self.board,
+            type="text",
+            x=10.0,
+            y=20.0,
+            width=100.0,
+            height=50.0,
+            is_deleted=False,
+        )
+
+        url = f"/api/miro/items/{item.id}/"
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        # Verify response format
+        self.assertEqual(response.data["id"], str(item.id))
+        self.assertEqual(response.data["is_deleted"], True)
+        self.assertIn("updated_at", response.data)
+
+        # Verify soft delete in DB
+        item.refresh_from_db()
+        self.assertEqual(item.is_deleted, True)
+        self.assertTrue(BoardItem.objects.filter(id=item.id).exists())
+
+    def test_delete_board_item_response_format(self):
+        """Verify DELETE response: {"id": "...", "is_deleted": true, "updated_at": "..."}"""
+        item = BoardItem.objects.create(
+            board=self.board,
+            type="text",
+            x=10.0,
+            y=20.0,
+            width=100.0,
+            height=50.0,
+        )
+
+        url = f"/api/miro/items/{item.id}/"
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        self.assertIn("id", response.data)
+        self.assertIn("is_deleted", response.data)
+        self.assertIn("updated_at", response.data)
+        self.assertEqual(response.data["is_deleted"], True)
+
+    def test_delete_board_item_non_member(self):
+        """DELETE item as non-member (404)"""
+        other_project = Project.objects.create(
+            name="Other Project",
+            organization=self.organization,
+            owner=self.other_user,
+        )
+        other_board = Board.objects.create(
+            project=other_project,
+            title="Other Board",
+            share_token="token223456789012345678",
+        )
+        item = BoardItem.objects.create(
+            board=other_board,
+            type="text",
+            x=10.0,
+            y=20.0,
+            width=100.0,
+            height=50.0,
+        )
+
+        url = f"/api/miro/items/{item.id}/"
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class BoardItemBatchUpdateTest(TestCase):
+    """Test batch item updates"""
+
+    def setUp(self):
+        """Set up test data"""
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="miro_user",
+            email="miro@example.com",
+            password="testpass123",
+        )
+        self.organization = Organization.objects.create(name="MIRO Org")
+        self.project = Project.objects.create(
+            name="MIRO Project",
+            organization=self.organization,
+            owner=self.user,
+        )
+        ProjectMember.objects.create(
+            user=self.user, project=self.project, is_active=True
+        )
+        self.board = Board.objects.create(
+            project=self.project,
+            title="Test Board",
+            share_token="token123456789012345678",
+        )
+        self.item1 = BoardItem.objects.create(
+            board=self.board,
+            type="text",
+            x=10.0,
+            y=20.0,
+            width=100.0,
+            height=50.0,
+        )
+        self.item2 = BoardItem.objects.create(
+            board=self.board,
+            type="shape",
+            x=30.0,
+            y=40.0,
+            width=80.0,
+            height=60.0,
+        )
+        self.client.force_authenticate(user=self.user)
+
+    def test_batch_update_items_success(self):
+        """PATCH /boards/{board_id}/items/batch/ updates multiple items (200)"""
+        url = f"/api/miro/boards/{self.board.id}/items/batch/"
+        payload = {
+            "items": [
+                {"id": str(self.item1.id), "x": 100.0, "y": 200.0},
+                {"id": str(self.item2.id), "x": 300.0, "y": 400.0},
+            ]
+        }
+
+        response = self.client.patch(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["updated"]), 2)
+        self.assertEqual(len(response.data["failed"]), 0)
+
+        # Verify updates in DB
+        self.item1.refresh_from_db()
+        self.item2.refresh_from_db()
+        self.assertEqual(self.item1.x, 100.0)
+        self.assertEqual(self.item2.x, 300.0)
+
+    def test_batch_update_items_partial_success(self):
+        """Batch update with some valid and invalid items returns both updated and failed arrays"""
+        invalid_id = str(uuid.uuid4())
+        url = f"/api/miro/boards/{self.board.id}/items/batch/"
+        payload = {
+            "items": [
+                {"id": str(self.item1.id), "x": 100.0},
+                {"id": invalid_id, "x": 200.0},  # Invalid ID
+            ]
+        }
+
+        response = self.client.patch(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["updated"]), 1)
+        self.assertEqual(len(response.data["failed"]), 1)
+        self.assertEqual(response.data["failed"][0]["id"], invalid_id)
+
+    def test_batch_update_items_all_fail(self):
+        """Batch update with all invalid items returns all in failed array"""
+        invalid_id1 = str(uuid.uuid4())
+        invalid_id2 = str(uuid.uuid4())
+        url = f"/api/miro/boards/{self.board.id}/items/batch/"
+        payload = {
+            "items": [
+                {"id": invalid_id1, "x": 100.0},
+                {"id": invalid_id2, "x": 200.0},
+            ]
+        }
+
+        response = self.client.patch(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["updated"]), 0)
+        self.assertEqual(len(response.data["failed"]), 2)
+
+    def test_batch_update_items_missing_id(self):
+        """Batch update with item missing id field returns error in failed array"""
+        url = f"/api/miro/boards/{self.board.id}/items/batch/"
+        payload = {
+            "items": [
+                {"x": 100.0},  # Missing id
+            ]
+        }
+
+        response = self.client.patch(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["updated"]), 0)
+        self.assertEqual(len(response.data["failed"]), 1)
+        self.assertIsNone(response.data["failed"][0]["id"])
+
+    def test_batch_update_items_not_found(self):
+        """Batch update with non-existent item_id returns error in failed array"""
+        invalid_id = str(uuid.uuid4())
+        url = f"/api/miro/boards/{self.board.id}/items/batch/"
+        payload = {
+            "items": [
+                {"id": invalid_id, "x": 100.0},
+            ]
+        }
+
+        response = self.client.patch(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["updated"]), 0)
+        self.assertEqual(len(response.data["failed"]), 1)
+        self.assertEqual(response.data["failed"][0]["id"], invalid_id)
+
+    def test_batch_update_items_wrong_board(self):
+        """Batch update with item from different board returns error"""
+        other_project = Project.objects.create(
+            name="Other Project",
+            organization=self.organization,
+            owner=self.user,
+        )
+        other_board = Board.objects.create(
+            project=other_project,
+            title="Other Board",
+            share_token="token223456789012345678",
+        )
+        other_item = BoardItem.objects.create(
+            board=other_board,
+            type="text",
+            x=10.0,
+            y=20.0,
+            width=100.0,
+            height=50.0,
+        )
+
+        url = f"/api/miro/boards/{self.board.id}/items/batch/"
+        payload = {
+            "items": [
+                {"id": str(other_item.id), "x": 100.0},  # Item from different board
+            ]
+        }
+
+        response = self.client.patch(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["updated"]), 0)
+        self.assertEqual(len(response.data["failed"]), 1)
+
+    def test_batch_update_items_response_format(self):
+        """Verify response format: {"updated": [...], "failed": [...]}"""
+        url = f"/api/miro/boards/{self.board.id}/items/batch/"
+        payload = {
+            "items": [
+                {"id": str(self.item1.id), "x": 100.0},
+            ]
+        }
+
+        response = self.client.patch(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("updated", response.data)
+        self.assertIn("failed", response.data)
+        self.assertIsInstance(response.data["updated"], list)
+        self.assertIsInstance(response.data["failed"], list)
+
+
+class BoardRevisionAPITest(TestCase):
+    """Test BoardRevision API endpoints"""
+
+    def setUp(self):
+        """Set up test data"""
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="miro_user",
+            email="miro@example.com",
+            password="testpass123",
+        )
+        self.organization = Organization.objects.create(name="MIRO Org")
+        self.project = Project.objects.create(
+            name="MIRO Project",
+            organization=self.organization,
+            owner=self.user,
+        )
+        ProjectMember.objects.create(
+            user=self.user, project=self.project, is_active=True
+        )
+        self.board = Board.objects.create(
+            project=self.project,
+            title="Test Board",
+            share_token="token123456789012345678",
+        )
+        self.client.force_authenticate(user=self.user)
+
+    def test_create_revision(self):
+        """POST /boards/{board_id}/revisions/ creates revision (201)"""
+        url = f"/api/miro/boards/{self.board.id}/revisions/"
+        payload = {
+            "snapshot": {"items": [{"id": "1", "type": "text"}]},
+            "note": "Initial revision",
+        }
+
+        response = self.client.post(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["version"], 1)
+        self.assertEqual(response.data["note"], "Initial revision")
+
+    def test_create_revision_auto_increment_version(self):
+        """Create multiple revisions, verify version auto-increments"""
+        url = f"/api/miro/boards/{self.board.id}/revisions/"
+        
+        # Create first revision
+        payload1 = {"snapshot": {"items": []}, "note": "Revision 1"}
+        response1 = self.client.post(url, payload1, format="json")
+        self.assertEqual(response1.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response1.data["version"], 1)
+
+        # Create second revision
+        payload2 = {"snapshot": {"items": []}, "note": "Revision 2"}
+        response2 = self.client.post(url, payload2, format="json")
+        self.assertEqual(response2.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response2.data["version"], 2)
+
+        # Create third revision
+        payload3 = {"snapshot": {"items": []}, "note": "Revision 3"}
+        response3 = self.client.post(url, payload3, format="json")
+        self.assertEqual(response3.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response3.data["version"], 3)
+
+    def test_list_revisions(self):
+        """GET /boards/{board_id}/revisions/ returns revisions (200)"""
+        rev1 = BoardRevision.objects.create(
+            board=self.board, version=1, snapshot={"items": []}
+        )
+        rev2 = BoardRevision.objects.create(
+            board=self.board, version=2, snapshot={"items": []}
+        )
+
+        url = f"/api/miro/boards/{self.board.id}/revisions/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+
+    def test_list_revisions_with_limit(self):
+        """List revisions with limit parameter (default 20, max 100)"""
+        # Create 5 revisions
+        for i in range(1, 6):
+            BoardRevision.objects.create(
+                board=self.board, version=i, snapshot={"items": []}
+            )
+
+        url = f"/api/miro/boards/{self.board.id}/revisions/?limit=3"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 3)
+
+    def test_list_revisions_ordering(self):
+        """Verify revisions ordered by -version, -created_at"""
+        rev1 = BoardRevision.objects.create(
+            board=self.board, version=1, snapshot={"items": []}
+        )
+        rev2 = BoardRevision.objects.create(
+            board=self.board, version=2, snapshot={"items": []}
+        )
+
+        url = f"/api/miro/boards/{self.board.id}/revisions/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        versions = [rev["version"] for rev in response.data]
+        self.assertEqual(versions, [2, 1])  # Descending order
+
+    def test_get_revision_detail(self):
+        """GET /boards/{board_id}/revisions/{version}/ returns specific revision (200)"""
+        revision = BoardRevision.objects.create(
+            board=self.board,
+            version=1,
+            snapshot={"items": [{"id": "1"}]},
+            note="Test revision",
+        )
+
+        url = f"/api/miro/boards/{self.board.id}/revisions/1/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["version"], 1)
+        self.assertEqual(response.data["note"], "Test revision")
+
+    def test_get_revision_detail_not_found(self):
+        """GET non-existent revision version (404)"""
+        url = f"/api/miro/boards/{self.board.id}/revisions/999/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_restore_revision(self):
+        """POST /boards/{board_id}/revisions/{version}/restore/ creates new revision with old snapshot (201)"""
+        old_revision = BoardRevision.objects.create(
+            board=self.board,
+            version=1,
+            snapshot={"items": [{"id": "1", "type": "text"}]},
+            note="Original revision",
+        )
+
+        url = f"/api/miro/boards/{self.board.id}/revisions/1/restore/"
+        response = self.client.post(url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["version"], 2)
+        self.assertIn("Restored from version 1", response.data["note"])
+        self.assertEqual(response.data["snapshot"], old_revision.snapshot)
+
+    def test_restore_revision_version_increment(self):
+        """Restore creates new revision with incremented version"""
+        rev1 = BoardRevision.objects.create(
+            board=self.board, version=1, snapshot={"items": []}
+        )
+        rev2 = BoardRevision.objects.create(
+            board=self.board, version=2, snapshot={"items": []}
+        )
+
+        url = f"/api/miro/boards/{self.board.id}/revisions/1/restore/"
+        response = self.client.post(url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["version"], 3)  # Incremented from max (2)
+
+    def test_restore_revision_not_found(self):
+        """Restore non-existent revision (404)"""
+        url = f"/api/miro/boards/{self.board.id}/revisions/999/restore/"
+        response = self.client.post(url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class ShareTokenAPITest(TestCase):
+    """Test share token access"""
+
+    def setUp(self):
+        """Set up test data"""
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="miro_user",
+            email="miro@example.com",
+            password="testpass123",
+        )
+        self.organization = Organization.objects.create(name="MIRO Org")
+        self.project = Project.objects.create(
+            name="MIRO Project",
+            organization=self.organization,
+            owner=self.user,
+        )
+        ProjectMember.objects.create(
+            user=self.user, project=self.project, is_active=True
+        )
+        self.board = Board.objects.create(
+            project=self.project,
+            title="Test Board",
+            share_token="token123456789012345678",
+        )
+
+    def test_share_board_access(self):
+        """GET /share/boards/{share_token}/ returns board and items without authentication (200)"""
+        item1 = BoardItem.objects.create(
+            board=self.board,
+            type="text",
+            x=10.0,
+            y=20.0,
+            width=100.0,
+            height=50.0,
+        )
+
+        url = f"/api/miro/share/boards/{self.board.share_token}/"
+        # No authentication
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("board", response.data)
+        self.assertIn("items", response.data)
+        self.assertEqual(response.data["board"]["id"], str(self.board.id))
+        self.assertEqual(len(response.data["items"]), 1)
+
+    def test_share_board_access_active_items_only(self):
+        """Share endpoint returns only non-deleted items"""
+        item1 = BoardItem.objects.create(
+            board=self.board,
+            type="text",
+            x=10.0,
+            y=20.0,
+            width=100.0,
+            height=50.0,
+            is_deleted=False,
+        )
+        item2 = BoardItem.objects.create(
+            board=self.board,
+            type="shape",
+            x=30.0,
+            y=40.0,
+            width=80.0,
+            height=60.0,
+            is_deleted=True,
+        )
+
+        url = f"/api/miro/share/boards/{self.board.share_token}/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["items"]), 1)
+        self.assertEqual(response.data["items"][0]["id"], str(item1.id))
+
+    def test_share_board_access_invalid_token(self):
+        """GET with invalid share_token (401/403)"""
+        url = "/api/miro/share/boards/invalid_token/"
+        response = self.client.get(url)
+        # DRF may return 401 for unauthenticated or 403 for permission denied
+        self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
+
+    def test_share_board_access_response_format(self):
+        """Verify response format: {"board": {...}, "items": [...]}"""
+        url = f"/api/miro/share/boards/{self.board.share_token}/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("board", response.data)
+        self.assertIn("items", response.data)
+        self.assertIsInstance(response.data["board"], dict)
+        self.assertIsInstance(response.data["items"], list)
+
+    def test_share_token_generation(self):
+        """Verify share_token is generated on board creation (24 chars, unique)"""
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        
+        url = "/api/miro/boards/"
+        payload = {
+            "project_id": self.project.id,
+            "title": "New Board",
+        }
+
+        response = client.post(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        share_token = response.data["share_token"]
+        self.assertEqual(len(share_token), 24)
+        
+        # Verify uniqueness
+        board1 = Board.objects.get(id=response.data["id"])
+        self.assertEqual(board1.share_token, share_token)
+
+
+class PermissionTest(TestCase):
+    """Test permission classes"""
+
+    def setUp(self):
+        """Set up test data"""
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="miro_user",
+            email="miro@example.com",
+            password="testpass123",
+        )
+        self.other_user = User.objects.create_user(
+            username="other_user",
+            email="other@example.com",
+            password="testpass123",
+        )
+        self.organization = Organization.objects.create(name="MIRO Org")
+        self.project = Project.objects.create(
+            name="MIRO Project",
+            organization=self.organization,
+            owner=self.user,
+        )
+        ProjectMember.objects.create(
+            user=self.user, project=self.project, is_active=True
+        )
+        self.board = Board.objects.create(
+            project=self.project,
+            title="Test Board",
+            share_token="token123456789012345678",
+        )
+
+    def test_is_board_project_member_access(self):
+        """Member can access board (200)"""
+        self.client.force_authenticate(user=self.user)
+        url = f"/api/miro/boards/{self.board.id}/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_is_board_project_member_denied(self):
+        """Non-member cannot access board (404)"""
+        self.client.force_authenticate(user=self.other_user)
+        url = f"/api/miro/boards/{self.board.id}/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_is_board_project_member_inactive(self):
+        """Inactive ProjectMember cannot access (404)"""
+        # Create inactive membership
+        ProjectMember.objects.create(
+            user=self.other_user, project=self.project, is_active=False
+        )
+        self.client.force_authenticate(user=self.other_user)
+        url = f"/api/miro/boards/{self.board.id}/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_has_valid_share_token_permission(self):
+        """Valid share_token allows access without auth"""
+        url = f"/api/miro/share/boards/{self.board.share_token}/"
+        # No authentication
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_has_valid_share_token_invalid(self):
+        """Invalid share_token denies access"""
+        url = "/api/miro/share/boards/invalid_token_here/"
+        response = self.client.get(url)
+        # DRF may return 401 for unauthenticated or 403 for permission denied
+        self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
+
+
+class SerializerValidationTest(TestCase):
+    """Test serializer validation"""
+
+    def setUp(self):
+        """Set up test data"""
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="miro_user",
+            email="miro@example.com",
+            password="testpass123",
+        )
+        self.other_user = User.objects.create_user(
+            username="other_user",
+            email="other@example.com",
+            password="testpass123",
+        )
+        self.organization = Organization.objects.create(name="MIRO Org")
+        self.project = Project.objects.create(
+            name="MIRO Project",
+            organization=self.organization,
+            owner=self.user,
+        )
+        ProjectMember.objects.create(
+            user=self.user, project=self.project, is_active=True
+        )
+        self.board = Board.objects.create(
+            project=self.project,
+            title="Test Board",
+            share_token="token123456789012345678",
+        )
+        self.client.force_authenticate(user=self.user)
+
+    def test_board_create_serializer_project_id_validation(self):
+        """Validates project_id exists and user has access"""
+        other_project = Project.objects.create(
+            name="Other Project",
+            organization=self.organization,
+            owner=self.other_user,
+        )
+        
+        url = "/api/miro/boards/"
+        payload = {
+            "project_id": str(other_project.id),
+            "title": "Test Board",
+        }
+
+        response = self.client.post(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("project_id", response.data)
+
+    def test_board_item_create_serializer_type_validation(self):
+        """Validates item type is valid enum value"""
+        url = f"/api/miro/boards/{self.board.id}/items/"
+        payload = {
+            "type": "invalid_type",
+            "x": 10.0,
+            "y": 20.0,
+            "width": 100.0,
+            "height": 50.0,
+        }
+
+        response = self.client.post(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("type", response.data)
+
+    def test_board_item_create_serializer_parent_item_validation(self):
+        """Validates parent_item_id belongs to same board"""
+        other_project = Project.objects.create(
+            name="Other Project",
+            organization=self.organization,
+            owner=self.user,
+        )
+        other_board = Board.objects.create(
+            project=other_project,
+            title="Other Board",
+            share_token="token223456789012345678",
+        )
+        other_item = BoardItem.objects.create(
+            board=other_board,
+            type="frame",
+            x=0.0,
+            y=0.0,
+            width=200.0,
+            height=200.0,
+        )
+
+        url = f"/api/miro/boards/{self.board.id}/items/"
+        payload = {
+            "type": "text",
+            "parent_item_id": str(other_item.id),  # Parent from different board
+            "x": 10.0,
+            "y": 20.0,
+            "width": 100.0,
+            "height": 50.0,
+        }
+
+        response = self.client.post(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("parent_item_id", response.data)
+
+    def test_board_revision_create_serializer_version_auto_increment(self):
+        """Verifies version auto-increment logic"""
+        url = f"/api/miro/boards/{self.board.id}/revisions/"
+        
+        # Create first revision
+        payload1 = {"snapshot": {"items": []}}
+        response1 = self.client.post(url, payload1, format="json")
+        self.assertEqual(response1.data["version"], 1)
+
+        # Create second revision
+        payload2 = {"snapshot": {"items": []}}
+        response2 = self.client.post(url, payload2, format="json")
+        self.assertEqual(response2.data["version"], 2)
+

--- a/backend/miro/urls.py
+++ b/backend/miro/urls.py
@@ -1,0 +1,26 @@
+from django.urls import path
+from miro.views import BoardViewSet, BoardItemViewSet, ShareBoardView
+
+app_name = 'miro'
+
+urlpatterns = [
+    # Board CRUD
+    path('boards/', BoardViewSet.as_view({'get': 'list', 'post': 'create'}), name='board-list'),
+    path('boards/<uuid:pk>/', BoardViewSet.as_view({'get': 'retrieve', 'patch': 'partial_update'}), name='board-detail'),
+    
+    # Board items (nested)
+    path('boards/<uuid:board_id>/items/', BoardViewSet.as_view({'get': 'items', 'post': 'items'}), name='board-items'),
+    path('boards/<uuid:board_id>/items/batch/', BoardViewSet.as_view({'patch': 'batch_items'}), name='board-items-batch'),
+    
+    # Item operations
+    path('items/<uuid:pk>/', BoardItemViewSet.as_view({'patch': 'partial_update', 'delete': 'destroy'}), name='item-detail'),
+    
+    # Board revisions (nested)
+    path('boards/<uuid:board_id>/revisions/', BoardViewSet.as_view({'get': 'revisions', 'post': 'revisions'}), name='board-revisions'),
+    path('boards/<uuid:board_id>/revisions/<int:version>/', BoardViewSet.as_view({'get': 'revision_detail'}), name='board-revision-detail'),
+    path('boards/<uuid:board_id>/revisions/<int:version>/restore/', BoardViewSet.as_view({'post': 'restore_revision'}), name='board-revision-restore'),
+    
+    # Share token access
+    path('share/boards/<str:share_token>/', ShareBoardView.as_view(), name='share-board'),
+]
+

--- a/backend/miro/views.py
+++ b/backend/miro/views.py
@@ -1,0 +1,258 @@
+from rest_framework import viewsets, status
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.views import APIView
+from rest_framework.exceptions import PermissionDenied, NotFound
+from django.shortcuts import get_object_or_404
+from django.db.models import Max
+
+from core.models import ProjectMember
+from miro.models import Board, BoardItem, BoardRevision
+from miro.serializers import (
+    BoardSerializer,
+    BoardCreateSerializer,
+    BoardUpdateSerializer,
+    BoardItemSerializer,
+    BoardItemCreateSerializer,
+    BoardItemUpdateSerializer,
+    BoardItemBatchUpdateSerializer,
+    BoardRevisionSerializer,
+    BoardRevisionCreateSerializer,
+    ShareBoardResponseSerializer,
+)
+from miro.permissions import IsBoardProjectMember, HasValidShareToken
+
+
+class BoardViewSet(viewsets.ModelViewSet):
+    """ViewSet for Board model"""
+    queryset = Board.objects.select_related('project')
+    permission_classes = [IsAuthenticated, IsBoardProjectMember]
+
+    def get_serializer_class(self):
+        """Return appropriate serializer based on action"""
+        if self.action == 'create':
+            return BoardCreateSerializer
+        elif self.action in ['update', 'partial_update']:
+            return BoardUpdateSerializer
+        return BoardSerializer
+
+    def get_queryset(self):
+        """Filter boards by user's project memberships"""
+        user = self.request.user
+        if not user.is_authenticated:
+            return Board.objects.none()
+
+        # Get all projects where user is a member
+        project_ids = ProjectMember.objects.filter(
+            user=user,
+            is_active=True
+        ).values_list('project_id', flat=True)
+
+        return Board.objects.filter(
+            project_id__in=project_ids
+        ).select_related('project').order_by('-created_at')
+
+    @action(detail=True, methods=['get', 'post'], url_path='items')
+    def items(self, request, pk=None):
+        """List or create board items"""
+        board = self.get_object()
+        
+        if request.method == 'GET':
+            # List items
+            include_deleted = request.query_params.get('include_deleted', 'false').lower() == 'true'
+            queryset = BoardItem.objects.filter(board=board)
+            
+            if not include_deleted:
+                queryset = queryset.filter(is_deleted=False)
+            
+            queryset = queryset.select_related('parent_item').order_by('z_index', 'created_at')
+            serializer = BoardItemSerializer(queryset, many=True)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        
+        elif request.method == 'POST':
+            # Create item
+            serializer = BoardItemCreateSerializer(
+                data=request.data,
+                context={'request': request, 'board': board}
+            )
+            serializer.is_valid(raise_exception=True)
+            item = serializer.save()
+            response_serializer = BoardItemSerializer(item)
+            return Response(response_serializer.data, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=['patch'], url_path='items/batch')
+    def batch_items(self, request, pk=None):
+        """Batch update board items (partial updates)"""
+        board = self.get_object()
+        
+        # Validate request data
+        batch_serializer = BoardItemBatchUpdateSerializer(data={'items': request.data.get('items', [])})
+        batch_serializer.is_valid(raise_exception=True)
+        items_data = batch_serializer.validated_data['items']
+        
+        updated = []
+        failed = []
+        
+        for item_data in items_data:
+            item_id = item_data.pop('id', None)
+            if not item_id:
+                failed.append({'id': None, 'error': 'Missing id field'})
+                continue
+            
+            try:
+                item = BoardItem.objects.get(id=item_id, board=board)
+                serializer = BoardItemUpdateSerializer(item, data=item_data, partial=True)
+                if serializer.is_valid():
+                    serializer.save()
+                    updated.append(serializer.data)
+                else:
+                    failed.append({'id': str(item_id), 'error': serializer.errors})
+            except BoardItem.DoesNotExist:
+                failed.append({'id': str(item_id), 'error': 'Item not found'})
+            except Exception as e:
+                failed.append({'id': str(item_id), 'error': str(e)})
+        
+        return Response({
+            'updated': updated,
+            'failed': failed
+        }, status=status.HTTP_200_OK)
+
+    @action(detail=True, methods=['get', 'post'], url_path='revisions')
+    def revisions(self, request, pk=None):
+        """List or create board revisions"""
+        board = self.get_object()
+        
+        if request.method == 'GET':
+            # List revisions
+            limit = int(request.query_params.get('limit', 20))
+            limit = max(1, min(limit, 100))  # Clamp between 1 and 100
+            
+            queryset = BoardRevision.objects.filter(
+                board=board
+            ).order_by('-version', '-created_at')[:limit]
+            
+            serializer = BoardRevisionSerializer(queryset, many=True)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        
+        elif request.method == 'POST':
+            # Create revision
+            serializer = BoardRevisionCreateSerializer(
+                data=request.data,
+                context={'request': request, 'board': board}
+            )
+            serializer.is_valid(raise_exception=True)
+            revision = serializer.save()
+            response_serializer = BoardRevisionSerializer(revision)
+            return Response(response_serializer.data, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=['get'], url_path='revisions/(?P<version>\\d+)')
+    def revision_detail(self, request, pk=None, version=None):
+        """Get a specific board revision by version"""
+        board = self.get_object()
+        
+        try:
+            revision = BoardRevision.objects.get(board=board, version=version)
+        except BoardRevision.DoesNotExist:
+            raise NotFound(f"Revision version {version} not found for this board")
+        
+        serializer = BoardRevisionSerializer(revision)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @action(detail=True, methods=['post'], url_path='revisions/(?P<version>\\d+)/restore')
+    def restore_revision(self, request, pk=None, version=None):
+        """Restore board from a revision (creates new revision)"""
+        board = self.get_object()
+        
+        try:
+            old_revision = BoardRevision.objects.get(board=board, version=version)
+        except BoardRevision.DoesNotExist:
+            raise NotFound(f"Revision version {version} not found for this board")
+        
+        # Get next version number
+        max_version = BoardRevision.objects.filter(
+            board=board
+        ).aggregate(Max('version'))['version__max'] or 0
+        new_version = max_version + 1
+        
+        # Create new revision with old snapshot
+        new_revision = BoardRevision.objects.create(
+            board=board,
+            version=new_version,
+            snapshot=old_revision.snapshot,
+            note=f"Restored from version {version}"
+        )
+        
+        serializer = BoardRevisionSerializer(new_revision)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+
+class BoardItemViewSet(viewsets.ModelViewSet):
+    """ViewSet for BoardItem model"""
+    queryset = BoardItem.objects.select_related('board', 'parent_item')
+    serializer_class = BoardItemSerializer
+    permission_classes = [IsAuthenticated, IsBoardProjectMember]
+
+    def get_serializer_class(self):
+        """Return appropriate serializer based on action"""
+        if self.action in ['update', 'partial_update']:
+            return BoardItemUpdateSerializer
+        return BoardItemSerializer
+
+    def get_queryset(self):
+        """Filter items by user's project memberships"""
+        user = self.request.user
+        if not user.is_authenticated:
+            return BoardItem.objects.none()
+
+        # Get all projects where user is a member
+        project_ids = ProjectMember.objects.filter(
+            user=user,
+            is_active=True
+        ).values_list('project_id', flat=True)
+
+        return BoardItem.objects.filter(
+            board__project_id__in=project_ids
+        ).select_related('board', 'parent_item')
+
+    def destroy(self, request, *args, **kwargs):
+        """Soft delete item and return specific response format"""
+        instance = self.get_object()
+        self.perform_destroy(instance)
+        return Response({
+            'id': str(instance.id),
+            'is_deleted': True,
+            'updated_at': instance.updated_at
+        }, status=status.HTTP_200_OK)
+
+    def perform_destroy(self, instance):
+        """Soft delete item (set is_deleted=True)"""
+        instance.is_deleted = True
+        instance.save(update_fields=['is_deleted', 'updated_at'])
+
+
+class ShareBoardView(APIView):
+    """View for accessing board via share token (public access)"""
+    permission_classes = [HasValidShareToken]
+
+    def get(self, request, share_token=None):
+        """Get board and active items via share token"""
+        try:
+            board = Board.objects.get(share_token=share_token)
+        except Board.DoesNotExist:
+            raise NotFound("Board not found or invalid share token")
+        
+        # Get active items only (exclude deleted)
+        items = BoardItem.objects.filter(
+            board=board,
+            is_deleted=False
+        ).select_related('parent_item').order_by('z_index', 'created_at')
+        
+        board_serializer = BoardSerializer(board)
+        items_serializer = BoardItemSerializer(items, many=True)
+        
+        return Response({
+            'board': board_serializer.data,
+            'items': items_serializer.data
+        }, status=status.HTTP_200_OK)
+

--- a/backend/miro/views.py
+++ b/backend/miro/views.py
@@ -54,9 +54,14 @@ class BoardViewSet(viewsets.ModelViewSet):
         ).select_related('project').order_by('-created_at')
 
     @action(detail=True, methods=['get', 'post'], url_path='items')
-    def items(self, request, pk=None):
+    def items(self, request, pk=None, board_id=None):
         """List or create board items"""
-        board = self.get_object()
+        # Support both pk (from router) and board_id (from manual URL pattern)
+        if board_id:
+            from miro.models import Board
+            board = get_object_or_404(Board, id=board_id)
+        else:
+            board = self.get_object()
         
         if request.method == 'GET':
             # List items
@@ -82,9 +87,14 @@ class BoardViewSet(viewsets.ModelViewSet):
             return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
     @action(detail=True, methods=['patch'], url_path='items/batch')
-    def batch_items(self, request, pk=None):
+    def batch_items(self, request, pk=None, board_id=None):
         """Batch update board items (partial updates)"""
-        board = self.get_object()
+        # Support both pk (from router) and board_id (from manual URL pattern)
+        if board_id:
+            from miro.models import Board
+            board = get_object_or_404(Board, id=board_id)
+        else:
+            board = self.get_object()
         
         # Validate request data
         batch_serializer = BoardItemBatchUpdateSerializer(data={'items': request.data.get('items', [])})
@@ -119,9 +129,14 @@ class BoardViewSet(viewsets.ModelViewSet):
         }, status=status.HTTP_200_OK)
 
     @action(detail=True, methods=['get', 'post'], url_path='revisions')
-    def revisions(self, request, pk=None):
+    def revisions(self, request, pk=None, board_id=None):
         """List or create board revisions"""
-        board = self.get_object()
+        # Support both pk (from router) and board_id (from manual URL pattern)
+        if board_id:
+            from miro.models import Board
+            board = get_object_or_404(Board, id=board_id)
+        else:
+            board = self.get_object()
         
         if request.method == 'GET':
             # List revisions
@@ -147,9 +162,14 @@ class BoardViewSet(viewsets.ModelViewSet):
             return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
     @action(detail=True, methods=['get'], url_path='revisions/(?P<version>\\d+)')
-    def revision_detail(self, request, pk=None, version=None):
+    def revision_detail(self, request, pk=None, version=None, board_id=None):
         """Get a specific board revision by version"""
-        board = self.get_object()
+        # Support both pk (from router) and board_id (from manual URL pattern)
+        if board_id:
+            from miro.models import Board
+            board = get_object_or_404(Board, id=board_id)
+        else:
+            board = self.get_object()
         
         try:
             revision = BoardRevision.objects.get(board=board, version=version)
@@ -160,9 +180,14 @@ class BoardViewSet(viewsets.ModelViewSet):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @action(detail=True, methods=['post'], url_path='revisions/(?P<version>\\d+)/restore')
-    def restore_revision(self, request, pk=None, version=None):
+    def restore_revision(self, request, pk=None, version=None, board_id=None):
         """Restore board from a revision (creates new revision)"""
-        board = self.get_object()
+        # Support both pk (from router) and board_id (from manual URL pattern)
+        if board_id:
+            from miro.models import Board
+            board = get_object_or_404(Board, id=board_id)
+        else:
+            board = self.get_object()
         
         try:
             old_revision = BoardRevision.objects.get(board=board, version=version)


### PR DESCRIPTION
### API Endpoints (`views.py`, `urls.py`)
- **Board Management**: POST `/boards/`, GET/PATCH `/boards/{board_id}/`
- **Share Access**: GET `/share/boards/{share_token}/` (public, no auth required)
- **Board Items**: GET/POST `/boards/{board_id}/items/`, PATCH `/items/{item_id}/`, DELETE `/items/{item_id}/`, PATCH `/boards/{board_id}/items/batch/`
- **Board Revisions**: GET/POST `/boards/{board_id}/revisions/`, GET `/boards/{board_id}/revisions/{version}/`, POST `/boards/{board_id}/revisions/{version}/restore/`

**Total**: 14 endpoints implemented

### Serializers (`serializers.py`)
- **Board**: BoardSerializer, BoardCreateSerializer (auto-generates share token), BoardUpdateSerializer
- **BoardItem**: BoardItemSerializer, BoardItemCreateSerializer, BoardItemUpdateSerializer, BoardItemBatchUpdateSerializer
- **BoardRevision**: BoardRevisionSerializer, BoardRevisionCreateSerializer (auto-increments version)
- **Share**: ShareBoardResponseSerializer

**Total**: 9 serializers with validation and custom logic

### Permissions (`permissions.py`)
- **IsBoardProjectMember**: Validates user is active member of board's project (works with Board, BoardItem, BoardRevision)
- **HasValidShareToken**: Validates share token for public access (no authentication required)

### Configuration
- **App Registration**: Added `miro.apps.MiroConfig` to `INSTALLED_APPS`
- **URL Routing**: Registered at `/api/miro/` in main URL configuration
- **Dependencies**: Uses existing `core.Project` and `core.ProjectMember` models

### Tests
<img width="504" height="59" alt="image" src="https://github.com/user-attachments/assets/6f6372c0-fae8-4ba0-872d-b902d3cffe01" />
