### PR TITLE
MED-80 Add mailchimp drafts stories and presentation components

### DIFF
--- a/frontend/src/components/mailchimp/DraftActions.tsx
+++ b/frontend/src/components/mailchimp/DraftActions.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import React from "react";
+
+// Action buttons kept decoupled from any draft card layout.
+export type DraftActionsProps = {
+  onEdit?: () => void;
+  onSend?: () => void;
+  onDelete?: () => void;
+  editDisabled?: boolean;
+  sendDisabled?: boolean;
+  deleteDisabled?: boolean;
+  deleteLoading?: boolean;
+  size?: "sm" | "md";
+};
+
+export function DraftActions({
+  onEdit,
+  onSend,
+  onDelete,
+  editDisabled = false,
+  sendDisabled = false,
+  deleteDisabled = false,
+  deleteLoading = false,
+  size = "md",
+}: DraftActionsProps) {
+  // Size variants are shared across button group.
+  const base =
+    size === "sm" ? "px-2.5 py-1 text-xs" : "px-3 py-1.5 text-sm";
+  const buttonClass = `rounded-md font-medium ${base}`;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <button
+        type="button"
+        className={`${buttonClass} border border-gray-300 text-gray-700 hover:bg-gray-50`}
+        onClick={onEdit}
+        disabled={editDisabled}
+      >
+        Edit
+      </button>
+      <button
+        type="button"
+        className={`${buttonClass} border border-red-200 text-red-600 hover:bg-red-50 ${
+          deleteLoading || deleteDisabled ? "opacity-70 cursor-not-allowed" : ""
+        }`}
+        onClick={onDelete}
+        disabled={deleteLoading || deleteDisabled}
+        aria-busy={deleteLoading}
+      >
+        {deleteLoading ? "Deleting..." : "Delete"}
+      </button>
+      <button
+        type="button"
+        className={`${buttonClass} bg-blue-600 text-white hover:bg-blue-700 ${
+          sendDisabled ? "opacity-60 cursor-not-allowed" : ""
+        }`}
+        onClick={onSend}
+        disabled={sendDisabled}
+      >
+        Send
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/mailchimp/DraftCard.tsx
+++ b/frontend/src/components/mailchimp/DraftCard.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import React from "react";
+
+// Presentation-only card for draft metadata.
+export type DraftCardStatus = "draft" | "scheduled" | "sent" | "error" | string;
+
+export type DraftCardProps = {
+  subject: string;
+  previewText?: string;
+  fromName?: string;
+  status?: DraftCardStatus;
+  statusLabel?: string;
+  sendTime?: string;
+  recipients?: number;
+  type?: string;
+  helperText?: string;
+  readOnly?: boolean;
+};
+
+// Shared badge styles for common states.
+const statusStyles: Record<string, string> = {
+  draft: "bg-gray-100 text-gray-600",
+  scheduled: "bg-blue-100 text-blue-700",
+  sent: "bg-green-100 text-green-700",
+  error: "bg-red-100 text-red-700",
+};
+
+// Default labels when no custom statusLabel is provided.
+const statusLabels: Record<string, string> = {
+  draft: "Draft",
+  scheduled: "Scheduled",
+  sent: "Sent",
+  error: "Error",
+};
+
+// Keep date formatting consistent with the list view.
+const formatDate = (dateString?: string) => {
+  if (!dateString) return "No send date";
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) return "No send date";
+  return date.toLocaleDateString();
+};
+
+export function DraftCard({
+  subject,
+  previewText,
+  fromName,
+  status = "draft",
+  statusLabel,
+  sendTime,
+  recipients,
+  type,
+  helperText,
+  readOnly = false,
+}: DraftCardProps) {
+  const normalizedStatus = status.toLowerCase();
+  const badgeClass =
+    statusStyles[normalizedStatus] ?? "bg-gray-100 text-gray-600";
+  const badgeLabel =
+    statusLabel ?? statusLabels[normalizedStatus] ?? status.toString();
+
+  return (
+    <div
+      className={`rounded-lg border bg-white p-4 shadow-sm ${
+        readOnly ? "opacity-60" : ""
+      }`}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h3 className="min-w-0 flex-1 truncate text-base font-semibold text-blue-700">
+              {subject}
+            </h3>
+            <span className={`px-2 py-1 text-xs rounded-full ${badgeClass}`}>
+              {badgeLabel}
+            </span>
+          </div>
+          {previewText ? (
+            <p className="mt-1 text-sm text-gray-600 line-clamp-2">
+              {previewText}
+            </p>
+          ) : null}
+          <div className="mt-3 flex flex-wrap gap-3 text-xs text-gray-500">
+            <span>From: {fromName || "Unknown sender"}</span>
+            <span>Type: {type || "Regular email"}</span>
+            <span>Recipients: {recipients ?? 0}</span>
+            <span>Send date: {formatDate(sendTime)}</span>
+          </div>
+          {helperText ? (
+            <div className="mt-2 text-xs text-red-600">{helperText}</div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/stories/mailchimp/DraftActions.stories.tsx
+++ b/frontend/src/stories/mailchimp/DraftActions.stories.tsx
@@ -1,0 +1,45 @@
+import React from "react"
+import { DraftActions } from "@/components/mailchimp/DraftActions"
+
+// Storybook coverage for decoupled action buttons.
+const meta = {
+  title: "Mailchimp/DraftActions",
+  parameters: {
+    layout: "padded",
+    chromatic: {
+      disableSnapshot: false,
+      viewports: [360, 768, 1200],
+    },
+    docs: {
+      description: {
+        component: "Action button group for draft operations.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+}
+
+export default meta
+
+export const AllEnabled = {
+  render: () => <DraftActions />,
+}
+
+export const SendDisabled = {
+  render: () => <DraftActions sendDisabled />,
+}
+
+export const DeleteLoading = {
+  render: () => <DraftActions deleteLoading />,
+}
+
+export const KeyboardFocus = {
+  render: () => (
+    <div className="space-y-3">
+      <div className="text-sm text-gray-600">
+        Press Tab to inspect focus-visible styles.
+      </div>
+      <DraftActions />
+    </div>
+  ),
+}

--- a/frontend/src/stories/mailchimp/DraftCard.stories.tsx
+++ b/frontend/src/stories/mailchimp/DraftCard.stories.tsx
@@ -1,0 +1,126 @@
+import React from "react"
+import { DraftCard } from "@/components/mailchimp/DraftCard"
+import { DraftActions } from "@/components/mailchimp/DraftActions"
+
+// Storybook coverage for the presentation-only draft card.
+const meta = {
+  title: "Mailchimp/DraftCard",
+  parameters: {
+    layout: "padded",
+    chromatic: {
+      disableSnapshot: false,
+      viewports: [360, 768, 1200],
+    },
+    docs: {
+      description: {
+        component:
+          "Presentation-only card for draft information. No click handlers.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+}
+
+export default meta
+
+// Shared layout wrapper to keep cards aligned.
+const cardFrameClass = "max-w-3xl"
+
+export const Default = {
+  render: () => (
+    <div className={cardFrameClass}>
+      <DraftCard
+        subject="Welcome to Our Newsletter"
+        previewText="Thanks for subscribing to our newsletter."
+        fromName="Newsletter Team"
+        status="draft"
+        sendTime="2024-01-15T10:00:00Z"
+        recipients={0}
+        type="Regular email"
+      />
+    </div>
+  ),
+}
+
+export const Scheduled = {
+  render: () => (
+    <div className={cardFrameClass}>
+      <DraftCard
+        subject="Product Launch Announcement"
+        previewText="Exciting news about our latest product launch."
+        fromName="Product Team"
+        status="scheduled"
+        sendTime="2024-02-01T08:00:00Z"
+        recipients={1250}
+        type="Campaign"
+      />
+    </div>
+  ),
+}
+
+export const LongText = {
+  render: () => (
+    <div className={cardFrameClass}>
+      <DraftCard
+        subject="This is a very long subject line meant to test truncation and layout behavior when the title exceeds the available space"
+        previewText="This preview text is intentionally verbose to verify how multi-line descriptions behave when the content runs long and should wrap or truncate based on the design."
+        fromName="Marketing Operations"
+        status="draft"
+        sendTime="2024-02-12T11:30:00Z"
+        recipients={340}
+        type="Newsletter"
+      />
+    </div>
+  ),
+}
+
+export const ErrorState = {
+  render: () => (
+    <div className={cardFrameClass}>
+      <DraftCard
+        subject="January Newsletter"
+        previewText="Draft failed to sync with the remote system."
+        fromName="Marketing Team"
+        status="error"
+        helperText="Sync failed. Please retry later."
+        sendTime="2024-01-12T11:30:00Z"
+        recipients={2500}
+        type="Newsletter"
+      />
+    </div>
+  ),
+}
+
+export const ReadOnly = {
+  render: () => (
+    <div className={cardFrameClass}>
+      <DraftCard
+        subject="Read-only Draft"
+        previewText="This draft is locked and cannot be edited."
+        fromName="Ops"
+        status="draft"
+        sendTime="2024-03-10T09:00:00Z"
+        recipients={42}
+        type="System"
+        readOnly
+      />
+    </div>
+  ),
+}
+
+export const CardWithActions = {
+  render: () => (
+    <div className="max-w-3xl space-y-3">
+      <DraftCard
+        subject="Launch Campaign"
+        previewText="Ready to send once approvals are complete."
+        fromName="Marketing Team"
+        status="scheduled"
+        sendTime="2024-04-01T08:00:00Z"
+        recipients={980}
+        type="Campaign"
+      />
+      <DraftActions />
+    </div>
+  ),
+}

--- a/frontend/src/stories/mailchimp/DraftFilters.stories.tsx
+++ b/frontend/src/stories/mailchimp/DraftFilters.stories.tsx
@@ -1,0 +1,187 @@
+import React from "react"
+import { Search } from "lucide-react"
+
+// Storybook coverage for search and filter UI fragments.
+const meta = {
+  title: "Mailchimp/DraftFilters",
+  parameters: {
+    layout: "padded",
+    chromatic: {
+      disableSnapshot: false,
+      viewports: [360, 768, 1200],
+    },
+    docs: {
+      description: {
+        component: "Search bar for email drafts (uses existing page markup).",
+      },
+    },
+  },
+  tags: ["autodocs"],
+}
+
+export default meta
+
+export const SearchEmpty = {
+  render: () => (
+    <div className="relative w-full max-w-xl">
+      <input
+        type="text"
+        defaultValue=""
+        placeholder="Search email drafts"
+        className="w-full border border-gray-300 rounded-md px-8 pr-10 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
+      />
+      <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-black pointer-events-none" />
+    </div>
+  ),
+}
+
+export const SearchWithQuery = {
+  render: () => (
+    <div className="relative w-full max-w-xl">
+      <input
+        type="text"
+        defaultValue="newsletter"
+        placeholder="Search email drafts"
+        className="w-full border border-gray-300 rounded-md px-8 pr-10 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
+      />
+      <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-black pointer-events-none" />
+    </div>
+  ),
+}
+
+export const FiltersRow = {
+  render: () => (
+    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 max-w-5xl">
+      <div className="flex flex-wrap gap-4 text-sm text-gray-600">
+        <div>
+          Type:
+          <select className="text-blue-600 ml-1">
+            <option>All</option>
+            <option>Regular</option>
+            <option>Automated</option>
+            <option>Newsletter</option>
+            <option>Promotional</option>
+            <option>A/B test</option>
+          </select>
+        </div>
+        <div>
+          Status:
+          <select className="text-blue-600 ml-1">
+            <option>All</option>
+            <option>Draft</option>
+            <option>Sent</option>
+            <option>Scheduled</option>
+            <option>Paused</option>
+            <option>Error</option>
+          </select>
+        </div>
+        <div>
+          Folder:
+          <select className="text-blue-600 ml-1">
+            <option>All</option>
+            <option>Campaigns</option>
+            <option>Newsletters</option>
+            <option>Promotions</option>
+            <option>System</option>
+          </select>
+        </div>
+        <div>
+          Date:
+          <select className="text-blue-600 ml-1">
+            <option>All</option>
+            <option>Last 7 days</option>
+            <option>Last 30 days</option>
+            <option>This quarter</option>
+            <option>Custom</option>
+          </select>
+        </div>
+        <button className="text-blue-600 hover:underline">Clear</button>
+      </div>
+      <div className="flex flex-wrap gap-4 text-sm text-gray-600">
+        <div className="relative">
+          Sort by:
+          <select className="text-blue-600 ml-1">
+            <option>Send date</option>
+            <option>Updated</option>
+            <option>Created</option>
+            <option>Recipients</option>
+          </select>
+        </div>
+      </div>
+    </div>
+  ),
+}
+
+export const SearchAndFilters = {
+  render: () => (
+    <div className="space-y-4">
+      <div className="relative w-full max-w-xl">
+        <input
+          type="text"
+          defaultValue="launch"
+          placeholder="Search email drafts"
+          className="w-full border border-gray-300 rounded-md px-8 pr-10 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
+        />
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-black pointer-events-none" />
+      </div>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 max-w-5xl">
+        <div className="flex flex-wrap gap-4 text-sm text-gray-600">
+          <div>
+            Type:
+            <select className="text-blue-600 ml-1">
+              <option>All</option>
+              <option>Regular</option>
+              <option>Automated</option>
+              <option>Newsletter</option>
+              <option>Promotional</option>
+              <option>A/B test</option>
+            </select>
+          </div>
+          <div>
+            Status:
+            <select className="text-blue-600 ml-1">
+              <option>All</option>
+              <option>Draft</option>
+              <option>Sent</option>
+              <option>Scheduled</option>
+              <option>Paused</option>
+              <option>Error</option>
+            </select>
+          </div>
+          <div>
+            Folder:
+            <select className="text-blue-600 ml-1">
+              <option>All</option>
+              <option>Campaigns</option>
+              <option>Newsletters</option>
+              <option>Promotions</option>
+              <option>System</option>
+            </select>
+          </div>
+          <div>
+            Date:
+            <select className="text-blue-600 ml-1">
+              <option>All</option>
+              <option>Last 7 days</option>
+              <option>Last 30 days</option>
+              <option>This quarter</option>
+              <option>Custom</option>
+            </select>
+          </div>
+          <button className="text-blue-600 hover:underline">Clear</button>
+        </div>
+        <div className="flex flex-wrap gap-4 text-sm text-gray-600">
+          <div className="relative">
+            Sort by:
+            <select className="text-blue-600 ml-1">
+              <option>Send date</option>
+              <option>Updated</option>
+              <option>Created</option>
+              <option>Recipients</option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+  ),
+}

--- a/frontend/src/stories/mailchimp/EmailDraftListCard.stories.tsx
+++ b/frontend/src/stories/mailchimp/EmailDraftListCard.stories.tsx
@@ -1,0 +1,174 @@
+import React from "react"
+import { EmailDraftListCard } from "@/components/mailchimp/EmailDraftListCard"
+import { EmailDraft } from "@/hooks/useMailchimpData"
+import { AppRouterContext } from "next/dist/shared/lib/app-router-context.shared-runtime"
+
+// Storybook coverage for table row variants.
+const meta = {
+  title: "Mailchimp/EmailDraftListCard",
+  parameters: {
+    layout: "padded",
+    chromatic: {
+      disableSnapshot: false,
+      viewports: [360, 768, 1200],
+    },
+    docs: {
+      description: {
+        component: "Email draft row used in the drafts list table.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+}
+
+export default meta
+
+const routerMock = {
+  push: () => {},
+  replace: () => {},
+  prefetch: async () => {},
+  back: () => {},
+  forward: () => {},
+  refresh: () => {},
+}
+
+// Table scaffold matching the page markup.
+const TableFrame = ({ children }: { children: React.ReactNode }) => (
+  <AppRouterContext.Provider value={routerMock}>
+    <div className="max-w-5xl">
+      <table className="w-full text-sm">
+        <thead className="border-b text-gray-600">
+          <tr>
+            <th className="w-10 p-3 text-left">
+              <input type="checkbox" className="accent-emerald-600" />
+            </th>
+            <th className="p-3 text-left font-medium">Name</th>
+            <th className="p-3 text-left font-medium">Status</th>
+            <th className="p-3 text-left font-medium">Audience</th>
+            <th className="p-3 text-left font-medium">Analytics</th>
+            <th className="p-3 text-right font-medium">Actions</th>
+          </tr>
+        </thead>
+        <tbody>{children}</tbody>
+      </table>
+    </div>
+  </AppRouterContext.Provider>
+)
+
+// Baseline draft data used for multiple row variants.
+const baseDraft: EmailDraft = {
+  id: 1,
+  subject: "Welcome to Our Newsletter",
+  preview_text: "Thanks for subscribing",
+  from_name: "Newsletter Team",
+  reply_to: "newsletter@company.com",
+  status: "draft",
+  created_at: "2024-01-15T10:00:00Z",
+  updated_at: "2024-01-15T10:00:00Z",
+  recipients: 0,
+  type: "Regular email",
+}
+
+export const Draft = {
+  render: () => (
+    <TableFrame>
+      <EmailDraftListCard draft={baseDraft} />
+    </TableFrame>
+  ),
+}
+
+export const Scheduled = {
+  render: () => (
+    <TableFrame>
+      <EmailDraftListCard
+        draft={{
+          ...baseDraft,
+          id: 2,
+          status: "scheduled",
+          recipients: 1250,
+          settings: {
+            subject_line: "Product Launch Announcement",
+            preview_text: "Exciting news about our latest product launch",
+          },
+          send_time: "2024-02-01T08:00:00Z",
+        }}
+      />
+    </TableFrame>
+  ),
+}
+
+export const Sent = {
+  render: () => (
+    <TableFrame>
+      <EmailDraftListCard
+        draft={{
+          ...baseDraft,
+          id: 3,
+          status: "sent",
+          subject: "Monthly Newsletter - January 2024",
+          recipients: 2500,
+          send_time: "2024-01-12T11:30:00Z",
+        }}
+      />
+    </TableFrame>
+  ),
+}
+
+export const MissingFields = {
+  render: () => (
+    <TableFrame>
+      <EmailDraftListCard
+        draft={{
+          id: 4,
+          status: "draft",
+        }}
+      />
+    </TableFrame>
+  ),
+}
+
+export const DisabledActions = {
+  render: () => (
+    <TableFrame>
+      <EmailDraftListCard
+        draft={{
+          ...baseDraft,
+          id: 5,
+          subject: "Rename in progress",
+        }}
+        disabled
+      />
+    </TableFrame>
+  ),
+}
+
+export const ErrorStatus = {
+  render: () => (
+    <TableFrame>
+      <EmailDraftListCard
+        draft={{
+          ...baseDraft,
+          id: 6,
+          status: "error",
+          subject: "January Newsletter",
+        }}
+      />
+    </TableFrame>
+  ),
+}
+
+export const Locked = {
+  render: () => (
+    <TableFrame>
+      <EmailDraftListCard
+        draft={{
+          ...baseDraft,
+          id: 7,
+          status: "locked",
+          subject: "Read-only Draft",
+        }}
+        disabled
+      />
+    </TableFrame>
+  ),
+}

--- a/frontend/src/stories/mailchimp/EmailDraftListTable.stories.tsx
+++ b/frontend/src/stories/mailchimp/EmailDraftListTable.stories.tsx
@@ -1,0 +1,175 @@
+import React from "react"
+import { EmailDraftListCard } from "@/components/mailchimp/EmailDraftListCard"
+import { EmailDraft } from "@/hooks/useMailchimpData"
+import { AppRouterContext } from "next/dist/shared/lib/app-router-context.shared-runtime"
+
+// Storybook coverage for table-level list states.
+const meta = {
+  title: "Mailchimp/EmailDraftListTable",
+  parameters: {
+    layout: "padded",
+    chromatic: {
+      disableSnapshot: false,
+      viewports: [360, 768, 1200],
+    },
+    docs: {
+      description: {
+        component: "Email drafts list/table states using existing row component.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+}
+
+export default meta
+
+// Router mock to satisfy useRouter usage in row component.
+const routerMock = {
+  push: () => {},
+  replace: () => {},
+  prefetch: async () => {},
+  back: () => {},
+  forward: () => {},
+  refresh: () => {},
+}
+
+// Table scaffold matching the page markup.
+const TableFrame = ({
+  children,
+  fixedHeight = false,
+}: {
+  children: React.ReactNode
+  fixedHeight?: boolean
+}) => (
+  <AppRouterContext.Provider value={routerMock}>
+    <div className={fixedHeight ? "max-w-5xl h-[420px] overflow-y-auto" : "max-w-5xl"}>
+      <table className="w-full text-sm">
+        <thead className="border-b text-gray-600">
+          <tr>
+            <th className="w-10 p-3 text-left">
+              <input type="checkbox" className="accent-emerald-600" />
+            </th>
+            <th className="p-3 text-left font-medium">Name</th>
+            <th className="p-3 text-left font-medium">Status</th>
+            <th className="p-3 text-left font-medium">Audience</th>
+            <th className="p-3 text-left font-medium">Analytics</th>
+            <th className="p-3 text-right font-medium">Actions</th>
+          </tr>
+        </thead>
+        <tbody>{children}</tbody>
+      </table>
+    </div>
+  </AppRouterContext.Provider>
+)
+
+// Baseline data reused across list state stories.
+const baseDrafts: EmailDraft[] = [
+  {
+    id: 1,
+    subject: "Welcome to Our Newsletter",
+    preview_text: "Thanks for subscribing to our newsletter",
+    from_name: "Newsletter Team",
+    status: "draft",
+    updated_at: "2024-01-15T10:00:00Z",
+    recipients: 0,
+    type: "Regular email",
+  },
+  {
+    id: 2,
+    subject: "Product Launch Announcement",
+    preview_text: "Exciting news about our latest product launch",
+    from_name: "Product Team",
+    status: "scheduled",
+    send_time: "2024-02-01T08:00:00Z",
+    recipients: 1250,
+    type: "Campaign",
+  },
+  {
+    id: 3,
+    subject: "Monthly Newsletter - January 2024",
+    preview_text: "Your monthly dose of company updates and insights",
+    from_name: "Marketing Team",
+    status: "sent",
+    send_time: "2024-01-12T11:30:00Z",
+    recipients: 2500,
+    type: "Newsletter",
+  },
+]
+
+// Long list data to validate scrolling behavior.
+const manyDrafts = Array.from({ length: 14 }, (_, index) => ({
+  ...baseDrafts[index % baseDrafts.length],
+  id: index + 10,
+  subject: `Draft ${index + 1} - ${baseDrafts[index % baseDrafts.length].subject}`,
+  recipients: (index + 1) * 42,
+}))
+
+export const ThreeDrafts = {
+  render: () => (
+    <TableFrame>
+      {baseDrafts.map((draft) => (
+        <EmailDraftListCard key={draft.id} draft={draft} />
+      ))}
+    </TableFrame>
+  ),
+}
+
+export const Loading = {
+  render: () => (
+    <TableFrame>
+      <tr>
+        <td colSpan={6} className="p-8 text-center text-gray-500">
+          Loading email drafts...
+        </td>
+      </tr>
+    </TableFrame>
+  ),
+}
+
+export const ErrorState = {
+  render: () => (
+    <TableFrame>
+      <tr>
+        <td colSpan={6} className="p-8 text-center text-red-500">
+          Failed to load email drafts
+        </td>
+      </tr>
+    </TableFrame>
+  ),
+}
+
+export const Empty = {
+  render: () => (
+    <TableFrame>
+      {/* Empty state when there are no drafts */}
+      <tr>
+        <td colSpan={6} className="p-8 text-center text-gray-500">
+          No email drafts found. Click &quot;Create&quot; to create a new one.
+        </td>
+      </tr>
+    </TableFrame>
+  ),
+}
+
+export const FilteredEmpty = {
+  render: () => (
+    <TableFrame>
+      {/* Empty state after applying filters/search */}
+      <tr>
+        <td colSpan={6} className="p-8 text-center text-gray-500">
+          No email drafts match your search query.
+        </td>
+      </tr>
+    </TableFrame>
+  ),
+}
+
+export const ManyRows = {
+  render: () => (
+    <TableFrame fixedHeight>
+      {manyDrafts.map((draft) => (
+        <EmailDraftListCard key={draft.id} draft={draft} />
+      ))}
+    </TableFrame>
+  ),
+}


### PR DESCRIPTION
## Summary
- Add Mailchimp draft presentation components (DraftCard, DraftActions) for Storybook usage
- Add Storybook coverage for draft rows, cards, filters/search, and list/table states (empty/loading/error/many)
- Align Storybook filter visuals to the blue variant used in this task

## Existing File Changes (Why)
- No existing production components were modified; EmailDraftListCard remains unchanged to avoid regressions.
- Adjustments were made to satisfy linting and visual requirements.

