### PR TITLE
SMP448-Task Page -- UI Redesign and Bug Fix

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -24,6 +24,12 @@ export default function DashboardPage() {
     const parsed = Number(value);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
   }, [searchParams]);
+  const taskId = useMemo(() => {
+    const value = searchParams.get('task_id');
+    if (!value) return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  }, [searchParams]);
 
   const fetchDashboardData = useCallback(async () => {
     try {
@@ -116,6 +122,22 @@ export default function DashboardPage() {
               <p className="text-sm text-gray-600 mt-1">Dashboard</p>
             </div>
             <div className="flex items-center gap-3">
+              {taskId && (
+                <Link
+                  href={`/tasks/${taskId}`}
+                  className="px-4 py-2 text-sm bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+                >
+                  Go back to task
+                </Link>
+              )}
+              {projectId && (
+                <Link
+                  href={`/tasks?project_id=${projectId}`}
+                  className="px-4 py-2 text-sm bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+                >
+                  Back to project tasks
+                </Link>
+              )}
               <Link
                 href="/projects"
                 className="px-4 py-2 text-sm bg-white border border-gray-300 rounded-md hover:bg-gray-50"

--- a/frontend/src/app/tasks/[taskId]/page.tsx
+++ b/frontend/src/app/tasks/[taskId]/page.tsx
@@ -855,6 +855,7 @@ export default function TaskPage() {
                 <ProjectSummaryPanel
                   projectId={task.project?.id ?? task.project_id}
                   projectName={task.project?.name}
+                  taskId={task.id}
                 />
                 
                 {/* Linked Object Details */}

--- a/frontend/src/app/timeline/page.tsx
+++ b/frontend/src/app/timeline/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import Layout from '@/components/layout/Layout';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
@@ -21,25 +21,53 @@ import { RetrospectiveAPI } from '@/lib/api/retrospectiveApi';
 import { ReportAPI } from '@/lib/api/reportApi';
 import useAuth from '@/hooks/useAuth';
 import toast from 'react-hot-toast';
+import { ProjectAPI } from '@/lib/api/projectApi';
+import { useProjectStore } from '@/lib/projectStore';
 
 function TimelinePageContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const projectIdParam = searchParams.get('project_id');
-  const projectId = projectIdParam ? Number(projectIdParam) : null;
+  const { activeProject } = useProjectStore();
+  const projectId = projectIdParam
+    ? Number(projectIdParam)
+    : activeProject?.id ?? null;
+
+  useEffect(() => {
+    if (projectIdParam || !activeProject?.id) return;
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('project_id', String(activeProject.id));
+    router.replace(`/timeline?${params.toString()}`);
+  }, [projectIdParam, activeProject?.id, router, searchParams]);
 
   const { user } = useAuth();
   const { tasks, loading, error, fetchTasks, reloadTasks, createTask, updateTask } = useTaskData();
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null);
-  
+  const [projectOptions, setProjectOptions] = useState<any[]>([]);
+  const [projectOptionsLoading, setProjectOptionsLoading] = useState(false);
+  const [projectOptionsError, setProjectOptionsError] = useState<string | null>(null);
+  const [projectPickerOpen, setProjectPickerOpen] = useState(false);
+  const [projectSearchQuery, setProjectSearchQuery] = useState('');
+  const [recentProjectIds, setRecentProjectIds] = useState<number[]>([]);
+
+  const getDefaultTaskDates = () => {
+    const today = new Date();
+    const tomorrow = new Date(today);
+    tomorrow.setDate(today.getDate() + 1);
+    return {
+      start_date: today.toISOString().slice(0, 10),
+      due_date: tomorrow.toISOString().slice(0, 10),
+    };
+  };
+
   const [taskData, setTaskData] = useState<Partial<CreateTaskData>>({
     project_id: null,
     type: '',
     summary: '',
     description: '',
     current_approver_id: null,
-    due_date: '',
+    ...getDefaultTaskDates(),
   });
   const [taskType, setTaskType] = useState('');
   const [contentType, setContentType] = useState('');
@@ -66,21 +94,69 @@ function TimelinePageContent() {
     slice_config: { csv_file_path: '' },
   });
 
+  const loadProjectOptions = useCallback(async () => {
+    try {
+      setProjectOptionsLoading(true);
+      setProjectOptionsError(null);
+      const projects = await ProjectAPI.getProjects();
+      setProjectOptions(projects || []);
+    } catch (error) {
+      console.error('Failed to load projects:', error);
+      setProjectOptionsError('Failed to load projects.');
+    } finally {
+      setProjectOptionsLoading(false);
+    }
+  }, []);
+
+  const openProjectPicker = useCallback(async () => {
+    setProjectPickerOpen(true);
+    setProjectSearchQuery('');
+    if (projectOptions.length === 0) {
+      await loadProjectOptions();
+    }
+  }, [loadProjectOptions, projectOptions.length]);
+
   useEffect(() => {
-    const load = async () => {
-      if (projectId) {
-        await fetchTasks({ project_id: projectId, include_subtasks: true });
-      } else {
-        await fetchTasks({ all_projects: true, include_subtasks: true });
+    if (projectOptions.length === 0 && !projectOptionsLoading) {
+      loadProjectOptions();
+    }
+  }, [projectOptions.length, projectOptionsLoading, loadProjectOptions]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = window.localStorage.getItem('recentProjectIds');
+    if (!stored) return;
+    try {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        setRecentProjectIds(parsed.filter((id) => Number.isFinite(id)));
       }
+    } catch (error) {
+      console.warn('Failed to parse recent projects:', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!projectId) return;
+    const load = async () => {
+      await fetchTasks({ project_id: projectId, include_subtasks: true });
     };
     load();
   }, [projectId, fetchTasks]);
 
+  useEffect(() => {
+    if (!projectId) return;
+    setTaskData((prev) => ({
+      ...prev,
+      project_id: prev.project_id || projectId,
+    }));
+  }, [projectId]);
+
   const visibleTasks = useMemo(() => {
+    if (!projectId) return [];
     if (!Array.isArray(tasks)) return [];
     return tasks;
-  }, [tasks]);
+  }, [projectId, tasks]);
 
   const hasTasks = visibleTasks.length > 0;
 
@@ -288,14 +364,15 @@ function TimelinePageContent() {
 
   // Generic function to reset form data
   const resetFormData = () => {
+    const defaultDates = getDefaultTaskDates();
     setTaskData({
       project_id: null,
       type: '',
       summary: '',
       description: '',
       current_approver_id: null,
-      start_date: '',
-      due_date: '',
+      start_date: defaultDates.start_date,
+      due_date: defaultDates.due_date,
     });
     setBudgetData({
       amount: '',
@@ -342,6 +419,52 @@ function TimelinePageContent() {
     }));
     setCreateModalOpen(true);
   };
+
+  const handlePickProject = (selectedProjectId: number | null) => {
+    if (!selectedProjectId) return;
+    setRecentProjectIds((prev) => {
+      const next = [
+        selectedProjectId,
+        ...prev.filter((id) => id !== selectedProjectId),
+      ].slice(0, 5);
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem('recentProjectIds', JSON.stringify(next));
+      }
+      return next;
+    });
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('project_id', String(selectedProjectId));
+    router.push(`/timeline?${params.toString()}`);
+  };
+
+  const filteredProjects = useMemo(() => {
+    if (!projectSearchQuery.trim()) return projectOptions;
+    const query = projectSearchQuery.trim().toLowerCase();
+    return projectOptions.filter((project) => {
+      const name = (project.name || '').toLowerCase();
+      const idText = project.id ? String(project.id) : '';
+      return name.includes(query) || idText.includes(query);
+    });
+  }, [projectOptions, projectSearchQuery]);
+
+  const recentProjects = useMemo(() => {
+    if (!recentProjectIds.length) return [];
+    const byId = new Map(
+      filteredProjects
+        .filter((project) => project?.id)
+        .map((project) => [project.id, project])
+    );
+    return recentProjectIds
+      .map((id) => byId.get(id))
+      .filter(Boolean);
+  }, [filteredProjects, recentProjectIds]);
+
+  const otherProjects = useMemo(() => {
+    const recentSet = new Set(recentProjectIds);
+    return filteredProjects.filter(
+      (project) => !recentSet.has(project?.id)
+    );
+  }, [filteredProjects, recentProjectIds]);
 
   const handleTaskDataChange = (data: Partial<CreateTaskData>) => {
     setTaskData((prev) => ({ ...prev, ...data }));
@@ -557,7 +680,9 @@ function TimelinePageContent() {
           <div className="flex items-center gap-4 mb-2">
             <h1 className="text-2xl font-semibold text-gray-900">Timeline</h1>
             <button
-              onClick={() => router.push('/tasks')}
+              onClick={() =>
+                router.push(projectId ? `/tasks?project_id=${projectId}` : '/tasks')
+              }
               className="px-3 py-1.5 rounded text-sm font-medium text-indigo-600 bg-indigo-50 hover:bg-indigo-100 border border-indigo-200 hover:border-indigo-300 transition-colors"
             >
               Return to Tasks
@@ -566,20 +691,78 @@ function TimelinePageContent() {
           <p className="text-sm text-gray-500">Long stories grouped by project.</p>
         </div>
 
-        {loading && (
+        <div className="mb-6 rounded-xl border border-gray-200 bg-gradient-to-r from-white via-white to-indigo-50/60 p-6 shadow-sm">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <div className="text-sm font-semibold text-gray-900">
+                {projectId ? 'Project selected' : "You haven't selected a project yet."}
+              </div>
+              <p className="mt-1 text-sm text-gray-600">
+                {projectId
+                  ? 'Switch projects to see a different timeline.'
+                  : 'Choose a project to view its timeline.'}
+              </p>
+            </div>
+            <div className="w-full sm:max-w-xs">
+              <label
+                htmlFor="timeline-project-selector"
+                className="block text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2"
+              >
+                Select project
+              </label>
+              <button
+                type="button"
+                onClick={openProjectPicker}
+                id="timeline-project-selector"
+                className={`flex w-full items-center justify-between rounded-lg border bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition ${
+                  projectId
+                    ? 'border-indigo-400 ring-2 ring-indigo-100'
+                    : 'border-gray-300 hover:border-gray-400'
+                }`}
+              >
+                <span className="truncate">
+                  {projectId
+                    ? `#${projectId} ${
+                        projectOptions.find((project) => project.id === projectId)
+                          ?.name || 'Unknown'
+                      }`
+                    : 'Select project'}
+                </span>
+                <svg
+                  className="h-4 w-4 text-gray-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 9l-7 7-7-7"
+                  />
+                </svg>
+              </button>
+              {projectOptionsError && (
+                <p className="mt-2 text-sm text-red-600">{projectOptionsError}</p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {projectId && loading && (
           <div className="text-center py-8">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600 mx-auto"></div>
             <p className="mt-2 text-gray-600">Loading tasks...</p>
           </div>
         )}
 
-        {error && !hasTasks && (
+        {projectId && error && !hasTasks && (
           <div className="text-center py-8">
             <p className="text-red-600">Error loading tasks.</p>
           </div>
         )}
 
-        {!loading && (hasTasks || !error) && (
+        {projectId && !loading && (hasTasks || !error) && (
           <TimelineView
             tasks={visibleTasks}
             reloadTasks={reloadTasks}
@@ -587,6 +770,172 @@ function TimelinePageContent() {
           />
         )}
       </div>
+
+      {/* Project Picker Modal */}
+      <Modal isOpen={projectPickerOpen} onClose={() => setProjectPickerOpen(false)}>
+        <div className="flex max-h-[80vh] w-full max-w-2xl flex-col overflow-hidden rounded-3xl border border-slate-100 bg-white shadow-2xl">
+          <div className="relative border-b border-slate-100 px-6 py-5">
+            <div className="absolute inset-0 bg-gradient-to-r from-indigo-50 via-white to-sky-50" />
+            <div className="absolute -left-10 -top-14 h-32 w-32 rounded-full bg-indigo-100/70 blur-2xl" />
+            <div className="relative flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-indigo-100 bg-white text-indigo-600 shadow-sm">
+                  <svg
+                    className="h-5 w-5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M4 6h16M4 12h16M4 18h7"
+                    />
+                  </svg>
+                </div>
+                <div>
+                  <h2 className="text-lg font-semibold text-gray-900">Select project</h2>
+                  <p className="text-sm text-gray-500">
+                    Choose a project to load its timeline.
+                  </p>
+                </div>
+              </div>
+              <button
+                onClick={() => setProjectPickerOpen(false)}
+                className="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-600 transition hover:border-gray-300 hover:bg-gray-50"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+
+          <div className="border-b border-slate-100 px-6 py-4">
+            <div className="relative">
+              <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-indigo-300">
+                <svg
+                  className="h-4 w-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                  />
+                </svg>
+              </div>
+              <input
+                type="text"
+                value={projectSearchQuery}
+                onChange={(event) => setProjectSearchQuery(event.target.value)}
+                placeholder="Search by project name or ID..."
+                className="w-full rounded-xl border border-slate-200 bg-slate-50 py-2.5 pl-9 pr-3 text-sm text-gray-900 transition focus:border-indigo-400 focus:bg-white focus:ring-2 focus:ring-indigo-100"
+              />
+            </div>
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-6 py-4">
+            {projectOptionsLoading && (
+              <div className="py-8 text-center text-sm text-gray-500">
+                Loading projects...
+              </div>
+            )}
+            {!projectOptionsLoading && projectOptionsError && (
+              <div className="py-8 text-center text-sm text-red-600">
+                {projectOptionsError}
+              </div>
+            )}
+            {!projectOptionsLoading &&
+              !projectOptionsError &&
+              filteredProjects.length === 0 && (
+                <div className="py-8 text-center text-sm text-gray-500">
+                  No projects found.
+                </div>
+              )}
+            {!projectOptionsLoading &&
+              !projectOptionsError &&
+              recentProjects.length > 0 && (
+                <div className="mb-4">
+                  <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400">
+                    Recent
+                  </div>
+                  {recentProjects.map((project) => (
+                    <button
+                      key={`recent-${project.id}`}
+                      onClick={() => {
+                        handlePickProject(project.id);
+                        setProjectPickerOpen(false);
+                      }}
+                      className={`group mb-3 w-full rounded-2xl border px-4 py-3 text-left transition ${
+                        project.id === projectId
+                          ? 'border-indigo-200 bg-gradient-to-r from-indigo-50 to-white'
+                          : 'border-slate-200 hover:border-indigo-200 hover:bg-indigo-50/50'
+                      }`}
+                    >
+                      <div className="flex items-center justify-between">
+                        <div className="text-sm font-semibold text-gray-900">
+                          #{project.id} {project.name || 'Untitled Project'}
+                        </div>
+                        {project.id === projectId && (
+                          <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-700">
+                            Current
+                          </span>
+                        )}
+                      </div>
+                      <div className="mt-1 text-xs text-gray-500">
+                        {project.description || 'No description'}
+                      </div>
+                      <div className="mt-3 h-[1px] w-full bg-gradient-to-r from-transparent via-indigo-100 to-transparent opacity-0 transition group-hover:opacity-100" />
+                    </button>
+                  ))}
+                </div>
+              )}
+            {!projectOptionsLoading &&
+              !projectOptionsError &&
+              otherProjects.length > 0 && (
+                <div>
+                  {recentProjects.length > 0 && (
+                    <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400">
+                      All projects
+                    </div>
+                  )}
+                  {otherProjects.map((project) => (
+                    <button
+                      key={project.id}
+                      onClick={() => {
+                        handlePickProject(project.id);
+                        setProjectPickerOpen(false);
+                      }}
+                      className={`group mb-3 w-full rounded-2xl border px-4 py-3 text-left transition ${
+                        project.id === projectId
+                          ? 'border-indigo-200 bg-gradient-to-r from-indigo-50 to-white'
+                          : 'border-slate-200 hover:border-indigo-200 hover:bg-indigo-50/50'
+                      }`}
+                    >
+                      <div className="flex items-center justify-between">
+                        <div className="text-sm font-semibold text-gray-900">
+                          #{project.id} {project.name || 'Untitled Project'}
+                        </div>
+                        {project.id === projectId && (
+                          <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-700">
+                            Current
+                          </span>
+                        )}
+                      </div>
+                      <div className="mt-1 text-xs text-gray-500">
+                        {project.description || 'No description'}
+                      </div>
+                      <div className="mt-3 h-[1px] w-full bg-gradient-to-r from-transparent via-indigo-100 to-transparent opacity-0 transition group-hover:opacity-100" />
+                    </button>
+                  ))}
+                </div>
+              )}
+          </div>
+        </div>
+      </Modal>
 
       {/* Create Task Modal */}
       <Modal isOpen={createModalOpen} onClose={() => setCreateModalOpen(false)}>
@@ -667,4 +1016,3 @@ export default function TimelinePage() {
     </ProtectedRoute>
   );
 }
-

--- a/frontend/src/components/dashboard/ProjectSummaryPanel.tsx
+++ b/frontend/src/components/dashboard/ProjectSummaryPanel.tsx
@@ -8,6 +8,7 @@ import type { ActivityEvent, DashboardSummary } from "@/types/dashboard";
 type ProjectSummaryPanelProps = {
   projectId?: number | null;
   projectName?: string | null;
+  taskId?: number | null;
   showViewAllLink?: boolean;
 };
 
@@ -25,9 +26,37 @@ const formatActivityTitle = (activity: ActivityEvent) => {
   return `${label}: ${summary}`;
 };
 
+const priorityStyles: Record<string, string> = {
+  HIGHEST: "bg-rose-100 text-rose-700 border-rose-200",
+  HIGH: "bg-orange-100 text-orange-700 border-orange-200",
+  MEDIUM: "bg-amber-100 text-amber-700 border-amber-200",
+  LOW: "bg-emerald-100 text-emerald-700 border-emerald-200",
+  LOWEST: "bg-slate-100 text-slate-600 border-slate-200",
+};
+
+const activityStyles: Record<ActivityEvent["event_type"], string> = {
+  task_created: "bg-indigo-50/40 text-slate-700 border-indigo-100/70",
+  approved: "bg-emerald-50/40 text-slate-700 border-emerald-100/70",
+  rejected: "bg-rose-50/40 text-slate-700 border-rose-100/70",
+  commented: "bg-sky-50/40 text-slate-700 border-sky-100/70",
+  task_updated: "bg-amber-50/40 text-slate-700 border-amber-100/70",
+};
+
+const tintByIndex = [
+  "bg-indigo-50 text-indigo-700 border-indigo-200",
+  "bg-sky-50 text-sky-700 border-sky-200",
+  "bg-emerald-50 text-emerald-700 border-emerald-200",
+  "bg-amber-50 text-amber-700 border-amber-200",
+  "bg-rose-50 text-rose-700 border-rose-200",
+  "bg-violet-50 text-violet-700 border-violet-200",
+];
+
+const pickTint = (index: number) => tintByIndex[index % tintByIndex.length];
+
 export default function ProjectSummaryPanel({
   projectId,
   projectName,
+  taskId,
   showViewAllLink = true,
 }: ProjectSummaryPanelProps) {
   const [summary, setSummary] = useState<DashboardSummary | null>(null);
@@ -39,6 +68,11 @@ export default function ProjectSummaryPanel({
     const parsed = Number(projectId);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
   }, [projectId]);
+  const taskIdValue = useMemo(() => {
+    if (!taskId) return null;
+    const parsed = Number(taskId);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  }, [taskId]);
 
   const fetchSummary = useCallback(async () => {
     if (!projectIdValue) {
@@ -96,20 +130,36 @@ export default function ProjectSummaryPanel({
   }, [summary]);
 
   return (
-    <section className="bg-white border border-gray-200 rounded-lg p-4 space-y-4">
-      <div className="flex items-start justify-between gap-4">
+    <section className="relative overflow-hidden rounded-[22px] border border-slate-200 bg-white p-6 shadow-[0_18px_50px_rgba(15,23,42,0.08)]">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -right-20 -top-24 h-44 w-44 rounded-full bg-indigo-100/70 blur-[60px]" />
+        <div className="absolute -left-12 -bottom-20 h-36 w-36 rounded-full bg-sky-100/70 blur-[60px]" />
+        <div className="absolute right-24 top-8 h-12 w-12 rounded-full bg-amber-100/80 blur-xl" />
+        <div className="absolute left-10 top-16 h-6 w-6 rounded-full bg-emerald-100/90 blur-lg" />
+        <div className="absolute left-1/2 bottom-10 h-8 w-8 rounded-full bg-rose-100/80 blur-lg" />
+      </div>
+      <div className="relative flex items-start justify-between gap-4">
         <div>
-          <h3 className="text-sm font-semibold text-gray-900">
-            Project Summary
+          <div className="inline-flex items-center gap-2 rounded-full border border-indigo-100 bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700 shadow-sm">
+            Summary
+            {projectName && <span className="text-indigo-500">•</span>}
+            {projectName && <span>{projectName}</span>}
+          </div>
+          <h3 className="mt-3 text-base font-semibold text-slate-900">
+            Project snapshot
           </h3>
-          {projectName && (
-            <p className="text-xs text-gray-500 mt-1">{projectName}</p>
-          )}
+          <p className="mt-1 text-xs text-slate-500">
+            A quick glance at workload, priority, and activity.
+          </p>
         </div>
         {showViewAllLink && projectIdValue && (
           <Link
-            href={`/dashboard?project_id=${projectIdValue}`}
-            className="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline"
+            href={
+              taskIdValue
+                ? `/dashboard?project_id=${projectIdValue}&task_id=${taskIdValue}`
+                : `/dashboard?project_id=${projectIdValue}`
+            }
+            className="text-xs font-semibold text-indigo-600 hover:text-indigo-700"
           >
             Full summary
           </Link>
@@ -117,22 +167,24 @@ export default function ProjectSummaryPanel({
       </div>
 
       {!projectIdValue && (
-        <p className="text-xs text-gray-500">
+        <p className="relative text-xs text-slate-500">
           Select a task with a project to see summary details.
         </p>
       )}
 
       {projectIdValue && loading && (
-        <p className="text-xs text-gray-500">Loading project summary...</p>
+        <p className="relative text-xs text-slate-500">
+          Loading project summary...
+        </p>
       )}
 
       {projectIdValue && !loading && error && (
-        <div className="space-y-2">
+        <div className="relative space-y-2 rounded-lg border border-red-100 bg-red-50 px-3 py-2">
           <p className="text-xs text-red-600">{error}</p>
           <button
             type="button"
             onClick={fetchSummary}
-            className="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline"
+            className="text-xs font-semibold text-red-700 hover:text-red-800"
           >
             Retry
           </button>
@@ -140,95 +192,125 @@ export default function ProjectSummaryPanel({
       )}
 
       {projectIdValue && !loading && !error && summary && (
-        <div className="space-y-4">
-          <div className="grid grid-cols-2 gap-2">
-            {metrics.map((metric) => (
-              <div
-                key={metric.label}
-                className="border border-gray-200 rounded-md px-2 py-2"
-              >
-                <p className="text-[11px] text-gray-500">{metric.label}</p>
-                <p className="text-base font-semibold text-gray-900">
-                  {metric.value}
-                </p>
+        <div className="relative space-y-5">
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+            {metrics.map((metric, index) => {
+              const accents = [
+                "from-indigo-50 to-white text-indigo-700 border-indigo-100",
+                "from-emerald-50 to-white text-emerald-700 border-emerald-100",
+                "from-amber-50 to-white text-amber-700 border-amber-100",
+                "from-rose-50 to-white text-rose-700 border-rose-100",
+              ];
+              const accent = accents[index % accents.length];
+              return (
+                <div
+                  key={metric.label}
+                  className={`rounded-xl border bg-gradient-to-br px-3 py-3 shadow-sm ${accent}`}
+                >
+                  <p className="text-[11px] text-slate-600">{metric.label}</p>
+                  <p className="mt-1 text-lg font-semibold text-slate-900">
+                    {metric.value}
+                  </p>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div className="rounded-xl border border-slate-200 bg-white/90 p-4 shadow-sm">
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                Status
+              </p>
+              <div className="mt-3 space-y-2">
+                {summary.status_overview.breakdown.map((item, index) => (
+                  <div
+                    key={item.status}
+                    className="flex items-center justify-between text-sm text-slate-700"
+                  >
+                    <span>{item.display_name}</span>
+                    <span
+                      className={`rounded-full border px-2 py-0.5 text-xs font-semibold ${pickTint(
+                        index
+                      )}`}
+                    >
+                      {item.count}
+                    </span>
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
+            </div>
 
-          <div>
-            <p className="text-[11px] font-semibold text-gray-600 uppercase tracking-wide">
-              Status
-            </p>
-            <div className="mt-2 space-y-1">
-              {summary.status_overview.breakdown.map((item) => (
-                <div
-                  key={item.status}
-                  className="flex items-center justify-between text-sm text-gray-700"
-                >
-                  <span>{item.display_name}</span>
-                  <span className="font-medium text-gray-900">
-                    {item.count}
-                  </span>
-                </div>
-              ))}
+            <div className="rounded-xl border border-slate-200 bg-white/90 p-4 shadow-sm">
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                Priority
+              </p>
+              <div className="mt-3 space-y-2">
+                {summary.priority_breakdown.map((item) => (
+                  <div
+                    key={item.priority}
+                    className="flex items-center justify-between text-sm text-slate-700"
+                  >
+                    <span>{item.priority}</span>
+                    <span
+                      className={`rounded-full border px-2 py-0.5 text-xs font-semibold ${
+                        priorityStyles[item.priority] ||
+                        "bg-slate-100 text-slate-600 border-slate-200"
+                      }`}
+                    >
+                      {item.count}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-slate-200 bg-white/90 p-4 shadow-sm">
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                Types of work
+              </p>
+              <div className="mt-3 space-y-2">
+                {summary.types_of_work.map((item, index) => (
+                  <div
+                    key={item.type}
+                    className="flex items-center justify-between text-sm text-slate-700"
+                  >
+                    <span>{item.display_name}</span>
+                    <span
+                      className={`rounded-full border px-2 py-0.5 text-xs font-semibold ${pickTint(
+                        index + 1
+                      )}`}
+                    >
+                      {item.count}
+                    </span>
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
 
-          <div>
-            <p className="text-[11px] font-semibold text-gray-600 uppercase tracking-wide">
-              Priority
-            </p>
-            <div className="mt-2 space-y-1">
-              {summary.priority_breakdown.map((item) => (
-                <div
-                  key={item.priority}
-                  className="flex items-center justify-between text-sm text-gray-700"
-                >
-                  <span>{item.priority}</span>
-                  <span className="font-medium text-gray-900">
-                    {item.count}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div>
-            <p className="text-[11px] font-semibold text-gray-600 uppercase tracking-wide">
-              Types of work
-            </p>
-            <div className="mt-2 space-y-1">
-              {summary.types_of_work.map((item) => (
-                <div
-                  key={item.type}
-                  className="flex items-center justify-between text-sm text-gray-700"
-                >
-                  <span>{item.display_name}</span>
-                  <span className="font-medium text-gray-900">
-                    {item.count}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div>
-            <p className="text-[11px] font-semibold text-gray-600 uppercase tracking-wide">
+          <div className="rounded-xl border border-slate-200 bg-white/90 p-4 shadow-sm">
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
               Recent activity
             </p>
-            <div className="mt-2 space-y-2">
+            <div className="mt-3 space-y-3">
               {summary.recent_activity.slice(0, 5).map((activity) => (
-                <div key={activity.id} className="text-xs text-gray-700">
-                  <p className="font-medium text-gray-900">
+                <div
+                  key={activity.id}
+                  className={`rounded-xl border px-4 py-3 text-xs text-slate-700 shadow-sm transition ${
+                    activityStyles[activity.event_type] ||
+                    "bg-white/90 border-slate-200"
+                  }`}
+                >
+                  <p className="font-semibold text-slate-900">
                     {formatActivityTitle(activity)}
                   </p>
-                  <p className="text-[11px] text-gray-500">
+                  <p className="text-[11px] text-slate-500">
                     {activity.human_readable}
                   </p>
                 </div>
               ))}
               {summary.recent_activity.length === 0 && (
-                <p className="text-xs text-gray-500">No recent activity.</p>
+                <p className="text-xs text-slate-500">No recent activity.</p>
               )}
             </div>
           </div>


### PR DESCRIPTION
Tasks entry now requires project selection first: opening /tasks without a project shows a full-page project picker; tasks workspace appears only after a project is selected.

Project picker UI updated to a Jira-like list: header, search bar, table-style rows with column headers; recent vs all sections.

Project pinning added: pinned section at top, pin/unpin per row, pinned projects are highlighted and stored locally.

Switch project control simplified: Summary area uses a single “Switch project” button that returns to project selection.

Tasks header now shows {Project Name} - Tasks instead of just “Tasks”.

Summary/Tasks/Board tabs are in-page toggles (no redirect to dashboard).

Board is embedded inside the Tasks page, showing dashboard-style charts and activity.

Timeline view is embedded inside the Tasks page alongside List and Broad view (no route change).

Create Task form locks the project to the current one (no project selector).

Summary panel styling improved: bubble background, card-based layout, colored chips for Status/Priority/Types.

Recent activity styling refined: single-row items with softer colors and card borders.

Lead column on project picker uses project owner
