### PR TITLE
Align Klaviyo & Mailchimp API calls with shared axios client

### DIFF
--- a/frontend/src/lib/api/klaviyoApi.ts
+++ b/frontend/src/lib/api/klaviyoApi.ts
@@ -8,8 +8,7 @@ import {
   CanvasBlocks,
   CanvasBlock,
 } from "@/components/mailchimp/email-builder/types";
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+import api from "@/lib/api";
 
 class KlaviyoApiError extends Error {
   constructor(message: string, public status?: number, public response?: any) {
@@ -18,65 +17,17 @@ class KlaviyoApiError extends Error {
   }
 }
 
-// Helper function to handle API responses
-const handleApiResponse = async (response: Response) => {
-  if (!response.ok) {
-    let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
-    let errorData: any = null;
-
-    try {
-      errorData = await response.json();
-      errorMessage = errorData.error || errorData.detail || errorMessage;
-
-      // Handle authentication errors
-      if (response.status === 401) {
-        errorMessage = errorData.detail || "Authentication required. Please log in again.";
-      }
-    } catch {
-      // If response is not JSON, use the status text
-      if (response.status === 401) {
-        errorMessage = "Authentication required. Please log in again.";
-      }
-    }
-
-    const error = new KlaviyoApiError(errorMessage, response.status);
-    error.response = errorData;
-    throw error;
-  }
-
-  const contentType = response.headers.get("content-type");
-  if (contentType && contentType.includes("application/json")) {
-    return await response.json();
-  }
-  return null;
-};
-
-// Helper function to get auth headers
-const getAuthHeaders = () => {
-  let token = null;
-
-  // Get token from Zustand auth store (same as other API files)
-  if (typeof window !== "undefined") {
-    const authStorage = localStorage.getItem("auth-storage");
-    if (authStorage) {
-      try {
-        const authData = JSON.parse(authStorage);
-        token = authData.state?.token;
-      } catch (error) {
-        console.warn("Failed to parse auth storage:", error);
-      }
-    }
-  }
-
-  const headers: { [key: string]: string } = {
-    "Content-Type": "application/json",
-  };
-
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
-
-  return headers;
+const normalizeApiError = (error: any, fallbackMessage: string) => {
+  const status = error?.response?.status;
+  const errorData = error?.response?.data;
+  const message =
+    errorData?.error ||
+    errorData?.detail ||
+    error?.message ||
+    fallbackMessage;
+  const apiError = new KlaviyoApiError(message, status);
+  apiError.response = errorData;
+  throw apiError;
 };
 
 /**
@@ -212,37 +163,23 @@ export const klaviyoApi = {
   // Get all email drafts
   getEmailDrafts: async (): Promise<KlaviyoDraft[]> => {
     try {
-      const response = await fetch(
-        `${API_BASE_URL}/api/klaviyo/klaviyo-drafts/`,
-        {
-          method: "GET",
-          headers: getAuthHeaders(),
-        }
-      );
-
-      const data = await handleApiResponse(response);
+      const response = await api.get("/api/klaviyo/klaviyo-drafts/");
+      const data = response.data;
       return data?.results || data || [];
     } catch (error) {
       console.error("Failed to fetch Klaviyo email drafts:", error);
-      throw error;
+      normalizeApiError(error, "Failed to fetch Klaviyo email drafts");
     }
   },
 
   // Get single email draft by ID
   getEmailDraft: async (id: number): Promise<KlaviyoDraft> => {
     try {
-      const response = await fetch(
-        `${API_BASE_URL}/api/klaviyo/klaviyo-drafts/${id}/`,
-        {
-          method: "GET",
-          headers: getAuthHeaders(),
-        }
-      );
-
-      return await handleApiResponse(response);
+      const response = await api.get(`/api/klaviyo/klaviyo-drafts/${id}/`);
+      return response.data;
     } catch (error) {
       console.error(`Failed to fetch Klaviyo email draft ${id}:`, error);
-      throw error;
+      normalizeApiError(error, `Failed to fetch Klaviyo email draft ${id}`);
     }
   },
 
@@ -260,19 +197,11 @@ export const klaviyoApi = {
         payload.name = data.name;
       }
 
-      const response = await fetch(
-        `${API_BASE_URL}/api/klaviyo/klaviyo-drafts/`,
-        {
-          method: "POST",
-          headers: getAuthHeaders(),
-          body: JSON.stringify(payload),
-        }
-      );
-
-      return await handleApiResponse(response);
+      const response = await api.post("/api/klaviyo/klaviyo-drafts/", payload);
+      return response.data;
     } catch (error) {
       console.error("Failed to create Klaviyo email draft:", error);
-      throw error;
+      normalizeApiError(error, "Failed to create Klaviyo email draft");
     }
   },
 
@@ -282,19 +211,11 @@ export const klaviyoApi = {
     data: UpdateKlaviyoDraftData
   ): Promise<KlaviyoDraft> => {
     try {
-      const response = await fetch(
-        `${API_BASE_URL}/api/klaviyo/klaviyo-drafts/${id}/`,
-        {
-          method: "PUT",
-          headers: getAuthHeaders(),
-          body: JSON.stringify(data),
-        }
-      );
-
-      return await handleApiResponse(response);
+      const response = await api.put(`/api/klaviyo/klaviyo-drafts/${id}/`, data);
+      return response.data;
     } catch (error) {
       console.error(`Failed to update Klaviyo email draft ${id}:`, error);
-      throw error;
+      normalizeApiError(error, `Failed to update Klaviyo email draft ${id}`);
     }
   },
 
@@ -304,39 +225,24 @@ export const klaviyoApi = {
     data: Partial<UpdateKlaviyoDraftData>
   ): Promise<KlaviyoDraft> => {
     try {
-      const response = await fetch(
-        `${API_BASE_URL}/api/klaviyo/klaviyo-drafts/${id}/`,
-        {
-          method: "PATCH",
-          headers: getAuthHeaders(),
-          body: JSON.stringify(data),
-        }
+      const response = await api.patch(
+        `/api/klaviyo/klaviyo-drafts/${id}/`,
+        data
       );
-
-      return await handleApiResponse(response);
+      return response.data;
     } catch (error) {
       console.error(`Failed to patch Klaviyo email draft ${id}:`, error);
-      throw error;
+      normalizeApiError(error, `Failed to patch Klaviyo email draft ${id}`);
     }
   },
 
   // Delete email draft
   deleteEmailDraft: async (id: number): Promise<void> => {
     try {
-      const response = await fetch(
-        `${API_BASE_URL}/api/klaviyo/klaviyo-drafts/${id}/`,
-        {
-          method: "DELETE",
-          headers: getAuthHeaders(),
-        }
-      );
-
-      if (!response.ok && response.status !== 204) {
-        await handleApiResponse(response);
-      }
+      await api.delete(`/api/klaviyo/klaviyo-drafts/${id}/`);
     } catch (error) {
       console.error(`Failed to delete Klaviyo email draft ${id}:`, error);
-      throw error;
+      normalizeApiError(error, `Failed to delete Klaviyo email draft ${id}`);
     }
   },
 
@@ -382,62 +288,19 @@ export const klaviyoImageApi = {
       formData.append('file', file);
       formData.append('name', file.name);
 
-      const token = (() => {
-        if (typeof window !== "undefined") {
-          const authStorage = localStorage.getItem("auth-storage");
-          if (authStorage) {
-            try {
-              const authData = JSON.parse(authStorage);
-              return authData.state?.token;
-            } catch (error) {
-              console.warn("Failed to parse auth storage:", error);
-            }
-          }
-        }
-        return null;
-      })();
-
-      const xhr = new XMLHttpRequest();
-
-      return new Promise((resolve, reject) => {
-        xhr.upload.addEventListener('progress', (e) => {
-          if (e.lengthComputable && onUploadProgress) {
-            const percent = Math.round((e.loaded / e.total) * 100);
-            onUploadProgress(percent);
-          }
-        });
-
-        xhr.addEventListener('load', () => {
-          if (xhr.status >= 200 && xhr.status < 300) {
-            try {
-              const response = JSON.parse(xhr.responseText);
-              resolve(response);
-            } catch (error) {
-              reject(new Error('Failed to parse response'));
-            }
-          } else {
-            try {
-              const errorResponse = JSON.parse(xhr.responseText);
-              reject(new Error(errorResponse.error || `HTTP ${xhr.status}`));
-            } catch {
-              reject(new Error(`HTTP ${xhr.status}: ${xhr.statusText}`));
-            }
-          }
-        });
-
-        xhr.addEventListener('error', () => {
-          reject(new Error('Network error'));
-        });
-
-        xhr.open('POST', `${API_BASE_URL}/api/klaviyo/images/upload/`);
-        if (token) {
-          xhr.setRequestHeader('Authorization', `Bearer ${token}`);
-        }
-        xhr.send(formData);
+      const response = await api.post("/api/klaviyo/images/upload/", formData, {
+        headers: { "Content-Type": "multipart/form-data" },
+        onUploadProgress: (event) => {
+          if (!onUploadProgress || !event.total) return;
+          const percent = Math.round((event.loaded / event.total) * 100);
+          onUploadProgress(percent);
+        },
       });
+
+      return response.data;
     } catch (error) {
       console.error("Failed to upload Klaviyo image:", error);
-      throw error;
+      normalizeApiError(error, "Failed to upload Klaviyo image");
     }
   },
 
@@ -449,42 +312,25 @@ export const klaviyoImageApi = {
     sort?: 'asc' | 'desc';
   }): Promise<KlaviyoImageListResponse> => {
     try {
-      const queryParams = new URLSearchParams();
-      if (params?.search) queryParams.append('search', params.search);
-      if (params?.page) queryParams.append('page', params.page.toString());
-      if (params?.page_size) queryParams.append('page_size', params.page_size.toString());
-      if (params?.sort) queryParams.append('sort', params.sort);
-
-      const url = `${API_BASE_URL}/api/klaviyo/images${queryParams.toString() ? '?' + queryParams.toString() : ''}`;
-      const response = await fetch(url, {
-        method: "GET",
-        headers: getAuthHeaders(),
-      });
-
-      return await handleApiResponse(response);
+      const response = await api.get("/api/klaviyo/images/", { params });
+      return response.data;
     } catch (error) {
       console.error("Failed to fetch Klaviyo images:", error);
-      throw error;
+      normalizeApiError(error, "Failed to fetch Klaviyo images");
     }
   },
 
   // Import image from URL
   importImageFromUrl: async (url: string, name?: string): Promise<KlaviyoImageItem> => {
     try {
-      const response = await fetch(
-        `${API_BASE_URL}/api/klaviyo/images/import-url/`,
-        {
-          method: "POST",
-          headers: getAuthHeaders(),
-          body: JSON.stringify({ url, name: name || 'Imported image' }),
-        }
-      );
-
-      return await handleApiResponse(response);
+      const response = await api.post("/api/klaviyo/images/import-url/", {
+        url,
+        name: name || "Imported image",
+      });
+      return response.data;
     } catch (error) {
       console.error("Failed to import Klaviyo image from URL:", error);
-      throw error;
+      normalizeApiError(error, "Failed to import Klaviyo image from URL");
     }
   },
 };
-


### PR DESCRIPTION
## Summary

This PR fixes Klaviyo and Mailchimp modules not working in production by aligning their API call implementation with existing, production-verified patterns used elsewhere in the codebase.

## Background

Klaviyo and Mailchimp were previously implemented using standalone `fetch` calls with absolute URLs and a `localhost` fallback.  
This caused requests in production to incorrectly target `http://localhost:8000`, resulting in connection failures.

Other external-API integrations (e.g. Stripe Plans, Facebook Meta Preview) are working in production and share a common implementation pattern:
- Shared axios client (`@/lib/api`)
- Relative API paths (`/api/...`)
- Centralised auth and error handling via interceptors

## Changes

- Migrated Klaviyo and Mailchimp API modules to use the shared axios client
- Replaced absolute URLs with relative `/api/...` paths
- Removed manual auth header handling and localhost fallbacks
- Preserved existing function signatures and error semantics
- Normalised axios errors back into existing custom error types

## Verification

- API calls now follow the same request path and auth flow as other production-working modules
- Backend API contracts were sanity-checked (Mailchimp comments endpoint supports `status` query param)
- No deployment or infrastructure configuration changes are required

## Scope

- Frontend only
- No backend or DevOps changes
