### PR TITLE
MED-76 Ticket Board Module

### DIFF
--- a/frontend/src/components/jira-ticket/JiraBoard.tsx
+++ b/frontend/src/components/jira-ticket/JiraBoard.tsx
@@ -1,0 +1,182 @@
+import * as React from "react";
+import { AlertTriangle, Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+import ScrollableContainer from "@/components/layout/primitives/ScrollableContainer";
+import JiraTicketKey from "@/components/jira-ticket/JiraTicketKey";
+import JiraTicketTypeIcon, {
+  JiraTicketType,
+} from "@/components/jira-ticket/JiraTicketTypeIcon";
+import { Avatar } from "@/components/avatar/Avatar";
+
+export interface JiraBoardColumnsProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  minWidth?: number;
+}
+
+const JiraBoardColumns = React.forwardRef<HTMLDivElement, JiraBoardColumnsProps>(
+  ({ children, className, minWidth = 920, ...props }, ref) => (
+    <ScrollableContainer direction="horizontal" className="mt-4 pb-2">
+      <div
+        ref={ref}
+        className={cn("flex items-start gap-4", className)}
+        style={{ minWidth }}
+        {...props}
+      >
+        {children}
+      </div>
+    </ScrollableContainer>
+  )
+);
+JiraBoardColumns.displayName = "JiraBoardColumns";
+
+export interface JiraBoardColumnProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  title: string;
+  count?: number;
+  showDoneIcon?: boolean;
+  footer?: React.ReactNode;
+}
+
+const JiraBoardColumn = React.forwardRef<HTMLDivElement, JiraBoardColumnProps>(
+  ({ title, count, showDoneIcon = false, footer, children, className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "flex w-[252px] flex-col rounded-md border border-slate-200 bg-[#f7f8f9] p-3",
+        className
+      )}
+      {...props}
+    >
+      <div className="mb-3 flex items-center justify-between text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+        <div className="flex items-center gap-2">
+          <span>{title}</span>
+          {typeof count === "number" ? (
+            <span className="rounded-sm bg-slate-200 px-1.5 py-0.5 text-[10px] font-semibold text-slate-600">
+              {count}
+            </span>
+          ) : null}
+        </div>
+        {showDoneIcon ? <Check className="h-4 w-4 text-emerald-500" /> : null}
+      </div>
+      <div className="flex min-h-[120px] flex-1 flex-col gap-2 overflow-y-auto pr-1">
+        {children}
+      </div>
+      {footer ? <div className="mt-3">{footer}</div> : null}
+    </div>
+  )
+);
+JiraBoardColumn.displayName = "JiraBoardColumn";
+
+export type JiraBoardDueTone = "default" | "warning" | "danger";
+
+export interface JiraBoardCardProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  summary: React.ReactNode;
+  ticketKey: string;
+  type: JiraTicketType | string;
+  dueDate?: string;
+  dueTone?: JiraBoardDueTone;
+  assignee?: {
+    name: string;
+    src?: string;
+    initials?: string;
+  } | null;
+  meta?: React.ReactNode;
+  isDragging?: boolean;
+  isDropTarget?: boolean;
+}
+
+const dueToneClasses: Record<JiraBoardDueTone, string> = {
+  default: "border-slate-300 bg-white text-slate-500",
+  warning: "border-amber-400 bg-white text-amber-600",
+  danger: "border-red-500 bg-white text-red-500",
+};
+
+const JiraBoardCard = React.forwardRef<HTMLDivElement, JiraBoardCardProps>(
+  (
+    {
+      summary,
+      ticketKey,
+      type,
+      dueDate,
+      dueTone = "default",
+      assignee,
+      meta,
+      isDragging = false,
+      isDropTarget = false,
+      className,
+      ...props
+    },
+    ref
+  ) => (
+    <div
+      ref={ref}
+      role="button"
+      tabIndex={0}
+      className={cn(
+        "min-h-[88px] rounded-md border bg-white px-3 py-2.5 text-[13px] shadow-sm transition",
+        "border-slate-200 hover:border-slate-300 hover:shadow",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+        isDragging && "border-blue-400 bg-blue-50 shadow-lg",
+        isDropTarget && "border-blue-500 ring-2 ring-blue-200",
+        className
+      )}
+      {...props}
+    >
+      {typeof summary === "string" ? (
+        <div className="text-[13px] font-medium text-slate-900">{summary}</div>
+      ) : (
+        summary
+      )}
+      {dueDate ? (
+        <div
+          className={cn(
+            "mt-2 inline-flex items-center gap-1.5 rounded border px-2 py-0.5 text-[11px] font-semibold",
+            dueToneClasses[dueTone]
+          )}
+        >
+          <AlertTriangle className="h-3 w-3" />
+          {dueDate}
+        </div>
+      ) : null}
+      <div className="mt-3 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <JiraTicketTypeIcon type={type} size={18} />
+          <JiraTicketKey jiraTicketKey={ticketKey} onClick={() => {}} />
+        </div>
+        <div className="flex items-center gap-2">
+          {meta}
+          {assignee ? (
+            <Avatar
+              size="xs"
+              src={assignee.src}
+              alt={assignee.name}
+              fallback={assignee.initials || assignee.name.charAt(0).toUpperCase()}
+              className="h-6 w-6 border border-slate-200 bg-slate-100 text-xs text-slate-600"
+            />
+          ) : (
+            <div className="flex h-6 w-6 items-center justify-center rounded-full border border-slate-200 bg-slate-100 text-[11px] font-semibold text-slate-500">
+              <span className="sr-only">Unassigned</span>
+              <svg
+                viewBox="0 0 24 24"
+                className="h-3.5 w-3.5"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="8" r="3" />
+                <path d="M5 19c1.5-3 5-4 7-4s5.5 1 7 4" />
+              </svg>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+);
+JiraBoardCard.displayName = "JiraBoardCard";
+
+export { JiraBoardColumns, JiraBoardColumn, JiraBoardCard };

--- a/frontend/src/components/jira-ticket/JiraBoardView.tsx
+++ b/frontend/src/components/jira-ticket/JiraBoardView.tsx
@@ -1,0 +1,261 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Filter, Search, Plus } from "lucide-react";
+import {
+  JiraBoardCard,
+  JiraBoardColumn,
+} from "@/components/jira-ticket/JiraBoard";
+
+type BoardColumn = {
+  key: string;
+  title: string;
+  empty: string;
+};
+
+type TaskLike = {
+  id?: number;
+  summary?: string;
+  type?: string;
+  due_date?: string;
+  current_approver?: {
+    username?: string;
+    email?: string;
+  } | null;
+};
+
+interface JiraBoardViewProps {
+  boardColumns: BoardColumn[];
+  tasksByType: Record<string, TaskLike[]>;
+  onCreateTask: () => void;
+  onTaskClick: (task: TaskLike) => void;
+  getTicketKey: (task: TaskLike) => string;
+  getBoardTypeIcon: (type?: string) => string;
+  formatBoardDate: (dateString?: string) => string;
+  getDueTone: (dateString?: string) => "default" | "warning" | "danger";
+  editingTaskId: number | null;
+  editingSummary: string;
+  setEditingSummary: (value: string) => void;
+  startBoardEdit: (task: TaskLike) => void;
+  cancelBoardEdit: () => void;
+  saveBoardEdit: (task: TaskLike) => void;
+}
+
+const BoardFilterPanel = () => (
+  <div className="w-[520px] overflow-hidden rounded-lg border border-slate-200 bg-white shadow-lg">
+    <div className="grid grid-cols-[180px_1fr]">
+      <div className="border-r border-slate-200 p-3 text-sm text-slate-700">
+        <div className="space-y-2">
+          {[
+            "Parent",
+            "Assignee",
+            "Work type",
+            "Labels",
+            "Status",
+            "Priority",
+          ].map((item) => (
+            <button
+              key={item}
+              type="button"
+              className="flex w-full items-center justify-between rounded-md px-2 py-1.5 text-left text-sm text-slate-600 hover:bg-slate-100"
+            >
+              {item}
+              <span className="text-slate-300">+</span>
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="p-4 text-sm text-slate-500">
+        Select a field to start creating a filter.
+      </div>
+    </div>
+    <div className="flex items-center justify-between border-t border-slate-200 px-4 py-2 text-xs text-slate-400">
+      <span className="inline-flex items-center gap-2">Give feedback</span>
+      <span>Press Shift + F to open and close</span>
+    </div>
+  </div>
+);
+
+const FilterPopover = ({
+  trigger,
+  children,
+}: {
+  trigger: React.ReactNode;
+  children: React.ReactNode;
+}) => {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className="relative inline-flex">
+      <span onClick={() => setOpen((prev) => !prev)}>{trigger}</span>
+      {open ? (
+        <div className="absolute left-0 top-full z-50 mt-2">{children}</div>
+      ) : null}
+    </div>
+  );
+};
+
+const JiraBoardView: React.FC<JiraBoardViewProps> = ({
+  boardColumns,
+  tasksByType,
+  onCreateTask,
+  onTaskClick,
+  getTicketKey,
+  getBoardTypeIcon,
+  formatBoardDate,
+  getDueTone,
+  editingTaskId,
+  editingSummary,
+  setEditingSummary,
+  startBoardEdit,
+  cancelBoardEdit,
+  saveBoardEdit,
+}) => {
+  return (
+    <div className="mt-4 space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative w-[220px]">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+          <input
+            type="text"
+            placeholder="Search board"
+            className="h-9 w-full rounded-md border border-slate-200 bg-white pl-9 pr-3 text-sm text-slate-700 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-200 text-xs font-semibold text-slate-600">
+            JX
+          </div>
+          <FilterPopover
+            trigger={
+              <button
+                type="button"
+                className="inline-flex items-center gap-2 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
+              >
+                <Filter className="h-4 w-4 text-slate-500" />
+                Filter
+              </button>
+            }
+          >
+            <BoardFilterPanel />
+          </FilterPopover>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {boardColumns.map((column) => {
+          const columnTasks = tasksByType[column.key] || [];
+          return (
+            <JiraBoardColumn
+              key={column.key}
+              title={column.title}
+              count={columnTasks.length}
+              className="w-full"
+              footer={
+                <button
+                  type="button"
+                  onClick={onCreateTask}
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-slate-500 hover:bg-slate-100"
+                >
+                  <span className="text-base">+</span>
+                  Create
+                </button>
+              }
+            >
+              {columnTasks.length === 0 ? (
+                <p className="text-xs text-slate-400">{column.empty}</p>
+              ) : (
+                columnTasks.map((task) => (
+                  <JiraBoardCard
+                    key={task.id}
+                    summary={
+                      editingTaskId === task.id ? (
+                        <input
+                          value={editingSummary}
+                          onChange={(event) =>
+                            setEditingSummary(event.target.value)
+                          }
+                          onClick={(event) => event.stopPropagation()}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter") {
+                              event.preventDefault();
+                              saveBoardEdit(task);
+                            }
+                            if (event.key === "Escape") {
+                              event.preventDefault();
+                              cancelBoardEdit();
+                            }
+                          }}
+                          onBlur={() => saveBoardEdit(task)}
+                          className="w-full rounded border border-slate-300 px-2 py-1 text-[13px] text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                        />
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            startBoardEdit(task);
+                          }}
+                          className="w-full text-left text-[13px] font-medium text-slate-900 hover:text-slate-900"
+                        >
+                          {task.summary || "Untitled task"}
+                        </button>
+                      )
+                    }
+                    ticketKey={getTicketKey(task)}
+                    type={getBoardTypeIcon(task.type)}
+                    dueDate={formatBoardDate(task.due_date)}
+                    dueTone={getDueTone(task.due_date)}
+                    assignee={
+                      task?.current_approver
+                        ? {
+                            name:
+                              task.current_approver.username ||
+                              task.current_approver.email ||
+                              "User",
+                            initials: (
+                              task.current_approver.username ||
+                              task.current_approver.email ||
+                              "?"
+                            )
+                              .slice(0, 2)
+                              .toUpperCase(),
+                          }
+                        : null
+                    }
+                    onClick={() => onTaskClick(task)}
+                  />
+                ))
+              )}
+            </JiraBoardColumn>
+          );
+        })}
+        <button
+          type="button"
+          onClick={onCreateTask}
+          className="flex h-full min-h-[120px] items-center justify-center rounded-md border border-slate-200 bg-white text-slate-600 shadow-sm hover:bg-slate-50"
+        >
+          <Plus className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default JiraBoardView;

--- a/frontend/src/stories/JiraTicketBoard.stories.tsx
+++ b/frontend/src/stories/JiraTicketBoard.stories.tsx
@@ -1,0 +1,155 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React, { useState } from "react";
+import JiraBoardView from "@/components/jira-ticket/JiraBoardView";
+
+const meta: Meta<typeof JiraBoardView> = {
+  title: "Jira Ticket/Board",
+  component: JiraBoardView,
+  parameters: {
+    layout: "fullscreen",
+    chromatic: {
+      disableSnapshot: false,
+      viewports: [360, 768, 1200],
+    },
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof JiraBoardView>;
+
+const boardColumns = [
+  { key: "budget", title: "Budget Tasks", empty: "No budget tasks found" },
+  { key: "asset", title: "Asset Tasks", empty: "No asset tasks found" },
+  {
+    key: "retrospective",
+    title: "Retrospective Tasks",
+    empty: "No retrospective tasks found",
+  },
+  { key: "report", title: "Report Tasks", empty: "No report tasks found" },
+  { key: "scaling", title: "Scaling Tasks", empty: "No scaling tasks found" },
+  {
+    key: "communication",
+    title: "Communication Tasks",
+    empty: "No communication tasks found",
+  },
+  { key: "experiment", title: "Experiment Tasks", empty: "No experiment tasks found" },
+  { key: "optimization", title: "Optimization Tasks", empty: "No optimization tasks found" },
+  { key: "alert", title: "Alert Tasks", empty: "No alert tasks found" },
+];
+
+const tasksByType = {
+  budget: [
+    {
+      id: 1,
+      summary: "Task 1",
+      type: "budget",
+      due_date: "2026-01-19",
+    },
+  ],
+  asset: [
+    {
+      id: 2,
+      summary: "Task 2",
+      type: "asset",
+      due_date: "2026-01-24",
+    },
+  ],
+  retrospective: [],
+  report: [],
+  scaling: [],
+  communication: [],
+  experiment: [],
+  optimization: [],
+  alert: [],
+};
+
+function JiraBoardStory() {
+  const [editingTaskId, setEditingTaskId] = useState<number | null>(null);
+  const [editingSummary, setEditingSummary] = useState("");
+
+  const getTicketKey = (task: { id?: number; type?: string }) => {
+    if (!task?.id) return "TASK-NEW";
+    const prefix = (task.type || "TASK").toUpperCase().slice(0, 4);
+    return `${prefix}-${task.id}`;
+  };
+
+  const getBoardTypeIcon = (type?: string) => {
+    switch (type) {
+      case "alert":
+        return "bug";
+      case "experiment":
+      case "optimization":
+        return "story";
+      default:
+        return "task";
+    }
+  };
+
+  const formatBoardDate = (dateString?: string) => {
+    if (!dateString) return "";
+    const date = new Date(dateString);
+    if (Number.isNaN(date.getTime())) return "";
+    return date.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  };
+
+  const getDueTone = (dateString?: string) => {
+    if (!dateString) return "default";
+    const due = new Date(dateString);
+    if (Number.isNaN(due.getTime())) return "default";
+    const today = new Date();
+    const dueDay = new Date(due.getFullYear(), due.getMonth(), due.getDate());
+    const todayDay = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate()
+    );
+    if (dueDay < todayDay) return "danger";
+    return "warning";
+  };
+
+  const startBoardEdit = (task: { id?: number; summary?: string }) => {
+    if (!task?.id) return;
+    setEditingTaskId(task.id);
+    setEditingSummary(task.summary || "");
+  };
+
+  const cancelBoardEdit = () => {
+    setEditingTaskId(null);
+    setEditingSummary("");
+  };
+
+  const saveBoardEdit = () => {
+    setEditingTaskId(null);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 px-6 py-6">
+      <JiraBoardView
+        boardColumns={boardColumns}
+        tasksByType={tasksByType}
+        onCreateTask={() => {}}
+        onTaskClick={() => {}}
+        getTicketKey={getTicketKey}
+        getBoardTypeIcon={getBoardTypeIcon}
+        formatBoardDate={formatBoardDate}
+        getDueTone={getDueTone}
+        editingTaskId={editingTaskId}
+        editingSummary={editingSummary}
+        setEditingSummary={setEditingSummary}
+        startBoardEdit={startBoardEdit}
+        cancelBoardEdit={cancelBoardEdit}
+        saveBoardEdit={saveBoardEdit}
+      />
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <JiraBoardStory />,
+};


### PR DESCRIPTION
Summary
- Build Jira-style Ticket Board UI and wire it into the Tasks page Board tab.
- Reuse Storybook components for board layout, cards, filter popover, and inline edit.
- Fix lint issues in the board story and tasks page.

Changes
- Added JiraBoardView and Storybook story for the Jira board.
- Tasks page now uses the Storybook board view for the Board tab.
- Board includes inline title edit, per-column create, “+” quick create, and filter popover.
- Adjusted board card/column sizing to better match Jira layout.