### PR TITLE
Decision Module: OpenAPI contract for draft, commit, review lifecycle

### DIFF
--- a/openapi/openapi_spec/decision.yaml
+++ b/openapi/openapi_spec/decision.yaml
@@ -1,0 +1,1077 @@
+openapi: 3.0.3
+info:
+  title: MediaJira Decision Module API
+  version: 0.2.0
+  description: |
+    Backend–frontend contract for the Decision Module.
+
+    Design principles (from URS + SRS):
+    - Decision is a record of human judgment, not performance data.
+    - Drafts are editable. Committed decisions are read-only for core fields.
+    - Commit is an explicit, irreversible action that locks core fields.
+    - Reviews are append-only and never mutate the original committed content.
+    - State transitions are guarded by the API and surfaced via explicit, machine-readable errors.
+
+servers:
+  - url: /api
+
+tags:
+  - name: DecisionDrafts
+    description: Draft creation and mutation endpoints (editable).
+  - name: Decisions
+    description: Read-only retrieval and discovery of committed decisions.
+  - name: DecisionCommit
+    description: Commit action (state transition).
+  - name: DecisionReviews
+    description: Post-execution reviews (append-only).
+  - name: DecisionAdmin
+    description: Admin/Lead lifecycle actions (e.g., approve, archive).
+
+security:
+  - bearerAuth: []
+
+paths:
+  /decisions/drafts:
+    post:
+      tags: [DecisionDrafts]
+      summary: Create a new Decision Draft
+      description: |
+        Creates a Decision in DRAFT status with minimal friction.
+        This endpoint MUST NOT trigger any execution behavior.
+
+        State transition:
+        - (none) -> DRAFT
+      operationId: createDecisionDraft
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDecisionDraftRequest'
+            examples:
+              minimal:
+                summary: Minimal create (recommended)
+                value:
+                  title: "Optional short title"
+      responses:
+        '201':
+          description: Draft created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecisionDraft'
+              examples:
+                created:
+                  value:
+                    id: "2b8c8b1a-4f90-4bb0-93c5-1de3cdb9c2aa"
+                    title: "Optional short title"
+                    contextSummary: null
+                    signals: []
+                    options: []
+                    reasoning: null
+                    riskLevel: null
+                    confidenceScore: null
+                    status: DRAFT
+                    createdAt: "2026-01-20T01:02:03Z"
+                    createdBy: "f8d2c5b5-1a42-4db3-8e0d-f4c0b1e2a333"
+                    lastEditedAt: null
+                    lastEditedBy: null
+                    commitRecord: null
+                    permissions:
+                      canView: true
+                      canEditDraft: true
+                      canCommit: true
+                      canAddReview: false
+                      canApprove: false
+                      canArchive: false
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /decisions/drafts/{decisionId}:
+    get:
+      tags: [DecisionDrafts]
+      summary: Get a Decision Draft (editable view)
+      description: |
+        Returns a Decision Draft for editing.
+
+        State constraints:
+        - Allowed: DRAFT, AWAITING_APPROVAL
+        - Rejected: COMMITTED, REVIEWED, ARCHIVED (use GET /decisions/{decisionId})
+      operationId: getDecisionDraft
+      parameters:
+        - $ref: '#/components/parameters/DecisionId'
+      responses:
+        '200':
+          description: Draft found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecisionDraft'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/InvalidState'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+    patch:
+      tags: [DecisionDrafts]
+      summary: Update a Decision Draft (context/signals/options/reasoning/risk/confidence)
+      description: |
+        Partially updates an editable Decision Draft.
+        MUST be rejected if the decision is COMMITTED/REVIEWED/ARCHIVED.
+
+        State constraints:
+        - Allowed: DRAFT, AWAITING_APPROVAL
+        - Rejected: COMMITTED, REVIEWED, ARCHIVED
+
+        Notes on array updates (contract choice):
+        - `signals` and `options` arrays use full replacement to keep the frontend contract unambiguous.
+          The client sends the complete current list.
+      operationId: updateDecisionDraft
+      parameters:
+        - $ref: '#/components/parameters/DecisionId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateDecisionDraftRequest'
+            examples:
+              updateDraft:
+                value:
+                  title: "Scale after client request"
+                  contextSummary: "Client requested aggressive scaling ahead of promo."
+                  signals:
+                    - type: CLIENT
+                      description: "Client requested aggressive scaling"
+                      severity: MEDIUM
+                      source: "Email"
+                  options:
+                    - text: "Increase budget 20% across top ad sets"
+                      isSelected: true
+                    - text: "Hold spend and monitor for 24h"
+                      isSelected: false
+                  reasoning: "We have enough headroom and promo window is short."
+                  riskLevel: MEDIUM
+                  confidenceScore: 3
+      responses:
+        '200':
+          description: Draft updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecisionDraft'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/InvalidState'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /decisions/{decisionId}/commit:
+    post:
+      tags: [DecisionCommit]
+      summary: Commit a Decision (Draft -> Committed or Awaiting Approval)
+      description: |
+        Commits a Decision Draft, recording accountability and locking core fields.
+
+        Validations (user-facing):
+        - contextSummary non-empty
+        - >= 1 signal
+        - >= 2 options
+        - exactly 1 option selected
+        - reasoning non-empty
+        - riskLevel set
+        - confidenceScore set
+
+        State transition:
+        - DRAFT -> COMMITTED (if no approval needed)
+        - DRAFT -> AWAITING_APPROVAL (if high-risk approval policy applies)
+
+        Immutability guarantee after COMMITTED:
+        - Core fields become read-only: contextSummary, signals, options, reasoning, riskLevel, confidenceScore
+        - Only reviews (append-only) and admin lifecycle actions are allowed.
+
+        When approval is required:
+        - The API returns 202 with status=AWAITING_APPROVAL (not an error).
+        - A Lead/Admin must call POST /decisions/{decisionId}/approve to finalize the commit.
+      operationId: commitDecision
+      parameters:
+        - $ref: '#/components/parameters/DecisionId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CommitDecisionRequest'
+            examples:
+              commit:
+                value:
+                  confirmationStatements:
+                    consideredAlternatives: true
+                    acceptRisk: true
+                    willReviewOutcome: true
+      responses:
+        '200':
+          description: Decision committed (core fields locked)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecisionCommitted'
+        '202':
+          description: Commit accepted but pending approval (status=AWAITING_APPROVAL)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecisionDraft'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/InvalidState'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /decisions/{decisionId}/approve:
+    post:
+      tags: [DecisionAdmin]
+      summary: Approve a pending decision commit (Lead/Admin)
+      description: |
+        Approves a decision that is pending approval.
+
+        State constraints:
+        - Allowed: AWAITING_APPROVAL
+        - Rejected: DRAFT, COMMITTED, REVIEWED, ARCHIVED
+
+        State transition:
+        - AWAITING_APPROVAL -> COMMITTED
+      operationId: approveDecision
+      parameters:
+        - $ref: '#/components/parameters/DecisionId'
+      responses:
+        '200':
+          description: Approved and committed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecisionCommitted'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/InvalidState'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /decisions:
+    get:
+      tags: [Decisions]
+      summary: List and search decisions (committed/read-only)
+      description: |
+        Returns decisions for discovery and learning.
+        Consumers SHOULD treat returned decisions as read-only records.
+
+        Search:
+        - Keyword search across contextSummary, signals.description, options.text, reasoning
+
+        Filtering:
+        - status, riskLevel, creatorId, date range
+      operationId: listDecisions
+      parameters:
+        - $ref: '#/components/parameters/Status'
+        - $ref: '#/components/parameters/RiskLevel'
+        - $ref: '#/components/parameters/CreatorId'
+        - $ref: '#/components/parameters/DateFrom'
+        - $ref: '#/components/parameters/DateTo'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageToken'
+      responses:
+        '200':
+          description: Decision list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecisionListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /decisions/{decisionId}:
+    get:
+      tags: [Decisions]
+      summary: Get a decision (read-only view for committed decisions)
+      description: |
+        Retrieves a decision for read-only viewing.
+        Intended for COMMITTED/REVIEWED/ARCHIVED decisions.
+
+        If the client needs an editable draft, use GET /decisions/drafts/{decisionId}.
+
+        State constraints:
+        - Allowed: COMMITTED, REVIEWED, ARCHIVED
+        - Rejected: DRAFT, AWAITING_APPROVAL (use drafts endpoint)
+      operationId: getCommittedDecision
+      parameters:
+        - $ref: '#/components/parameters/DecisionId'
+      responses:
+        '200':
+          description: Decision found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecisionCommitted'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/InvalidState'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /decisions/{decisionId}/reviews:
+    get:
+      tags: [DecisionReviews]
+      summary: List reviews for a decision
+      description: |
+        Returns review entries appended to a decision.
+        Reviews are append-only and do not mutate original decision content.
+      operationId: listDecisionReviews
+      parameters:
+        - $ref: '#/components/parameters/DecisionId'
+      responses:
+        '200':
+          description: Reviews list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReviewListResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+    post:
+      tags: [DecisionReviews]
+      summary: Submit a review (append-only)
+      description: |
+        Adds a post-execution review entry to a decision.
+
+        State constraints:
+        - Allowed: COMMITTED, REVIEWED
+        - Rejected: DRAFT, AWAITING_APPROVAL, ARCHIVED
+
+        State transition:
+        - COMMITTED -> REVIEWED (server MAY keep status as COMMITTED and infer "reviewed" by presence of reviews;
+          if explicit status is used, it becomes REVIEWED after first review is added)
+      operationId: addDecisionReview
+      parameters:
+        - $ref: '#/components/parameters/DecisionId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateReviewRequest'
+            examples:
+              review:
+                value:
+                  outcomeText: "CPA stabilized after 72h."
+                  reflectionText: "Budget reduction helped; next time test new creative sooner."
+                  decisionQuality: GOOD
+                  tags: ["budget", "creative"]
+      responses:
+        '201':
+          description: Review created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Review'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/InvalidState'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /decisions/{decisionId}/archive:
+    post:
+      tags: [DecisionAdmin]
+      summary: Archive a decision (Admin only)
+      description: |
+        Archives a decision. Archived decisions are read-only and can be hidden from default lists.
+
+        State transition:
+        - ANY -> ARCHIVED
+      operationId: archiveDecision
+      parameters:
+        - $ref: '#/components/parameters/DecisionId'
+      responses:
+        '200':
+          description: Archived
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecisionCommitted'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/InvalidState'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  parameters:
+    DecisionId:
+      name: decisionId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+
+    Status:
+      name: status
+      in: query
+      required: false
+      description: Filter by decision status.
+      schema:
+        $ref: '#/components/schemas/DecisionStatus'
+
+    RiskLevel:
+      name: riskLevel
+      in: query
+      required: false
+      schema:
+        $ref: '#/components/schemas/RiskLevel'
+
+    CreatorId:
+      name: creatorId
+      in: query
+      required: false
+      schema:
+        type: string
+        format: uuid
+
+    DateFrom:
+      name: from
+      in: query
+      required: false
+      description: Inclusive start date/time (ISO-8601).
+      schema:
+        type: string
+        format: date-time
+
+    DateTo:
+      name: to
+      in: query
+      required: false
+      description: Exclusive end date/time (ISO-8601).
+      schema:
+        type: string
+        format: date-time
+
+    Search:
+      name: q
+      in: query
+      required: false
+      description: Keyword search across contextSummary, signals.description, options.text, reasoning.
+      schema:
+        type: string
+        maxLength: 200
+
+    PageSize:
+      name: pageSize
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+
+    PageToken:
+      name: pageToken
+      in: query
+      required: false
+      schema:
+        type: string
+
+  responses:
+    Unauthorized:
+      description: Authentication required.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            errorCode: UNAUTHORIZED
+            message: "Authentication required."
+
+    Forbidden:
+      description: Caller does not have permission.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            errorCode: FORBIDDEN
+            message: "You do not have permission to perform this action."
+
+    NotFound:
+      description: Resource not found.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            errorCode: NOT_FOUND
+            message: "Decision not found."
+
+    ValidationError:
+      description: |
+        Request failed validation. Frontend can show field-level errors.
+
+        Field error keys are standardized for UI mapping (commit + draft validation):
+        - title
+        - contextSummary
+        - signals
+        - options
+        - selectedOption
+        - reasoning
+        - riskLevel
+        - confidenceScore
+        - confirmationStatements
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ValidationErrorResponse'
+          example:
+            errorCode: VALIDATION_ERROR
+            message: "Please fix the highlighted fields."
+            fieldErrors:
+              contextSummary: ["Context Summary is required before commit."]
+              signals: ["Please add at least one Signal describing what triggered this decision."]
+              options: ["Please add at least two options."]
+              selectedOption: ["Select exactly one option before committing."]
+              reasoning: ["Reasoning is required before commit."]
+              riskLevel: ["Please select a risk level (Low/Medium/High)."]
+              confidenceScore: ["Please select a confidence score (1–5)."]
+              confirmationStatements: ["All confirmation statements must be accepted to commit."]
+
+    InvalidState:
+      description: Invalid state transition or operation not allowed in current status.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/InvalidStateErrorResponse'
+          examples:
+            committedCannotEdit:
+              summary: Attempt to edit draft after commit
+              value:
+                errorCode: INVALID_STATE_TRANSITION
+                message: "This operation is not allowed in the current state."
+                details:
+                  currentStatus: COMMITTED
+                  allowedStatuses: ["DRAFT", "AWAITING_APPROVAL"]
+                  suggestedAction: "Use GET /decisions/{decisionId} for read-only view."
+            draftCannotReadCommittedEndpoint:
+              summary: Attempt to read draft from committed endpoint
+              value:
+                errorCode: INVALID_STATE_TRANSITION
+                message: "This operation is not allowed in the current state."
+                details:
+                  currentStatus: DRAFT
+                  allowedStatuses: ["COMMITTED", "REVIEWED", "ARCHIVED"]
+                  suggestedAction: "Use GET /decisions/drafts/{decisionId} for editable view."
+
+  schemas:
+    DecisionStatus:
+      type: string
+      description: |
+        Decision lifecycle status.
+
+        Primary states:
+        - DRAFT: editable
+        - AWAITING_APPROVAL: commit accepted but pending Lead/Admin approval
+        - COMMITTED: core fields locked, read-only
+        - REVIEWED: at least one review exists (explicit or derived)
+        - ARCHIVED: hidden/read-only terminal state
+      enum: [DRAFT, AWAITING_APPROVAL, COMMITTED, REVIEWED, ARCHIVED]
+
+    RiskLevel:
+      type: string
+      enum: [LOW, MEDIUM, HIGH]
+
+    ConfidenceScore:
+      type: integer
+      minimum: 1
+      maximum: 5
+
+    SignalType:
+      type: string
+      description: Common signal categories; teams may extend.
+      enum: [PERFORMANCE, CLIENT, PLATFORM, INTUITION, OTHER]
+
+    SignalSeverity:
+      type: string
+      enum: [LOW, MEDIUM, HIGH]
+
+    DecisionQuality:
+      type: string
+      enum: [GOOD, ACCEPTABLE, POOR]
+
+    DecisionPermissions:
+      type: object
+      description: |
+        Server-computed permissions for the current caller.
+        Frontend should use these to show/enable actions without guessing role logic.
+      required: [canView, canEditDraft, canCommit, canAddReview, canApprove, canArchive]
+      properties:
+        canView:
+          type: boolean
+        canEditDraft:
+          type: boolean
+        canCommit:
+          type: boolean
+        canAddReview:
+          type: boolean
+        canApprove:
+          type: boolean
+        canArchive:
+          type: boolean
+
+    DecisionCore:
+      type: object
+      required: [id, status, createdAt, createdBy]
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        title:
+          type: string
+          maxLength: 120
+          nullable: true
+        contextSummary:
+          type: string
+          maxLength: 5000
+          nullable: true
+        signals:
+          type: array
+          items:
+            $ref: '#/components/schemas/Signal'
+          default: []
+        options:
+          type: array
+          items:
+            $ref: '#/components/schemas/Option'
+          default: []
+        reasoning:
+          type: string
+          maxLength: 8000
+          nullable: true
+        riskLevel:
+          $ref: '#/components/schemas/RiskLevel'
+          nullable: true
+        confidenceScore:
+          $ref: '#/components/schemas/ConfidenceScore'
+          nullable: true
+        status:
+          $ref: '#/components/schemas/DecisionStatus'
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+        createdBy:
+          type: string
+          format: uuid
+          readOnly: true
+        lastEditedAt:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        lastEditedBy:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+        permissions:
+          $ref: '#/components/schemas/DecisionPermissions'
+          readOnly: true
+
+    DecisionDraft:
+      allOf:
+        - $ref: '#/components/schemas/DecisionCore'
+        - type: object
+          description: |
+            Editable decision representation.
+            Only available via /decisions/drafts endpoints.
+          properties:
+            commitRecord:
+              nullable: true
+              readOnly: true
+              allOf:
+                - $ref: '#/components/schemas/CommitRecord'
+
+    DecisionCommitted:
+      allOf:
+        - $ref: '#/components/schemas/DecisionCore'
+        - type: object
+          description: |
+            Read-only decision representation for committed states.
+
+            Immutability:
+            - contextSummary, signals, options, reasoning, riskLevel, confidenceScore are locked after commit.
+            - Updates MUST be rejected via draft mutation endpoints once committed.
+
+            Reviews are append-only and returned alongside.
+          required: [commitRecord]
+          properties:
+            committedAt:
+              type: string
+              format: date-time
+              readOnly: true
+              nullable: true
+            committedBy:
+              type: string
+              format: uuid
+              readOnly: true
+              nullable: true
+            commitRecord:
+              $ref: '#/components/schemas/CommitRecord'
+            reviews:
+              type: array
+              items:
+                $ref: '#/components/schemas/Review'
+              readOnly: true
+              default: []
+
+    Signal:
+      type: object
+      required: [type, description]
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        type:
+          $ref: '#/components/schemas/SignalType'
+        description:
+          type: string
+          maxLength: 2000
+        severity:
+          $ref: '#/components/schemas/SignalSeverity'
+        source:
+          type: string
+          maxLength: 200
+          nullable: true
+
+    Option:
+      type: object
+      required: [text, isSelected]
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        text:
+          type: string
+          maxLength: 2000
+        isSelected:
+          type: boolean
+          description: Exactly one option must be selected before commit.
+
+    CreateDecisionDraftRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        title:
+          type: string
+          maxLength: 120
+          nullable: true
+
+    UpdateDecisionDraftRequest:
+      type: object
+      additionalProperties: false
+      description: |
+        Partial update payload for draft edits.
+        Fields omitted are left unchanged.
+
+        Note:
+        - `signals` and `options` are full-replacement arrays when present.
+      properties:
+        title:
+          type: string
+          maxLength: 120
+          nullable: true
+        contextSummary:
+          type: string
+          maxLength: 5000
+          nullable: true
+        signals:
+          type: array
+          items:
+            $ref: '#/components/schemas/Signal'
+        options:
+          type: array
+          items:
+            $ref: '#/components/schemas/Option'
+        reasoning:
+          type: string
+          maxLength: 8000
+          nullable: true
+        riskLevel:
+          $ref: '#/components/schemas/RiskLevel'
+          nullable: true
+        confidenceScore:
+          $ref: '#/components/schemas/ConfidenceScore'
+          nullable: true
+
+    CommitDecisionRequest:
+      type: object
+      required: [confirmationStatements]
+      properties:
+        confirmationStatements:
+          type: object
+          required: [consideredAlternatives, acceptRisk, willReviewOutcome]
+          properties:
+            consideredAlternatives:
+              type: boolean
+            acceptRisk:
+              type: boolean
+            willReviewOutcome:
+              type: boolean
+
+    CommitRecord:
+      type: object
+      description: Commit metadata recorded when decision becomes official.
+      required: [timestamp, userId, confirmationStatements]
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          readOnly: true
+        userId:
+          type: string
+          format: uuid
+          readOnly: true
+        confirmationStatements:
+          type: object
+          required: [consideredAlternatives, acceptRisk, willReviewOutcome]
+          properties:
+            consideredAlternatives:
+              type: boolean
+            acceptRisk:
+              type: boolean
+            willReviewOutcome:
+              type: boolean
+
+    CreateReviewRequest:
+      type: object
+      additionalProperties: false
+      required: [outcomeText, reflectionText, decisionQuality]
+      properties:
+        outcomeText:
+          type: string
+          maxLength: 8000
+        reflectionText:
+          type: string
+          maxLength: 8000
+        decisionQuality:
+          $ref: '#/components/schemas/DecisionQuality'
+        tags:
+          type: array
+          items:
+            type: string
+            maxLength: 50
+          default: []
+
+    Review:
+      type: object
+      required: [id, decisionId, outcomeText, reflectionText, decisionQuality, reviewerId, reviewedAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        decisionId:
+          type: string
+          format: uuid
+          readOnly: true
+        outcomeText:
+          type: string
+          maxLength: 8000
+        reflectionText:
+          type: string
+          maxLength: 8000
+        decisionQuality:
+          $ref: '#/components/schemas/DecisionQuality'
+        tags:
+          type: array
+          items:
+            type: string
+            maxLength: 50
+          default: []
+        reviewerId:
+          type: string
+          format: uuid
+          readOnly: true
+        reviewedAt:
+          type: string
+          format: date-time
+          readOnly: true
+
+    DecisionListItem:
+      type: object
+      required: [id, status, title, contextSummary, riskLevel, confidenceScore, createdAt, createdBy]
+      properties:
+        id:
+          type: string
+          format: uuid
+        status:
+          $ref: '#/components/schemas/DecisionStatus'
+        title:
+          type: string
+          nullable: true
+        contextSummary:
+          type: string
+          nullable: true
+        selectedOptionText:
+          type: string
+          nullable: true
+          description: Convenience field for list rendering.
+        riskLevel:
+          $ref: '#/components/schemas/RiskLevel'
+          nullable: true
+        confidenceScore:
+          $ref: '#/components/schemas/ConfidenceScore'
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        createdBy:
+          type: string
+          format: uuid
+        committedAt:
+          type: string
+          format: date-time
+          nullable: true
+        hasReviews:
+          type: boolean
+          default: false
+
+    DecisionListResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/DecisionListItem'
+        nextPageToken:
+          type: string
+          nullable: true
+
+    ReviewListResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Review'
+
+    ErrorResponse:
+      type: object
+      required: [errorCode, message]
+      properties:
+        errorCode:
+          type: string
+          description: Stable machine-readable error code.
+        message:
+          type: string
+        details:
+          type: object
+          additionalProperties: true
+
+    InvalidStateErrorDetails:
+      type: object
+      description: |
+        Standardized details for INVALID_STATE_TRANSITION errors.
+        Frontend can use these fields to render helpful messages and guidance.
+      required: [currentStatus, allowedStatuses, suggestedAction]
+      properties:
+        currentStatus:
+          $ref: '#/components/schemas/DecisionStatus'
+        allowedStatuses:
+          type: array
+          items:
+            $ref: '#/components/schemas/DecisionStatus'
+        suggestedAction:
+          type: string
+          maxLength: 500
+
+    InvalidStateErrorResponse:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+        - type: object
+          required: [details]
+          properties:
+            details:
+              $ref: '#/components/schemas/InvalidStateErrorDetails'
+
+    ValidationErrorResponse:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+        - type: object
+          required: [fieldErrors]
+          properties:
+            fieldErrors:
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  type: string
+              description: |
+                Field-level validation errors for UI mapping.
+
+                Standard keys:
+                - title
+                - contextSummary
+                - signals
+                - options
+                - selectedOption
+                - reasoning
+                - riskLevel
+                - confidenceScore
+                - confirmationStatements


### PR DESCRIPTION
## What

This PR introduces a complete OpenAPI 3.0.3 specification for the Decision Module, defining the backend–frontend contract for all decision-related flows.

The spec covers the full Decision lifecycle, including:
- Draft creation and iterative updates
- Explicit commit action with validation and immutability guarantees
- High-risk commit handling with pending approval (202 Accepted)
- Read-only retrieval of committed decisions
- Append-only post-execution reviews
- Archival as a terminal lifecycle action

## Why

The Decision Module relies on a strict state machine (Draft → Committed → Reviewed → Archived) and clear separation between editable and immutable states.

Defining the OpenAPI contract upfront ensures:
- Frontend can implement flows without backend clarification
- Invalid state transitions are guarded and explicit
- Validation and error scenarios are predictable and testable
- Permissions and allowed actions are unambiguous at the API boundary

## Key Design Decisions

- Clear separation between draft (editable) and committed (read-only) endpoints
- Commit modeled as an explicit action, not a generic update
- High-risk decisions enter an `AWAITING_APPROVAL` state and return 202, rather than failing with an error
- Validation errors expose stable, field-level keys for UI mapping
- Invalid state transitions return structured details (current status, allowed states, suggested action)
- Server-computed `permissions` are returned to support frontend action gating

## Scope

This PR defines API contracts only.
No backend implementation or UI changes are included.
