### PR TITLE
fix(stripe): add data migration for default subscription plans

### DIFF
--- a/backend/stripe_meta/management/commands/init_plans.py
+++ b/backend/stripe_meta/management/commands/init_plans.py
@@ -10,6 +10,9 @@ class Command(BaseCommand):
         
     This command populates the database with default Plans (Free, Pro, Ultimate).
     It is idempotent (safe to run multiple times).
+
+    DEPRECATED: Please use `python manage.py migrate` instead. 
+    Data seeding is now handled automatically by migration 0002_seed_plans.py.
     """
 
     def handle(self, *args, **options):

--- a/backend/stripe_meta/migrations/0002_seed_plans.py
+++ b/backend/stripe_meta/migrations/0002_seed_plans.py
@@ -1,0 +1,61 @@
+from django.db import migrations
+
+def seed_plans(apps, schema_editor):
+    Plan = apps.get_model('stripe_meta', 'Plan')
+    
+    plans = [
+        {
+            'name': 'Free',
+            'desc': 'Free plan',
+            'max_team_members': 5,
+            'max_previews_per_day': 2,
+            'max_tasks_per_day': 5,
+            'stripe_price_id': None
+        },
+        {
+            'name': 'Pro',
+            'desc': 'Pro plan',
+            'max_team_members': 10,
+            'max_previews_per_day': 10,
+            'max_tasks_per_day': 20,
+            'stripe_price_id': 'price_1SsOu9HPShvpl3V3M3QZ5R5T'
+        },
+        {
+            'name': 'Ultimate',
+            'desc': 'Ultimate plan',
+            'max_team_members': 20,
+            'max_previews_per_day': 50,
+            'max_tasks_per_day': 50,
+            'stripe_price_id': 'price_1SsOwQHPShvpl3V3Y2xMMWRG'
+        }
+    ]
+
+    for plan_data in plans:
+        # We manually replicate update_or_create logic because 
+        # update_or_create is a manager method, which might not be fully available on the historical model
+        # although usually it works, explicit get/create is safer in migrations
+        obj, created = Plan.objects.get_or_create(
+            name=plan_data['name'],
+            defaults=plan_data
+        )
+        if not created:
+            # Update existing plan with new defaults if it existed
+            for key, value in plan_data.items():
+                setattr(obj, key, value)
+            obj.save()
+
+def reverse_seed(apps, schema_editor):
+    # Optional: Delete plans on reverse? Usually we keep user data, but strict reverse would be:
+    # Plan = apps.get_model('stripe_meta', 'Plan')
+    # Plan.objects.filter(name__in=['Free', 'Pro', 'Ultimate']).delete()
+    pass
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('stripe_meta', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_plans, reverse_seed),
+    ]

--- a/backend/stripe_meta/stripe_utils.py
+++ b/backend/stripe_meta/stripe_utils.py
@@ -4,6 +4,10 @@ def initialize_default_plans():
     """
     Initialize default subscription plans (Free, Pro, Ultimate) if they don't exist.
     This function is idempotent.
+
+    NOTE: This logic is now superseded by migration 0002_seed_plans.py.
+    The primary method for seeding data should be `python manage.py migrate`.
+    This function is kept for legacy support or manual re-initialization.
     """
     plans = [
         {

--- a/backend/stripe_meta/tests/test_serializers.py
+++ b/backend/stripe_meta/tests/test_serializers.py
@@ -17,6 +17,9 @@ class PlanSerializerTest(TestCase):
     """Test cases for PlanSerializer"""
     
     def setUp(self):
+        # Clear existing plans from migrations to ensure deterministic tests
+        Plan.objects.all().delete()
+        
         self.plan = Plan.objects.create(
             name="Basic Plan",
             desc="A basic plan description",
@@ -65,6 +68,9 @@ class SubscriptionSerializerTest(TestCase):
     """Test cases for SubscriptionSerializer"""
     
     def setUp(self):
+        # Clear existing plans from migrations to ensure deterministic tests
+        Plan.objects.all().delete()
+        
         self.organization = Organization.objects.create(
             name="Test Organization",
             slug="test-org"
@@ -156,6 +162,9 @@ class CheckoutSessionSerializerTest(TestCase):
     
     def setUp(self):
         """Set up test data"""
+        # Clear existing plans from migrations to ensure deterministic tests
+        Plan.objects.all().delete()
+        
         self.plan = Plan.objects.create(
             name="Test Plan",
             max_team_members=5,

--- a/backend/stripe_meta/tests/test_views.py
+++ b/backend/stripe_meta/tests/test_views.py
@@ -26,6 +26,10 @@ class StripeViewsTestCase(TestCase):
         self.client = APIClient()
         
         # Create test data
+        
+        # Clear existing plans from migrations to ensure deterministic tests
+        Plan.objects.all().delete()
+        
         self.organization = Organization.objects.create(
             name="Test Organization",
             slug="test-org"


### PR DESCRIPTION
Added a Django data migration [0002_seed_plans.py] to populate the database with default plans (Free, Pro, Ultimate).