### PR TITLE
fix(BGF-24): Auto-assign Free plan to new organizations

### DIFF
--- a/backend/stripe_meta/apps.py
+++ b/backend/stripe_meta/apps.py
@@ -5,3 +5,6 @@ class StripeConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'stripe_meta'
     verbose_name = 'Stripe Integration'
+
+    def ready(self):
+        import stripe_meta.signals

--- a/backend/stripe_meta/signals.py
+++ b/backend/stripe_meta/signals.py
@@ -1,0 +1,38 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from django.utils import timezone
+from datetime import timedelta
+from core.models import Organization
+from .models import Plan, Subscription
+import logging
+
+logger = logging.getLogger(__name__)
+
+@receiver(post_save, sender=Organization)
+def create_default_subscription(sender, instance, created, **kwargs):
+    """
+    Automatically assign a Free plan subscription to new organizations.
+    """
+    if created:
+        try:
+            # 1. Get the Free Plan (seeded in migration 0002)
+            try:
+                free_plan = Plan.objects.get(name="Free")
+            except Plan.DoesNotExist:
+                logger.error(f"Free plan not found. Auto-subscription failed for organization '{instance.name}'.")
+                return
+
+            # 2. Create a default subscription
+            Subscription.objects.create(
+                organization=instance,
+                plan=free_plan,
+                stripe_subscription_id="sub_free_internal", # Dummy ID for internal free plan
+                start_date=timezone.now(),
+                end_date=timezone.now() + timedelta(days=365*100), # Effectively forever (100 years)
+                is_active=True
+            )
+            
+            logger.info(f"Auto-subscribed organization '{instance.name}' (ID: {instance.id}) to Free plan.")
+
+        except Exception as e:
+            logger.error(f"Failed to auto-subscribe organization '{instance.name}': {str(e)}")

--- a/backend/stripe_meta/tests/test_middleware.py
+++ b/backend/stripe_meta/tests/test_middleware.py
@@ -50,6 +50,9 @@ class UsageTrackingMiddlewareTest(TestCase):
             is_active=True
         )
         
+        # Delete auto-created Free subscription to keep tests focused on Basic Plan
+        Subscription.objects.filter(organization=self.organization, plan__name="Free").delete()
+        
         # Generate organization access token
         self.org_token = generate_organization_access_token(self.user)
     

--- a/backend/stripe_meta/tests/test_views.py
+++ b/backend/stripe_meta/tests/test_views.py
@@ -1309,8 +1309,11 @@ class SubscriptionCheckoutErrorTests(TestCase):
 
     def test_get_subscription_no_active_subscription(self):
         """Test get_subscription when no active subscription exists"""
-        # Create a subscription but mark it as inactive
-        subscription = Subscription.objects.create(
+        # Delete auto-created Free subscription (from setUp)
+        Subscription.objects.filter(organization=self.organization).delete()
+        
+        # Create an inactive subscription
+        Subscription.objects.create(
             organization=self.organization,
             plan=self.plan,
             stripe_subscription_id="sub_inactive",
@@ -1345,6 +1348,9 @@ class SubscriptionCheckoutErrorTests(TestCase):
 
     def test_switch_plan_no_active_subscription(self):
         """Test switch_plan when no active subscription exists"""
+        # Delete auto-created Free subscription (from setUp)
+        Subscription.objects.filter(organization=self.organization).delete()
+        
         response = self.client.post(
             reverse("stripe_meta:switch_plan"),
             data={"plan_id": self.plan2.id},
@@ -1412,6 +1418,9 @@ class SubscriptionCheckoutErrorTests(TestCase):
 
     def test_cancel_subscription_no_active_subscription(self):
         """Test cancel_subscription when no active subscription exists"""
+        # Delete auto-created Free subscription (from setUp)
+        Subscription.objects.filter(organization=self.organization).delete()
+        
         response = self.client.post(
             reverse("stripe_meta:cancel_subscription"),
             HTTP_X_ORGANIZATION_TOKEN=self.org_token
@@ -1473,6 +1482,9 @@ class SubscriptionCheckoutErrorTests(TestCase):
 
     def test_create_checkout_session_stripe_error_handling(self):
         """Test create_checkout_session Stripe error handling"""
+        # Delete auto-created Free subscription so we can reach the Stripe API call
+        Subscription.objects.filter(organization=self.organization).delete()
+        
         # Mock stripe.checkout.Session.create to raise a StripeError
         with patch("stripe_meta.views.stripe.checkout.Session.create") as mock_create:
             mock_create.side_effect = stripe.StripeError("Stripe API error")


### PR DESCRIPTION
This PR implements automatic Free plan subscription assignment for new organizations.
- Add post_save signal to automatically create Free plan subscription
- Register signals in stripe_meta app configuration
- Prevents 'no active subscription found' error for new orgs"