### PR TITLE
Fix: unexpected Chat WebSocket connections outside chat UI

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -252,12 +252,6 @@ const Sidebar: FC<SidebarProps> = ({
   
   // Get global unread count from chat store for Messages badge (across ALL projects)
   const globalUnreadCount = useChatStore(state => state.globalUnreadCount);
-  const fetchGlobalUnreadCount = useChatStore(state => state.fetchGlobalUnreadCount);
-  
-  // Fetch global unread count on mount
-  useEffect(() => {
-    fetchGlobalUnreadCount();
-  }, [fetchGlobalUnreadCount]);
 
   const navigationItems = useMemo(() => {
     const items = getNavigationItems(userRole, userRoleLevel, t);

--- a/frontend/src/components/messages/MessagePageContent.tsx
+++ b/frontend/src/components/messages/MessagePageContent.tsx
@@ -36,6 +36,7 @@ export default function MessagePageContent() {
   
   // Connect to WebSocket for real-time updates
   const { connected } = useChatSocket(userId, {
+    enabled: true,
     onMessage: (message) => {
       console.log('[MessagePage] New message received:', message);
     },
@@ -236,4 +237,3 @@ export default function MessagePageContent() {
     </div>
   );
 }
-


### PR DESCRIPTION
Added explicit enabled control to useChatSocket (useChatSocket.ts) to gate connection lifecycle.

Updated socket start condition from userId only to userId && enabled.

Prevented auto-reconnect when socket is disabled, so non-chat contexts no longer retry/connect unexpectedly.

Made MessagePageContent the messages-page WS owner with enabled: true (MessagePageContent.tsx).

Gated ChatWidget WS with enabled: isWidgetOpen && !isMessagePageOpen (ChatWidget.tsx) to avoid background connections.

Added REST unread fallback refresh in ChatWidget on mount/login, route change, window focus, and visibility return, with 15s throttle.

Removed duplicate unread-count fetch on sidebar mount to reduce redundant API calls (Sidebar.tsx).