### PR TITLE
Smp 473 notion optmzation v2

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -477,6 +477,15 @@ hr {
   scrollbar-width: none;  /* Firefox */
 }
 
+/* Outline overlay: no scrollbar gutter */
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+.no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
 /* Visible scrollbar for spreadsheet grid; only this container scrolls (page/body do not). */
 .spreadsheet-scroll-container {
   /* Firefox */

--- a/frontend/src/app/notion/page.tsx
+++ b/frontend/src/app/notion/page.tsx
@@ -16,172 +16,6 @@ import {
 import { toast } from 'react-hot-toast';
 import { useRouter } from 'next/navigation';
 
-const HEADING_TYPES = new Set([ 'heading_1', 'heading_2', 'heading_3', 'heading', 'h1', 'h2', 'h3' ]);
-const headingLevel = (type: string): number => {
-  if (type === 'heading_1' || type === 'h1') return 1;
-  if (type === 'heading_2' || type === 'h2') return 2;
-  return 3;
-};
-  
-const stripHtml = (html: string): string => {
-  if (typeof document === 'undefined') return html;
-  const div = document.createElement('div');
-  div.innerHTML = html;
-    return div.textContent || div.innerText || '';
-};
-
-interface OutlineItem {
-    id: string; 
-    label: string;
-    level: number; 
-}
-interface OutlineSidebarProps {
-  items: OutlineItem[];
-  activeId: string | null;
-  onItemClick: (id: string) => void;
-}
-
-function OutlineSidebar({ items, activeId, onItemClick }: OutlineSidebarProps) {
-  const [hovered, setHovered] = useState(false);
-  return (
-    <div
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      style={{
-        position: 'fixed', right: 0, top: 0, bottom: 0,
-        width: hovered ? 260 : 20,
-        transition: 'width 0.2s cubic-bezier(0.4,0,0.2,1)',
-        zIndex: 40, overflow: 'hidden',
-      }}
-    >
-      {/* Collapsed state: thin gray indicator lines */}
-      {!hovered && (
-        <div style={{ 
-          position:'absolute', right:5, top:'50%',
-          transform:'translateY(-50%)',
-          display:'flex', flexDirection:'column', gap:3 }}>
-          {(items.length ? items : Array(8).fill(null)).slice(0,14).map((item,i) => (
-            <div key={i} style={{
-              width: item ? (item.level===1?14:item.level===2?11:8) : [14,11,8,14,11,8,14,11][i%8],
-              height: 1.5, background: '#d1d5db', borderRadius: 1,
-            }}/>
-          ))}
-        </div>
-      )}
-
-      {/* Expanded state: full panel */}
-      <div style={{
-        position: 'absolute', top: 0, right: 0,
-        width: 260, height: '100%',
-        background: '#fff',
-        borderLeft: '2px solid #e5e7eb',
-        boxShadow: '-4px 0 24px rgba(0,0,0,0.10)',
-        opacity: hovered ? 1 : 0,
-        transition: 'opacity 0.15s ease',
-        pointerEvents: hovered ? 'auto' : 'none',
-        display: 'flex', 
-        flexDirection: 'column',
-      }}>
-      <div style={{
-        padding: '20px 20px 10px 20px',
-        fontSize: 11, 
-        fontWeight: 700,
-        color: '#3b82f6',
-        letterSpacing: '0.06em',
-        textTransform: 'uppercase', 
-        flexShrink: 0,
-        borderBottom: '1px solid #f3f4f6',
-      }}>
-        Table of Contents
-        </div>
-
-        {/* Scrollable list */}
-        <div style={{
-          flex: 1,
-          overflowY: 'auto',
-          maxHeight: 'calc(80vh - 52px)',
-          padding: '8px 0',
-          // Webkit scrollbar — narrow and subtle
-          // @ts-ignore
-          scrollbarWidth: 'thin',
-          scrollbarColor: '#d1d5db transparent',
-        }}
-        className="outline-scroll"
-        >
-          
-          {items.length === 0 ? (
-          <div style={{
-            padding: '12px 20px', fontSize: 12,
-            color: '#9ca3af', fontStyle: 'italic',
-          }}>
-            Add headings to see outline
-          </div>
-        ) : items.map((item) => {
-          
-          const isActive = activeId === item.id;
-          const indent = item.level === 1 ? 16 : item.level === 2 ? 28 : 40;
-          return (
-              <button
-                key={item.id}
-                type="button"
-                onClick={() => onItemClick(item.id)}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  width: '100%',
-                  minHeight: 32,
-                  padding: `0 12px 0 0`,
-                  paddingLeft: 0,
-                  margin: 0,
-                  border: 'none',
-                  background: isActive ? '#eff6ff' : 'transparent',
-                  cursor: 'pointer',
-                  textAlign: 'left',
-                  borderRadius: 0,
-                  transition: 'background 0.1s',
-                }}
-                onMouseEnter={e => {
-                  if (!isActive) (e.currentTarget as HTMLElement).style.background = '#f9fafb';
-                }}
-                onMouseLeave={e => {
-                  if (!isActive) (e.currentTarget as HTMLElement).style.background = 'transparent';
-                }}
-              >
-                {/* ── Blue active indicator bar ── */}
-                <div style={{
-                  width: 3, alignSelf: 'stretch', flexShrink: 0,
-                  background: isActive ? '#3b82f6' : 'transparent',
-                  borderRadius: '0 2px 2px 0',
-                  marginRight: 0,
-                  transition: 'background 0.15s',
-                }} />
-
-                {/* ── Label with indent ── */}
-                <span style={{
-                  paddingLeft: indent,
-                  paddingRight: 12,
-                  fontSize: 13,
-                  lineHeight: '20px',
-                  fontWeight: isActive ? 600 : 400,
-                  color: isActive ? '#1d4ed8' : '#6b7280',
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  flex: 1,
-                  minWidth: 0,
-                }}>
-                  {item.label || 'Untitled heading'}
-                </span>
-              </button>
-            );
-       })}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-
 const TODO_STATE_REGEX = /data-todo-state="(checked|unchecked)"/i;
 const addTodoMarkerIfMissing = (html: string) => {
   if (TODO_STATE_REGEX.test(html)) {
@@ -392,86 +226,8 @@ function NotionPageContent() {
   const [lastEditedAt, setLastEditedAt] = useState<Date | null>(null);
   const [isPreviewOpen, setIsPreviewOpen] = useState<boolean>(false);
   const [deletingDraftId, setDeletingDraftId] = useState<number | null>(null);
-  const [activeOutlineId, setActiveOutlineId] =useState<string | null>(null);
 
   const snapshotRef = useRef<string>(buildSnapshot(title, status, blocks));
-
-   // ── Outline: derive items from heading blocks
-  const outlineItems = useMemo<OutlineItem[]>(() => {
-    return blocks
-      .filter((b) => HEADING_TYPES.has(b.type))
-      .map((b) => ({
-        id: b.id,
-        label: stripHtml(b.html),
-        level: headingLevel(b.type),
-      }));
-  }, [blocks]);
-
-  // ── Outline: scroll to heading on click and set activeOutlineId
-  const handleOutlineClick = useCallback((blockId: string) => {
-    setActiveOutlineId(blockId);
-    const el = document.querySelector(
-      `[data-block-id="${blockId}"]`
-    ) as HTMLElement | null;
-    if (el) el.scrollIntoView({ behavior:'smooth', block:'start' });
-  }, []);
-
-  // ── Single observer ref (created once, reused) ─ to track visible headings and update activeOutlineId
-  const observerRef = useRef<IntersectionObserver | null>(null);
-
-  useEffect(() => {
-  if (outlineItems.length === 0) {
-    setActiveOutlineId(null);
-    return;
-  }
-
-  // Disconnect previous before creating new
-  if (observerRef.current) observerRef.current.disconnect();
-
-  const visibleMap = new Map<string, number>();
-
-  observerRef.current = new IntersectionObserver(
-    (entries) => {
-      entries.forEach((entry) => {
-        const id = entry.target.getAttribute('data-block-id');
-        if (!id) return;
-        if (entry.isIntersecting) {
-          visibleMap.set(id, entry.intersectionRatio);
-        } else {
-          visibleMap.delete(id);
-        }
-      });
-
-      if (visibleMap.size === 0) return;
-
-      const topId = [...visibleMap.entries()]
-        .sort((a, b) => b[1] - a[1])[0][0];
-
-      setActiveOutlineId((prev) => prev !== topId ? topId : prev);
-    },
-    {
-      root: null,
-      // ── Key fix: narrows detection zone to top 10%–20% of viewport
-      // so the active item tracks what you're actually reading, not
-      // whatever heading last entered the bottom of the screen
-      rootMargin: '-10% 0% -80% 0%',
-      threshold: [0, 0.25, 0.5, 0.75, 1],
-    }
-  );
-
-  // Small delay — ensures DOM has rendered after blocks state update
-  const timer = setTimeout(() => {
-    outlineItems.forEach(({ id }) => {
-      const el = document.querySelector(`[data-block-id="${id}"]`);
-      if (el) observerRef.current?.observe(el);
-    });
-  }, 50);
-
-  return () => {
-    clearTimeout(timer);
-    observerRef.current?.disconnect();
-  };
-}, [outlineItems]);
 
   const layoutUser = useMemo(
     () =>
@@ -538,7 +294,6 @@ function NotionPageContent() {
         // Reset lastEditedAt when loading a draft (user hasn't edited yet)
         setLastEditedAt(null);
         setHasChanges(false);
-        setActiveOutlineId(null);
         syncSnapshot(nextTitle, nextStatus, nextBlocks);
         
         // Focus the first block after loading
@@ -746,7 +501,6 @@ function NotionPageContent() {
       setLastEditedAt(null);
       setHasChanges(false);
       setIsLoadingEditor(false);
-      setActiveOutlineId(null);
       syncSnapshot(nextTitle, nextStatus, nextBlocks);
       
       // Refresh drafts list to update the UI (in background, don't wait)
@@ -806,7 +560,6 @@ function NotionPageContent() {
             setTitle('Untitled');
             setStatus('draft');
             setLastEditedAt(null);
-            setActiveOutlineId(null);
             syncSnapshot('Untitled', 'draft', defaultBlocks);
           }
         }
@@ -961,7 +714,7 @@ function NotionPageContent() {
 
   return (
     <Layout user={layoutUser} onUserAction={handleUserAction}>
-      <div className="h-full flex bg-gray-50 min-h-0">
+      <div className="h-screen overflow-hidden flex bg-gray-50 min-h-0">
         <NotionDraftList
           drafts={drafts}
           selectedId={selectedDraftId}
@@ -970,7 +723,7 @@ function NotionPageContent() {
           onDelete={handleDeleteDraft}
           isLoading={isLoadingDrafts || deletingDraftId !== null}
         />
-        <div className="flex-1 flex flex-col min-h-0">
+        <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
           <div className="border-b border-gray-200 bg-white px-8 py-6 flex-shrink-0">
             <div className="flex items-center gap-4">
               <input
@@ -1007,13 +760,18 @@ function NotionPageContent() {
             </div>
           </div>
 
-          <div className="flex-1 bg-white min-h-0 overflow-y-auto">
+          <div className="flex-1 bg-white min-h-0 overflow-hidden">
             {isLoadingEditor ? (
               <div className="h-full flex items-center justify-center text-gray-400">
                 Loading draft…
               </div>
             ) : selectedDraftId ? (
-              <NotionEditor blocks={blocks} setBlocks={setBlocks} draftId={selectedDraftId || undefined} />
+              <NotionEditor
+                key={selectedDraftId}
+                blocks={blocks}
+                setBlocks={setBlocks}
+                draftId={selectedDraftId || undefined}
+              />
             ) : (
               <div className="h-full flex flex-col items-center justify-center text-center text-gray-400 space-y-3">
                 <h2 className="text-xl font-semibold text-gray-500">
@@ -1035,15 +793,6 @@ function NotionPageContent() {
           </div>
         </div>
       </div>
-
-       {/* Outline sidebar — only shown when a draft is open */}
-      {selectedDraftId && (
-        <OutlineSidebar
-          items={outlineItems}
-          activeId={activeOutlineId}
-          onItemClick={handleOutlineClick}
-        />
-      )}
 
       {isPreviewOpen && (
         <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/40 px-4 py-8">

--- a/frontend/src/app/notion/page.tsx
+++ b/frontend/src/app/notion/page.tsx
@@ -3,10 +3,9 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Layout from '@/components/layout/Layout';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
-import useAuth from '@/hooks/useAuth';
 import { NotionDraftAPI } from '@/lib/api/notionDraftApi';
-import NotionDraftList from '@/components/notion/NotionDraftList';
-import NotionEditor, { createEmptyBlock } from '@/components/notion/NotionEditor';
+import { createEmptyBlock } from '@/components/notion/NotionEditor';
+import NotionLayout from '@/components/notion/NotionLayout';
 import {
   DraftStatus,
   DraftSummary,
@@ -14,7 +13,6 @@ import {
   NotionContentBlockRecord,
 } from '@/types/notion';
 import { toast } from 'react-hot-toast';
-import { useRouter } from 'next/navigation';
 
 const TODO_STATE_REGEX = /data-todo-state="(checked|unchecked)"/i;
 const addTodoMarkerIfMissing = (html: string) => {
@@ -199,9 +197,6 @@ const buildSnapshot = (title: string, status: string, blocks: EditorBlock[]) =>
   });
 
 function NotionPageContent() {
-  const { user, logout } = useAuth();
-  const router = useRouter();
-
   const [drafts, setDrafts] = useState<DraftSummary[]>([]);
   // Initialize selectedDraftId from localStorage if available
   const [selectedDraftId, setSelectedDraftId] = useState<number | null>(() => {
@@ -228,30 +223,6 @@ function NotionPageContent() {
   const [deletingDraftId, setDeletingDraftId] = useState<number | null>(null);
 
   const snapshotRef = useRef<string>(buildSnapshot(title, status, blocks));
-
-  const layoutUser = useMemo(
-    () =>
-      user
-        ? {
-            name: user.username || 'User',
-            email: user.email || '',
-            role: user.roles?.length ? user.roles[0] : 'user',
-          }
-        : undefined,
-    [user]
-  );
-
-  const handleUserAction = useCallback(
-    async (action: string) => {
-      if (action === 'logout') {
-        await logout();
-      }
-      if (action === 'settings') {
-        router.push('/profile/settings');
-      }
-    },
-    [logout, router]
-  );
 
   const syncSnapshot = useCallback(
     (nextTitle: string, nextStatus: string, nextBlocks: EditorBlock[]) => {
@@ -535,11 +506,8 @@ function NotionPageContent() {
     }
   }, [syncSnapshot]);
 
-  const handleDeleteDraft = useCallback(
+  const performDeleteDraft = useCallback(
     async (draftId: number) => {
-      if (!window.confirm('Delete this draft?')) {
-        return;
-      }
       try {
         setDeletingDraftId(draftId);
         await NotionDraftAPI.deleteDraft(draftId);
@@ -571,6 +539,52 @@ function NotionPageContent() {
       }
     },
     [drafts, loadDraftDetail, selectedDraftId, syncSnapshot]
+  );
+
+  const handleDeleteDraft = useCallback(
+    (draftId: number) => {
+      toast(
+        (t) => (
+          <div className="flex items-center gap-4 bg-white rounded-lg shadow-lg border border-gray-100 px-4 py-3 min-w-[280px]">
+            <div className="flex items-center gap-2 flex-1">
+              <svg className="w-4 h-4 text-red-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+              <span className="text-sm font-medium text-gray-700">Delete this draft?</span>
+            </div>
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <button
+                type="button"
+                onClick={() => {
+                  toast.dismiss(t.id);
+                  performDeleteDraft(draftId);
+                }}
+                className="px-3 py-1 text-xs font-semibold text-white bg-red-500 hover:bg-red-600 rounded-md transition-colors"
+              >
+                Delete
+              </button>
+              <button
+                type="button"
+                onClick={() => toast.dismiss(t.id)}
+                className="px-3 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-md transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ),
+        {
+          duration: 4000,
+          position: 'bottom-center',
+          style: {
+            background: 'transparent',
+            boxShadow: 'none',
+            padding: 0,
+          },
+        }
+      );
+    },
+    [performDeleteDraft]
   );
 
   const handleSave = useCallback(async () => {
@@ -713,147 +727,27 @@ function NotionPageContent() {
   }, [lastEditedAt]);
 
   return (
-    <Layout user={layoutUser} onUserAction={handleUserAction}>
-      <div className="h-screen overflow-hidden flex bg-gray-50 min-h-0">
-        <NotionDraftList
-          drafts={drafts}
-          selectedId={selectedDraftId}
-          onSelect={loadDraftDetail}
-          onCreate={handleCreateDraft}
-          onDelete={handleDeleteDraft}
-          isLoading={isLoadingDrafts || deletingDraftId !== null}
-        />
-        <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
-          <div className="border-b border-gray-200 bg-white px-8 py-6 flex-shrink-0">
-            <div className="flex items-center gap-4">
-              <input
-                type="text"
-                value={title}
-                onChange={(event) => setTitle(event.target.value)}
-                placeholder="Untitled"
-                className="flex-1 border-0 border-b border-transparent focus:border-blue-500 focus:ring-0 text-3xl font-semibold text-gray-900 placeholder:text-gray-300"
-                disabled={!selectedDraftId}
-              />
-              {lastEditedLabel && (
-                <span aria-live="polite" className="text-sm text-gray-500 whitespace-nowrap">
-                  {lastEditedLabel}
-                </span>
-              )}
-              <div className="flex items-center gap-3">
-                <button
-                  type="button"
-                  onClick={() => setIsPreviewOpen(true)}
-                  className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  disabled={!selectedDraftId}
-                >
-                  Preview
-                </button>
-                <button
-                  type="button"
-                  onClick={handleSave}
-                  className="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-60"
-                  disabled={!selectedDraftId || isSaving || !hasChanges}
-                >
-                  {isSaving ? 'Saving…' : 'Save'}
-                </button>
-              </div>
-            </div>
-          </div>
-
-          <div className="flex-1 bg-white min-h-0 overflow-hidden">
-            {isLoadingEditor ? (
-              <div className="h-full flex items-center justify-center text-gray-400">
-                Loading draft…
-              </div>
-            ) : selectedDraftId ? (
-              <NotionEditor
-                key={selectedDraftId}
-                blocks={blocks}
-                setBlocks={setBlocks}
-                draftId={selectedDraftId || undefined}
-              />
-            ) : (
-              <div className="h-full flex flex-col items-center justify-center text-center text-gray-400 space-y-3">
-                <h2 className="text-xl font-semibold text-gray-500">
-                  No draft selected
-                </h2>
-                <p className="max-w-md text-sm text-gray-500">
-                  Create a new draft or select one from the sidebar to start
-                  writing with the Notion-style editor.
-                </p>
-                <button
-                  type="button"
-                  onClick={handleCreateDraft}
-                  className="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-                >
-                  New draft
-                </button>
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-
-      {isPreviewOpen && (
-        <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/40 px-4 py-8">
-          <div className="relative flex flex-col max-h-[90vh] w-full max-w-3xl rounded-xl bg-white shadow-2xl">
-            <div className="flex-shrink-0 h-16 border-b border-gray-200 bg-white px-6 flex items-center">
-              <div className="flex-1">
-                <h3 className="text-lg font-semibold text-gray-900">
-                  {title || 'Untitled'}
-                </h3>
-                <p className="text-sm text-gray-500">Preview mode</p>
-              </div>
-              <button
-                type="button"
-                onClick={() => setIsPreviewOpen(false)}
-                className="rounded-full bg-gray-100 p-2 text-gray-500 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                aria-label="Close preview"
-              >
-                <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                  <path
-                    fillRule="evenodd"
-                    d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                    clipRule="evenodd"
-                  />
-                </svg>
-              </button>
-            </div>
-            <div className="flex-1 overflow-y-auto p-8 space-y-6 min-h-0">
-              {blocks.map((block) => {
-                if (block.type === 'divider') {
-                  return (
-                    <div key={block.id} className="w-full border-t border-gray-300 my-4" />
-                  );
-                }
-                if (block.type === 'image' || block.type === 'video' || block.type === 'audio' || block.type === 'file' || block.type === 'web_bookmark') {
-                  return (
-                    <div
-                      key={block.id}
-                      className="prose prose-gray max-w-none"
-                      dangerouslySetInnerHTML={{ __html: block.html || '' }}
-                    />
-                  );
-                }
-                if (!block.html) {
-                  return (
-                    <div key={block.id} className="text-gray-300 italic">
-                      Empty block
-                    </div>
-                  );
-                }
-                return (
-                  <div
-                    key={block.id}
-                    className="prose prose-gray max-w-none"
-                    dangerouslySetInnerHTML={{ __html: block.html }}
-                  />
-                );
-              })}
-            </div>
-          </div>
-        </div>
-      )}
+    <Layout showHeader={true} showSidebar={true}>
+      <NotionLayout
+        drafts={drafts}
+        selectedDraftId={selectedDraftId}
+        onSelectDraft={loadDraftDetail}
+        onCreateDraft={handleCreateDraft}
+        onDeleteDraft={handleDeleteDraft}
+        isDraftListLoading={isLoadingDrafts || deletingDraftId !== null}
+        title={title}
+        onTitleChange={setTitle}
+        lastEditedLabel={lastEditedLabel}
+        onOpenPreview={() => setIsPreviewOpen(true)}
+        onSave={handleSave}
+        isSaving={isSaving}
+        hasChanges={hasChanges}
+        isLoadingEditor={isLoadingEditor}
+        blocks={blocks}
+        setBlocks={setBlocks}
+        isPreviewOpen={isPreviewOpen}
+        onClosePreview={() => setIsPreviewOpen(false)}
+      />
     </Layout>
   );
 }

--- a/frontend/src/app/notion/page.tsx
+++ b/frontend/src/app/notion/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import Layout from '@/components/layout/Layout';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { NotionDraftAPI } from '@/lib/api/notionDraftApi';
@@ -222,7 +223,58 @@ function NotionPageContent() {
   const [isPreviewOpen, setIsPreviewOpen] = useState<boolean>(false);
   const [deletingDraftId, setDeletingDraftId] = useState<number | null>(null);
 
+  const router = useRouter();
   const snapshotRef = useRef<string>(buildSnapshot(title, status, blocks));
+
+  const handleNavigateAway = useCallback(
+    (destination: string) => {
+      if (!hasChanges) {
+        router.push(destination);
+        return;
+      }
+      toast(
+        (t: { id: string }) => (
+          <div className="flex items-center gap-4 bg-white rounded-lg shadow-lg border border-gray-100 px-4 py-3 min-w-[300px]">
+            <div className="flex items-center gap-2 flex-1">
+              <svg className="w-4 h-4 text-amber-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+              </svg>
+              <span className="text-sm font-medium text-gray-700">Unsaved changes will be lost</span>
+            </div>
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <button
+                type="button"
+                onClick={() => {
+                  toast.dismiss(t.id);
+                  router.push(destination);
+                }}
+                className="px-3 py-1 text-xs font-semibold text-white bg-amber-500 hover:bg-amber-600 rounded-md transition-colors"
+              >
+                Leave
+              </button>
+              <button
+                type="button"
+                onClick={() => toast.dismiss(t.id)}
+                className="px-3 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-md transition-colors"
+              >
+                Stay
+              </button>
+            </div>
+          </div>
+        ),
+        {
+          duration: 6000,
+          position: 'bottom-center',
+          style: {
+            background: 'transparent',
+            boxShadow: 'none',
+            padding: 0,
+          },
+        }
+      );
+    },
+    [hasChanges, router]
+  );
 
   const syncSnapshot = useCallback(
     (nextTitle: string, nextStatus: string, nextBlocks: EditorBlock[]) => {
@@ -427,16 +479,6 @@ function NotionPageContent() {
       setLastEditedAt(new Date());
     }
   }, [blocks, selectedDraftId, status, title]);
-
-  useEffect(() => {
-    const beforeUnload = (event: BeforeUnloadEvent) => {
-      if (!hasChanges) return;
-      event.preventDefault();
-      event.returnValue = '';
-    };
-    window.addEventListener('beforeunload', beforeUnload);
-    return () => window.removeEventListener('beforeunload', beforeUnload);
-  }, [hasChanges]);
 
   const handleCreateDraft = useCallback(async () => {
     try {
@@ -727,7 +769,13 @@ function NotionPageContent() {
   }, [lastEditedAt]);
 
   return (
-    <Layout showHeader={true} showSidebar={true}>
+    <Layout
+      showHeader={true}
+      showSidebar={true}
+      unsavedChangesGuard={
+        hasChanges ? { hasChanges, onNavigateAway: handleNavigateAway } : undefined
+      }
+    >
       <NotionLayout
         drafts={drafts}
         selectedDraftId={selectedDraftId}

--- a/frontend/src/components/email-drafts/EmailDraftsWorkspace.tsx
+++ b/frontend/src/components/email-drafts/EmailDraftsWorkspace.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import React, { useState, useMemo } from "react";
+import { DraftViewToggle, type DraftView } from "./DraftViewToggle";
+import { DraftSearchBar } from "./DraftSearchBar";
+import { EmailDraftListCard } from "./EmailDraftListCard";
+import { DraftCard } from "./DraftCard";
+import { DraftActions } from "./DraftActions";
+import Button from "@/components/button/Button";
+
+export type EmailDraftWorkspaceDraft = {
+  id: string | number;
+  title: string;
+  previewText?: string;
+  fromName?: string;
+  status?: string;
+  statusLabel?: string;
+  typeLabel?: string;
+  sendTime?: string;
+  dateLabel?: string;
+  recipients?: number;
+  audienceLabel?: string;
+};
+
+export type EmailDraftsWorkspaceProps = {
+  pageTitle: string;
+  searchPlaceholder?: string;
+  drafts: EmailDraftWorkspaceDraft[];
+  loading?: boolean;
+  error?: string | null;
+  initialView?: DraftView;
+  loadingMessage?: string;
+  emptyStateTitle?: string;
+  emptyStateDescription?: string;
+  noSearchResultMessage?: string;
+  showListPreview?: boolean;
+  onCreate: () => void;
+  onOpen: (draft: EmailDraftWorkspaceDraft) => void;
+  onEdit: (draft: EmailDraftWorkspaceDraft) => void;
+  onSend: (draft: EmailDraftWorkspaceDraft) => void;
+  onDelete: (draft: EmailDraftWorkspaceDraft) => void;
+};
+
+export function EmailDraftsWorkspace({
+  pageTitle,
+  searchPlaceholder = "Search email drafts",
+  drafts,
+  loading = false,
+  error = null,
+  initialView = "list",
+  loadingMessage = "Loading email drafts...",
+  emptyStateTitle = "No email drafts found.",
+  emptyStateDescription = 'Click "Create" to create a new email draft.',
+  noSearchResultMessage = "No email drafts match your search query.",
+  showListPreview = false,
+  onCreate,
+  onOpen,
+  onEdit,
+  onSend,
+  onDelete,
+}: EmailDraftsWorkspaceProps) {
+  const [view, setView] = useState<DraftView>(initialView);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const filteredDrafts = useMemo(() => {
+    if (!searchQuery.trim()) return drafts;
+    const query = searchQuery.toLowerCase();
+    return drafts.filter(
+      (draft) =>
+        draft.title.toLowerCase().includes(query) ||
+        draft.previewText?.toLowerCase().includes(query) ||
+        draft.fromName?.toLowerCase().includes(query) ||
+        draft.typeLabel?.toLowerCase().includes(query)
+    );
+  }, [drafts, searchQuery]);
+
+  if (loading) {
+    return (
+      <div className="h-full space-y-8 text-gray-800 bg-white p-8">
+        <div className="flex items-center justify-center h-64">
+          <p className="text-gray-500">{loadingMessage}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="h-full space-y-8 text-gray-800 bg-white p-8">
+        <div className="flex items-center justify-center h-64">
+          <div className="text-center">
+            <p className="text-red-600 font-semibold">Error</p>
+            <p className="text-gray-500 mt-2">{error}</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const isEmpty = filteredDrafts.length === 0;
+  const isSearchResult = searchQuery.trim() !== "" && isEmpty;
+
+  return (
+    <div className="h-full space-y-8 text-gray-800 bg-white">
+      {/* Header */}
+      <div className="flex items-center justify-between px-8 pt-8">
+        <h1 className="text-2xl font-semibold">{pageTitle}</h1>
+        <div className="flex space-x-4">
+          <Button variant="primary" size="md" onClick={onCreate}>
+            Create
+          </Button>
+        </div>
+      </div>
+
+      {/* View Toggle */}
+      <div className="border-t border-b px-8">
+        <DraftViewToggle view={view} onChange={setView} />
+      </div>
+
+      {/* Search */}
+      <div className="flex w-full sm:w-1/2 px-8">
+        <DraftSearchBar
+          value={searchQuery}
+          onChange={setSearchQuery}
+          placeholder={searchPlaceholder}
+          containerClassName="w-full"
+          inputClassName="px-8 pr-10"
+          iconClassName="left-10 text-black"
+        />
+      </div>
+
+      {/* Content */}
+      <div className="px-8 pb-8">
+        {isEmpty ? (
+          <div className="flex items-center justify-center h-64">
+            <div className="text-center">
+              <p className="text-gray-900 font-semibold text-lg">
+                {isSearchResult ? noSearchResultMessage : emptyStateTitle}
+              </p>
+              {!isSearchResult && (
+                <p className="text-gray-500 mt-2">{emptyStateDescription}</p>
+              )}
+            </div>
+          </div>
+        ) : view === "list" ? (
+          <div className="max-w-5xl">
+            <table className="w-full text-sm table-fixed">
+              <thead className="border-b text-gray-600">
+                <tr>
+                  <th className="w-10 p-3 text-left">
+                    <input type="checkbox" className="accent-blue-600" />
+                  </th>
+                  <th className="p-3 text-left font-medium">Name</th>
+                  <th className="p-3 text-left font-medium">Status</th>
+                  <th className="p-3 text-left font-medium">Audience</th>
+                  <th className="p-3 text-right font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredDrafts.map((draft) => (
+                  <EmailDraftListCard
+                    key={draft.id}
+                    title={draft.title}
+                    status={draft.status}
+                    statusLabel={draft.statusLabel}
+                    typeLabel={draft.typeLabel}
+                    date={draft.sendTime}
+                    dateLabel={draft.dateLabel}
+                    recipients={draft.recipients}
+                    audienceLabel={draft.audienceLabel}
+                    onTitleClick={() => onOpen(draft)}
+                    onEdit={() => onEdit(draft)}
+                    onDelete={() => onDelete(draft)}
+                    onSend={() => onSend(draft)}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {filteredDrafts.map((draft) => (
+              <DraftCard
+                key={draft.id}
+                subject={draft.title}
+                previewText={draft.previewText}
+                fromName={draft.fromName}
+                status={draft.status}
+                statusLabel={draft.statusLabel}
+                type={draft.typeLabel}
+                sendTime={draft.sendTime}
+                recipients={draft.recipients}
+                onSubjectClick={() => onOpen(draft)}
+                menu={
+                  <DraftActions
+                    onEdit={() => onEdit(draft)}
+                    onDelete={() => onDelete(draft)}
+                    onSend={() => onSend(draft)}
+                    size="sm"
+                    variant="icons"
+                  />
+                }
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -155,7 +155,7 @@ const Layout: React.FC<LayoutProps> = ({
 
           {/* main content */}
           <main className={`
-            flex-1 overflow-hidden bg-gray-50 
+            flex-1 overflow-hidden bg-white 
             ${isMobile && !isSidebarCollapsed ? 'hidden' : 'block'}
             transition-all duration-300 ease-in-out
           `}>

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -14,6 +14,10 @@ interface LayoutProps {
   sidebarCollapsed?: boolean;
   showHeader?: boolean;
   showSidebar?: boolean;
+  unsavedChangesGuard?: {
+    hasChanges: boolean;
+    onNavigateAway: (destination: string) => void;
+  };
   user?: {
     name: string;
     email: string;
@@ -33,6 +37,7 @@ const Layout: React.FC<LayoutProps> = ({
   showHeader = true,
   showSidebar = true,
   showPermissionRole = false,
+  unsavedChangesGuard,
   user: propUser,
   onUserAction,
   onSearch,
@@ -150,6 +155,7 @@ const Layout: React.FC<LayoutProps> = ({
               onCollapseChange={handleSidebarCollapseChange}
               userRole={user.role}
               userRoleLevel={userRoleLevel}
+              unsavedChangesGuard={unsavedChangesGuard}
             />
           )}
 

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -155,7 +155,7 @@ const Layout: React.FC<LayoutProps> = ({
 
           {/* main content */}
           <main className={`
-            flex-1 overflow-auto bg-gray-50 
+            flex-1 overflow-hidden bg-gray-50 
             ${isMobile && !isSidebarCollapsed ? 'hidden' : 'block'}
             transition-all duration-300 ease-in-out
           `}>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -52,6 +52,10 @@ interface SidebarProps {
   onCollapseChange?: (collapsed: boolean) => void;
   userRole?: string;
   userRoleLevel?: number;
+  unsavedChangesGuard?: {
+    hasChanges: boolean;
+    onNavigateAway: (destination: string) => void;
+  };
 }
 
 // Navigation configuration - can be dynamically adjusted based on user role
@@ -222,6 +226,7 @@ const Sidebar: FC<SidebarProps> = ({
   onCollapseChange,
   userRole = "user",
   userRoleLevel = 10,
+  unsavedChangesGuard,
 }) => {
   const [collapsed, setCollapsed] = useState(defaultCollapsed);
   const [expandedItems, setExpandedItems] = useState<string[]>([]);
@@ -265,6 +270,17 @@ const Sidebar: FC<SidebarProps> = ({
         ? prev.filter((name) => name !== itemName)
         : [...prev, itemName]
     );
+  };
+
+  // Intercept navigation when on Notion page with unsaved changes
+  const handleLinkClick = (e: React.MouseEvent<HTMLAnchorElement>, href: string) => {
+    if (!unsavedChangesGuard?.hasChanges || href === "#") return;
+    const isOnNotion = pathname === "/notion" || pathname.startsWith("/notion/");
+    const isNavigatingAway = href !== "/notion" && !href.startsWith("/notion/");
+    if (isOnNotion && isNavigatingAway) {
+      e.preventDefault();
+      unsavedChangesGuard.onNavigateAway(href);
+    }
   };
 
   // Check if path matches
@@ -399,6 +415,7 @@ const Sidebar: FC<SidebarProps> = ({
                   // <Link href={item.href} className={...}>
                   <a
                     href={item.href}
+                    onClick={(e) => handleLinkClick(e, item.href)}
                     className={`
                       flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200
                       ${
@@ -450,6 +467,7 @@ const Sidebar: FC<SidebarProps> = ({
                       <a
                         key={child.href}
                         href={child.href}
+                        onClick={(e) => handleLinkClick(e, child.href)}
                         className={`
                           flex items-center gap-3 px-3 py-2 text-sm rounded-lg transition-all duration-200
                           ${

--- a/frontend/src/components/notion/NotionDraftList.tsx
+++ b/frontend/src/components/notion/NotionDraftList.tsx
@@ -39,133 +39,108 @@ export default function NotionDraftList({
 }: NotionDraftListProps) {
   // Ensure drafts is always an array
   const safeDrafts = Array.isArray(drafts) ? drafts : [];
-  
+
   return (
-    <aside className="h-full w-72 flex-shrink-0 border-r border-gray-200 bg-white flex flex-col">
-      <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
-        <div>
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-gray-500">
-            Drafts
-          </h2>
-          <p className="text-xs text-gray-400 mt-1">
-            Manage your Notion-style drafts
-          </p>
+    <div className="flex-1 overflow-y-auto min-h-0">
+      {isLoading ? (
+        <div className="p-4 space-y-3">
+          {Array.from({ length: 4 }).map((_, idx) => (
+            <div
+              key={idx}
+              className="h-14 rounded-md bg-gray-100 animate-pulse"
+            />
+          ))}
         </div>
-        <button
-          type="button"
-          onClick={onCreate}
-          className="rounded-md bg-blue-600 px-2.5 py-1.5 text-xs font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-        >
-          New
-        </button>
-      </div>
-      <div className="flex-1 overflow-y-auto">
-        {isLoading ? (
-          <div className="p-4 space-y-3">
-            {Array.from({ length: 4 }).map((_, idx) => (
-              <div
-                key={idx}
-                className="h-14 rounded-md bg-gray-100 animate-pulse"
-              />
-            ))}
-          </div>
-        ) : safeDrafts.length === 0 ? (
-          <div className="p-6 text-sm text-gray-500 leading-relaxed">
-            No drafts yet. Click <span className="font-semibold">New</span> to
-            start a document.
-          </div>
-        ) : (
-          <ul className="py-2">
-            {safeDrafts.map((draft) => {
-              // Validate draft.id exists and is valid
-              if (!draft || draft.id === undefined || draft.id === null) {
-                return null;
-              }
-              
-              // Ensure draft.id is a valid number or string
-              const draftId = typeof draft.id === 'string' ? parseInt(draft.id, 10) : draft.id;
-              if (isNaN(draftId) || draftId <= 0) {
-                return null;
-              }
-              
-              const isSelected = draftId === selectedId;
-              const timestamp = formatTimestamp(draft.updated_at);
-              return (
-                <li key={draftId}>
-                  <div
-                    role="button"
-                    tabIndex={0}
-                    onClick={(e) => {
+      ) : safeDrafts.length === 0 ? (
+        <div className="p-6 text-sm text-gray-500 leading-relaxed">
+          No drafts yet. Click <span className="font-semibold">New</span> to
+          start a document.
+        </div>
+      ) : (
+        <ul className="py-2">
+          {safeDrafts.map((draft) => {
+            // Validate draft.id exists and is valid
+            if (!draft || draft.id === undefined || draft.id === null) {
+              return null;
+            }
+
+            // Ensure draft.id is a valid number or string
+            const draftId = typeof draft.id === 'string' ? parseInt(draft.id, 10) : draft.id;
+            if (isNaN(draftId) || draftId <= 0) {
+              return null;
+            }
+
+            const isSelected = draftId === selectedId;
+            const timestamp = formatTimestamp(draft.updated_at);
+            return (
+              <li key={draftId} className="group">
+                <div
+                  role="button"
+                  tabIndex={0}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (draftId) {
+                      onSelect(draftId);
+                    }
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
                       e.preventDefault();
-                      e.stopPropagation();
                       if (draftId) {
                         onSelect(draftId);
                       }
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        if (draftId) {
-                          onSelect(draftId);
-                        }
-                      }
-                    }}
-                    className={`w-full text-left px-4 py-3 transition-colors cursor-pointer ${
-                      isSelected
-                        ? 'bg-blue-50 border-l-4 border-blue-500'
-                        : 'hover:bg-gray-100'
+                    }
+                  }}
+                  className={`w-full text-left py-1.5 px-3 transition-colors cursor-pointer flex items-center justify-between gap-2 ${
+                    isSelected
+                      ? 'bg-blue-50 border-l-2 border-blue-500'
+                      : 'hover:bg-gray-100'
+                  }`}
+                >
+                  <p
+                    className={`text-sm truncate min-w-0 max-w-full ${
+                      isSelected ? 'text-blue-600 font-medium' : 'text-gray-900'
                     }`}
                   >
-                    <div className="flex items-center justify-between gap-2">
-                      <p
-                        className={`text-sm font-medium ${
-                          isSelected ? 'text-blue-700' : 'text-gray-900'
-                        }`}
+                    {draft.title || 'Untitled'}
+                  </p>
+                  <div className="flex items-center gap-1 flex-shrink-0">
+                    <span className="text-xs text-gray-400 whitespace-nowrap">
+                      {timestamp}
+                    </span>
+                    {onDelete ? (
+                      <button
+                        type="button"
+                        onClick={(event) => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          onDelete(draft.id);
+                        }}
+                        className="opacity-0 group-hover:opacity-100 flex-shrink-0 text-gray-400 hover:text-red-500 transition-opacity"
+                        aria-label="Delete draft"
                       >
-                        {draft.title || 'Untitled'}
-                      </p>
-                      {onDelete ? (
-                        <button
-                          type="button"
-                          onClick={(event) => {
-                            event.preventDefault();
-                            event.stopPropagation();
-                            onDelete(draft.id);
-                          }}
-                          className="text-gray-400 hover:text-red-500 focus:text-red-500 transition"
-                          aria-label="Delete draft"
+                        <svg
+                          className="h-4 w-4"
+                          viewBox="0 0 20 20"
+                          fill="currentColor"
+                          aria-hidden="true"
                         >
-                          <svg
-                            className="h-4 w-4"
-                            viewBox="0 0 20 20"
-                            fill="currentColor"
-                            aria-hidden="true"
-                          >
-                            <path
-                              fillRule="evenodd"
-                              d="M8.5 3a1 1 0 00-.894.553L7.382 4H5a1 1 0 100 2h10a1 1 0 100-2h-2.382l-.224-.447A1 1 0 0011.5 3h-3zm-3 5a1 1 0 011 1v6a1 1 0 102 0V9a1 1 0 112 0v6a1 1 0 102 0V9a1 1 0 112 0v6a3 3 0 01-3 3H8.5a3 3 0 01-3-3V9a1 1 0 011-1z"
-                              clipRule="evenodd"
-                            />
-                          </svg>
-                        </button>
-                      ) : null}
-                    </div>
-                    <div className="mt-1 flex items-center justify-between">
-                      <span className="text-xs uppercase tracking-wide text-gray-400">
-                        {draft.status}
-                      </span>
-                      <span className="text-xs text-gray-400">
-                        {timestamp}
-                      </span>
-                    </div>
+                          <path
+                            fillRule="evenodd"
+                            d="M8.5 3a1 1 0 00-.894.553L7.382 4H5a1 1 0 100 2h10a1 1 0 100-2h-2.382l-.224-.447A1 1 0 0011.5 3h-3zm-3 5a1 1 0 011 1v6a1 1 0 102 0V9a1 1 0 112 0v6a1 1 0 102 0V9a1 1 0 112 0v6a3 3 0 01-3 3H8.5a3 3 0 01-3-3V9a1 1 0 011-1z"
+                            clipRule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    ) : null}
                   </div>
-                </li>
-              );
-            })}
-          </ul>
-        )}
-      </div>
-    </aside>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
   );
 }
-

--- a/frontend/src/components/notion/NotionEditor.tsx
+++ b/frontend/src/components/notion/NotionEditor.tsx
@@ -3074,17 +3074,14 @@ export default function NotionEditor({ blocks, setBlocks, draftId }: NotionEdito
   }, []);
 
   return (
-    <div className="relative flex h-full min-h-0 overflow-hidden">
-      {/* Inner scroller: hidden scrollbar, right gutter for minimap */}
+    <div className="relative h-full min-h-0 overflow-hidden">
       <div
         ref={editorScrollRef}
-        className="flex-1 min-h-0 h-full min-w-0 overflow-y-auto overflow-x-visible overscroll-contain pr-[64px] scrollbar-hide"
-        style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
+        className="absolute inset-0 overflow-y-auto overflow-x-hidden overscroll-contain"
         data-notion-editor-container
       >
-        <div className="flex-1 min-w-0">
-          <div className="flex-1 pb-24 relative">
-            <div className="max-w-3xl mx-auto w-full py-10 pr-16 space-y-0 relative">
+        <div className="flex-1 min-w-0 pb-24">
+          <div className="max-w-3xl mx-auto w-full py-10 px-8 space-y-0 relative">
           {displayBlocks.map((block, index) => {
             const isActive = block.id === activeBlockId;
             const isHovered = hoveredBlockId === block.id;
@@ -3737,7 +3734,6 @@ export default function NotionEditor({ blocks, setBlocks, draftId }: NotionEdito
             );
           })}
           </div>
-        </div>
         </div>
       </div>
 

--- a/frontend/src/components/notion/NotionEditor.tsx
+++ b/frontend/src/components/notion/NotionEditor.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { EditorBlock, NotionBlockType } from '@/types/notion';
 import { NotionDraftAPI } from '@/lib/api/notionDraftApi';
+import useOutline from '@/hooks/useOutline';
+import OutlineOverlay from './OutlineOverlay';
 import { toast } from 'react-hot-toast';
 
 type Command = 'bold' | 'italic' | 'underline' | 'link';
@@ -794,6 +796,18 @@ export default function NotionEditor({ blocks, setBlocks, draftId }: NotionEdito
   const [highlightedCode, setHighlightedCode] = useState<Record<string, string>>({});
   const [resizingColumn, setResizingColumn] = useState<{ blockId: string; columnIndex: number } | null>(null);
   const resizingRef = useRef<{ blockId: string; columnIndex: number; startX: number; startWidth: number } | null>(null);
+
+  const editorScrollRef = useRef<HTMLDivElement>(null);
+  const [scrollReady, setScrollReady] = useState(false);
+
+  useLayoutEffect(() => {
+    if (editorScrollRef.current) {
+      setScrollReady(true);
+    }
+  }, []);
+
+  const { outlineItems, activeOutlineId, hoveredOutlineId, setHoveredOutlineId, handleOutlineClick } =
+    useOutline(blocks, editorScrollRef, scrollReady);
 
   const activeBlock = useMemo(
     () => blocks.find((block) => block.id === activeBlockId) || null,
@@ -3060,12 +3074,17 @@ export default function NotionEditor({ blocks, setBlocks, draftId }: NotionEdito
   }, []);
 
   return (
-    <div className="flex-1 flex flex-col bg-white h-full">
-      <div 
-        className="flex-1 pb-24 relative"
+    <div className="relative flex h-full min-h-0 overflow-hidden">
+      {/* Inner scroller: hidden scrollbar, right gutter for minimap */}
+      <div
+        ref={editorScrollRef}
+        className="flex-1 min-h-0 h-full min-w-0 overflow-y-auto overflow-x-visible overscroll-contain pr-[64px] scrollbar-hide"
+        style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
         data-notion-editor-container
       >
-        <div className="max-w-3xl mx-auto w-full py-10 space-y-0 relative">
+        <div className="flex-1 min-w-0">
+          <div className="flex-1 pb-24 relative">
+            <div className="max-w-3xl mx-auto w-full py-10 pr-16 space-y-0 relative">
           {displayBlocks.map((block, index) => {
             const isActive = block.id === activeBlockId;
             const isHovered = hoveredBlockId === block.id;
@@ -3717,8 +3736,19 @@ export default function NotionEditor({ blocks, setBlocks, draftId }: NotionEdito
               </div>
             );
           })}
+          </div>
+        </div>
         </div>
       </div>
+
+      <OutlineOverlay
+        items={outlineItems}
+        activeId={activeOutlineId}
+        hoveredId={hoveredOutlineId}
+        setHoveredId={setHoveredOutlineId}
+        onItemClick={handleOutlineClick}
+        editorScrollRef={editorScrollRef}
+      />
 
       {/* Command Menu */}
       {showCommandMenu && activeBlockId && (

--- a/frontend/src/components/notion/NotionLayout.tsx
+++ b/frontend/src/components/notion/NotionLayout.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import React from 'react';
+import { ChevronDown, Plus, Search } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import NotionDraftList from '@/components/notion/NotionDraftList';
+import NotionEditor from '@/components/notion/NotionEditor';
+import { DraftSummary, EditorBlock } from '@/types/notion';
+
+interface NotionLayoutProps {
+  drafts: DraftSummary[];
+  selectedDraftId: number | null;
+  onSelectDraft: (draftId: number | string | null | undefined) => void | Promise<void>;
+  onCreateDraft: () => void | Promise<void>;
+  onDeleteDraft: (draftId: number) => void | Promise<void>;
+  isDraftListLoading: boolean;
+  title: string;
+  onTitleChange: (value: string) => void;
+  lastEditedLabel: string | null;
+  onOpenPreview: () => void;
+  onSave: () => void | Promise<void>;
+  isSaving: boolean;
+  hasChanges: boolean;
+  isLoadingEditor: boolean;
+  blocks: EditorBlock[];
+  setBlocks: React.Dispatch<React.SetStateAction<EditorBlock[]>>;
+  isPreviewOpen: boolean;
+  onClosePreview: () => void;
+}
+
+export default function NotionLayout({
+  drafts,
+  selectedDraftId,
+  onSelectDraft,
+  onCreateDraft,
+  onDeleteDraft,
+  isDraftListLoading,
+  title,
+  onTitleChange,
+  lastEditedLabel,
+  onOpenPreview,
+  onSave,
+  isSaving,
+  hasChanges,
+  isLoadingEditor,
+  blocks,
+  setBlocks,
+  isPreviewOpen,
+  onClosePreview,
+}: NotionLayoutProps) {
+  const router = useRouter();
+
+  return (
+    <div className="flex h-full w-full overflow-hidden bg-white">
+      <aside className="w-60 flex-shrink-0 bg-[#f7f7f5] border-r border-gray-200 flex flex-col overflow-hidden">
+        <div className="flex items-center justify-between px-3 py-3 hover:bg-gray-200/60 cursor-pointer">
+          <div className="flex items-center gap-2">
+            <div className="w-5 h-5 bg-blue-600 rounded flex items-center justify-center">
+              <div className="w-2.5 h-2.5 bg-white rounded-sm" />
+            </div>
+            <span className="text-sm font-semibold text-gray-800">MediaJira</span>
+          </div>
+          <ChevronDown className="h-3.5 w-3.5 text-gray-500" />
+        </div>
+
+        <div className="px-2 space-y-0.5">
+          <button
+            type="button"
+            className="w-full flex items-center gap-2.5 px-2 py-1.5 text-sm text-gray-600 hover:bg-gray-200/70 rounded-md transition-colors"
+          >
+            <Search className="h-3.5 w-3.5" />
+            Search
+          </button>
+          <button
+            type="button"
+            onClick={onCreateDraft}
+            className="w-full flex items-center gap-2.5 px-2 py-1.5 text-sm text-gray-600 hover:bg-gray-200/70 rounded-md transition-colors"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            New page
+          </button>
+        </div>
+
+        <div className="mx-3 my-2 border-t border-gray-200" />
+
+        <div className="px-4 mb-1">
+          <span className="text-xs font-medium text-gray-400 uppercase tracking-wider">Drafts</span>
+        </div>
+
+        <div className="flex-1 min-h-0 overflow-hidden">
+          <NotionDraftList
+            drafts={drafts}
+            selectedId={selectedDraftId}
+            onSelect={onSelectDraft}
+            onCreate={onCreateDraft}
+            onDelete={onDeleteDraft}
+            isLoading={isDraftListLoading}
+          />
+        </div>
+      </aside>
+
+      <div className="flex-1 flex min-h-0 flex-col overflow-hidden bg-white">
+        <div className="sticky top-0 z-20 border-b border-gray-100 bg-white/80 backdrop-blur-sm px-6 py-3 flex items-center gap-4">
+          <input
+            type="text"
+            value={title}
+            onChange={(event) => onTitleChange(event.target.value)}
+            placeholder="Untitled"
+            className="flex-1 border-0 focus:ring-0 text-4xl font-bold text-gray-900 placeholder:text-gray-300 bg-transparent"
+            disabled={!selectedDraftId}
+          />
+          {lastEditedLabel && (
+            <span aria-live="polite" className="text-sm text-gray-500 whitespace-nowrap">
+              {lastEditedLabel}
+            </span>
+          )}
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onOpenPreview}
+              className="px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100 rounded-md transition-colors disabled:opacity-60"
+              disabled={!selectedDraftId}
+            >
+              Preview
+            </button>
+            <button
+              type="button"
+              onClick={onSave}
+              className="px-3 py-1.5 text-sm bg-blue-600 text-white hover:bg-blue-700 rounded-md transition-colors font-medium disabled:opacity-60"
+              disabled={!selectedDraftId || isSaving || !hasChanges}
+            >
+              {isSaving ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </div>
+
+        <div className="flex-1 min-h-0 overflow-hidden">
+          {isLoadingEditor ? (
+            <div className="h-full flex items-center justify-center text-gray-400">
+              Loading draft…
+            </div>
+          ) : selectedDraftId ? (
+            <div className="h-full">
+              <NotionEditor
+                blocks={blocks}
+                setBlocks={setBlocks}
+                draftId={selectedDraftId || undefined}
+              />
+            </div>
+          ) : (
+            <div className="h-full flex flex-col items-center justify-center text-center text-gray-400 space-y-3 px-16">
+              <h2 className="text-4xl font-bold text-gray-900">No draft selected</h2>
+              <p className="max-w-md text-base text-gray-800 leading-relaxed">
+                Create a new draft or select one from the sidebar to start writing with
+                the Notion-style editor.
+              </p>
+              <button
+                type="button"
+                onClick={onCreateDraft}
+                className="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+              >
+                New draft
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {isPreviewOpen && (
+        <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/40 px-4 py-8">
+          <div className="relative flex flex-col max-h-[90vh] w-full max-w-3xl rounded-xl bg-white shadow-2xl">
+            <div className="flex-shrink-0 h-16 border-b border-gray-200 bg-white px-6 flex items-center">
+              <div className="flex-1">
+                <h3 className="text-lg font-semibold text-gray-900">{title || 'Untitled'}</h3>
+                <p className="text-sm text-gray-500">Preview mode</p>
+              </div>
+              <button
+                type="button"
+                onClick={onClosePreview}
+                className="rounded-full bg-gray-100 p-2 text-gray-500 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                aria-label="Close preview"
+              >
+                <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                  <path
+                    fillRule="evenodd"
+                    d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </button>
+            </div>
+            <div className="flex-1 overflow-y-auto p-8 space-y-6 min-h-0">
+              {blocks.map((block) => {
+                if (block.type === 'divider') {
+                  return (
+                    <div key={block.id} className="w-full border-t border-gray-300 my-4" />
+                  );
+                }
+                if (
+                  block.type === 'image' ||
+                  block.type === 'video' ||
+                  block.type === 'audio' ||
+                  block.type === 'file' ||
+                  block.type === 'web_bookmark'
+                ) {
+                  return (
+                    <div
+                      key={block.id}
+                      className="prose prose-gray max-w-none"
+                      dangerouslySetInnerHTML={{ __html: block.html || '' }}
+                    />
+                  );
+                }
+                if (!block.html) {
+                  return (
+                    <div key={block.id} className="text-gray-300 italic">
+                      Empty block
+                    </div>
+                  );
+                }
+                return (
+                  <div
+                    key={block.id}
+                    className="prose prose-gray max-w-none"
+                    dangerouslySetInnerHTML={{ __html: block.html }}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/notion/OutlineOverlay.tsx
+++ b/frontend/src/components/notion/OutlineOverlay.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+import { OutlineItem } from '@/hooks/useOutline';
+import OutlineSidebar from './OutlineSidebar';
+
+interface OutlineOverlayProps {
+  items: OutlineItem[];
+  activeId: string | null;
+  hoveredId: string | null;
+  setHoveredId: (id: string | null) => void;
+  onItemClick: (id: string) => void;
+  editorScrollRef?: RefObject<HTMLDivElement | null>;
+}
+
+/** Unified pill geometry: interaction zone = visual zone */
+const PILL_GEOMETRY = { top: '38%', height: '65vh' } as const;
+const VIEWPORT_INDICATOR_WIDTH = 6;
+
+export default function OutlineOverlay({
+  items,
+  activeId,
+  hoveredId,
+  setHoveredId,
+  onItemClick,
+  editorScrollRef,
+}: OutlineOverlayProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [viewportIndicator, setViewportIndicator] = useState<{ top: number; height: number } | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const root = editorScrollRef?.current;
+    if (!root) return;
+
+    const updateIndicator = () => {
+      const { scrollTop, scrollHeight, clientHeight } = root;
+      if (scrollHeight <= clientHeight) {
+        setViewportIndicator(null);
+        return;
+      }
+      const railHeight = clientHeight;
+      const ratio = railHeight / scrollHeight;
+      setViewportIndicator({
+        top: (scrollTop / scrollHeight) * railHeight,
+        height: Math.max(20, ratio * railHeight),
+      });
+    };
+
+    const handleScroll = () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(updateIndicator);
+    };
+
+    updateIndicator();
+    root.addEventListener('scroll', handleScroll, { passive: true });
+    const resizeObs = new ResizeObserver(handleScroll);
+    resizeObs.observe(root);
+
+    return () => {
+      root.removeEventListener('scroll', handleScroll);
+      resizeObs.disconnect();
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [editorScrollRef]);
+
+  return (
+    <div
+      className="absolute inset-y-0 right-0 w-[64px] pointer-events-none z-20 no-scrollbar overflow-visible"
+      style={{ overflow: 'visible', scrollbarWidth: 'none', msOverflowStyle: 'none' }}
+    >
+      {/* Hover bridge: uses PILL_GEOMETRY when collapsed; expands to cover TOC when open */}
+      <div
+        className={`absolute right-0 inset-y-0 w-[288px] no-scrollbar ${isExpanded ? 'pointer-events-auto' : 'pointer-events-none'}`}
+        style={{ overflow: 'visible', scrollbarWidth: 'none', msOverflowStyle: 'none' }}
+        onMouseLeave={() => setIsExpanded(false)}
+      >
+        {/* Visual pill: hit-area = PILL_GEOMETRY, only receives hover when collapsed */}
+        <div
+          className="absolute right-0 -translate-y-1/2 w-[6px] rounded-full flex flex-col bg-transparent cursor-pointer z-30 transition-opacity duration-200 ease-in-out pointer-events-auto no-scrollbar"
+          style={{
+            top: PILL_GEOMETRY.top,
+            height: PILL_GEOMETRY.height,
+            transform: 'translateY(-50%)',
+            opacity: isExpanded ? 0 : 1,
+            visibility: isExpanded ? 'hidden' : 'visible',
+          }}
+          aria-label="Outline"
+          onMouseEnter={() => setIsExpanded(true)}
+        >
+          {viewportIndicator && !isExpanded && (
+            <div
+              className="absolute rounded z-20 pointer-events-none"
+              style={{
+                left: (6 - VIEWPORT_INDICATOR_WIDTH) / 2,
+                top: viewportIndicator.top,
+                width: VIEWPORT_INDICATOR_WIDTH,
+                height: viewportIndicator.height,
+                backgroundColor: 'rgba(156, 163, 175, 0.02)',
+                border: '1px solid rgba(156, 163, 175, 0.05)',
+              }}
+            />
+          )}
+          <OutlineSidebar
+            variant="pills"
+            items={items.length ? items.filter((_, i) => i % 2 === 0) : Array(4).fill(null)}
+            activeId={activeId}
+            hoveredId={hoveredId}
+            setHoveredId={setHoveredId}
+            onItemClick={onItemClick}
+          />
+        </div>
+        {/* TOC Panel: floating card, glassmorphism */}
+        <div
+          className={`absolute top-12 right-0 bottom-12 w-64 z-10 max-h-[calc(100vh-6rem)] overflow-hidden rounded-2xl shadow-2xl transition-all duration-200 ease-in-out bg-white/95 backdrop-blur-[10px] border border-gray-100 dark:border-white/10 dark:bg-white/90 ${isExpanded ? 'pointer-events-auto' : 'pointer-events-none'}`}
+          style={{
+            transform: isExpanded ? 'translateX(0)' : 'translateX(20px)',
+            opacity: isExpanded ? 1 : 0,
+          }}
+        >
+          <div
+            className={`h-full max-h-[calc(100%-32px)] flex flex-col min-h-0 py-4 ${isExpanded ? 'overflow-y-auto' : 'overflow-visible'}`}
+          >
+            <OutlineSidebar
+              variant="list"
+              items={items}
+              activeId={activeId}
+              hoveredId={hoveredId}
+              setHoveredId={setHoveredId}
+              onItemClick={onItemClick}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/notion/OutlineOverlay.tsx
+++ b/frontend/src/components/notion/OutlineOverlay.tsx
@@ -14,9 +14,11 @@ interface OutlineOverlayProps {
   editorScrollRef?: RefObject<HTMLDivElement | null>;
 }
 
-/** Unified pill geometry: interaction zone = visual zone */
-const PILL_GEOMETRY = { top: '38%', height: '65vh' } as const;
-const VIEWPORT_INDICATOR_WIDTH = 6;
+/** H1 pill width (24px) + padding (4px) for viewport indicator */
+const VIEWPORT_INDICATOR_WIDTH = 16;
+const VIEWPORT_INDICATOR_RADIUS = 3;
+const VIEWPORT_INDICATOR_BG = 'rgba(55, 53, 47, 0.04)';
+const VIEWPORT_INDICATOR_BORDER = '1px solid rgba(55, 53, 47, 0.08)';
 
 export default function OutlineOverlay({
   items,
@@ -26,9 +28,22 @@ export default function OutlineOverlay({
   onItemClick,
   editorScrollRef,
 }: OutlineOverlayProps) {
+  const MINIMAP_RIGHT = 20;
+  const PILL_WIDTH = 28;
+  const TOC_GAP = 8;
+  const TOC_WIDTH = 280;
+  const TOC_RADIUS = 16;
+  const TOC_BG = '#fdfdfc';
+  const TOC_BORDER = '1px solid rgba(55,53,47,0.08)';
+  const TOC_SHADOW = '0 20px 60px rgba(0,0,0,0.06)';
+  const ANIMATION_DURATION = 160;
+  const ANIMATION_EASING = 'cubic-bezier(0.4, 0, 0.2, 1)';
+
   const [isExpanded, setIsExpanded] = useState(false);
   const [viewportIndicator, setViewportIndicator] = useState<{ top: number; height: number } | null>(null);
   const rafRef = useRef<number | null>(null);
+  const handleMouseEnter = () => setIsExpanded(true);
+  const handleMouseLeave = () => setIsExpanded(false);
 
   useEffect(() => {
     const root = editorScrollRef?.current;
@@ -66,73 +81,143 @@ export default function OutlineOverlay({
   }, [editorScrollRef]);
 
   return (
-    <div
-      className="absolute inset-y-0 right-0 w-[64px] pointer-events-none z-20 no-scrollbar overflow-visible"
-      style={{ overflow: 'visible', scrollbarWidth: 'none', msOverflowStyle: 'none' }}
-    >
-      {/* Hover bridge: uses PILL_GEOMETRY when collapsed; expands to cover TOC when open */}
+    <div className="pointer-events-none">
+      {/* Single Anchor: fixed root, handles hover. Child A (Minimap) and Child B (Panel) are siblings. */}
       <div
-        className={`absolute right-0 inset-y-0 w-[288px] no-scrollbar ${isExpanded ? 'pointer-events-auto' : 'pointer-events-none'}`}
-        style={{ overflow: 'visible', scrollbarWidth: 'none', msOverflowStyle: 'none' }}
-        onMouseLeave={() => setIsExpanded(false)}
+        className="outline-overlay-anchor"
+        style={{
+          position: 'fixed',
+          top: '24%',
+          bottom: '14%',
+          right: MINIMAP_RIGHT,
+          width: isExpanded ? PILL_WIDTH + TOC_GAP + TOC_WIDTH : PILL_WIDTH,
+          transition: `width ${ANIMATION_DURATION}ms ${ANIMATION_EASING}`,
+          zIndex: 50,
+          pointerEvents: 'auto',
+        }}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
       >
-        {/* Visual pill: hit-area = PILL_GEOMETRY, only receives hover when collapsed */}
+        {/* Child A: Minimap Track — pills only, scrollbar nuked */}
         <div
-          className="absolute right-0 -translate-y-1/2 w-[6px] rounded-full flex flex-col bg-transparent cursor-pointer z-30 transition-opacity duration-200 ease-in-out pointer-events-auto no-scrollbar"
+          className="outline-minimap-track"
           style={{
-            top: PILL_GEOMETRY.top,
-            height: PILL_GEOMETRY.height,
-            transform: 'translateY(-50%)',
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            width: PILL_WIDTH,
+            height: '100%',
+            zIndex: 1,
+            pointerEvents: 'none',
             opacity: isExpanded ? 0 : 1,
-            visibility: isExpanded ? 'hidden' : 'visible',
+            transition: `opacity ${ANIMATION_DURATION}ms ${ANIMATION_EASING}`,
+            overflow: 'hidden',
+            scrollbarWidth: 'none',
+            msOverflowStyle: 'none',
           }}
-          aria-label="Outline"
-          onMouseEnter={() => setIsExpanded(true)}
+          aria-label="Outline minimap"
         >
           {viewportIndicator && !isExpanded && (
             <div
               className="absolute rounded z-20 pointer-events-none"
               style={{
-                left: (6 - VIEWPORT_INDICATOR_WIDTH) / 2,
+                left: (PILL_WIDTH - VIEWPORT_INDICATOR_WIDTH) / 2,
                 top: viewportIndicator.top,
                 width: VIEWPORT_INDICATOR_WIDTH,
                 height: viewportIndicator.height,
-                backgroundColor: 'rgba(156, 163, 175, 0.02)',
-                border: '1px solid rgba(156, 163, 175, 0.05)',
+                borderRadius: VIEWPORT_INDICATOR_RADIUS,
+                backgroundColor: VIEWPORT_INDICATOR_BG,
+                border: VIEWPORT_INDICATOR_BORDER,
               }}
             />
           )}
           <OutlineSidebar
             variant="pills"
-            items={items.length ? items.filter((_, i) => i % 2 === 0) : Array(4).fill(null)}
+            items={items}
             activeId={activeId}
             hoveredId={hoveredId}
             setHoveredId={setHoveredId}
             onItemClick={onItemClick}
           />
         </div>
-        {/* TOC Panel: floating card, glassmorphism */}
+        {/* Child B: Expanded Panel — appears on hover, has custom scrollbar with arrows */}
         <div
-          className={`absolute top-12 right-0 bottom-12 w-64 z-10 max-h-[calc(100vh-6rem)] overflow-hidden rounded-2xl shadow-2xl transition-all duration-200 ease-in-out bg-white/95 backdrop-blur-[10px] border border-gray-100 dark:border-white/10 dark:bg-white/90 ${isExpanded ? 'pointer-events-auto' : 'pointer-events-none'}`}
           style={{
-            transform: isExpanded ? 'translateX(0)' : 'translateX(20px)',
+            position: 'absolute',
+            top: 0,
+            right: PILL_WIDTH + TOC_GAP,
+            width: TOC_WIDTH,
+            height: '100%',
+            zIndex: 2,
+            pointerEvents: isExpanded ? 'auto' : 'none',
+            visibility: isExpanded ? 'visible' : 'hidden',
+            transform: isExpanded ? 'translateX(0)' : 'translateX(6px)',
             opacity: isExpanded ? 1 : 0,
+            transition: `opacity ${ANIMATION_DURATION}ms ${ANIMATION_EASING}, transform ${ANIMATION_DURATION}ms ${ANIMATION_EASING}`,
+            borderRadius: TOC_RADIUS,
+            backgroundColor: isExpanded ? TOC_BG : 'transparent',
+            border: TOC_BORDER,
+            boxShadow: TOC_SHADOW,
           }}
         >
           <div
-            className={`h-full max-h-[calc(100%-32px)] flex flex-col min-h-0 py-4 ${isExpanded ? 'overflow-y-auto' : 'overflow-visible'}`}
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              height: '100%',
+              paddingTop: 16,
+              paddingBottom: 16,
+              boxSizing: 'border-box',
+            }}
           >
-            <OutlineSidebar
-              variant="list"
-              items={items}
-              activeId={activeId}
-              hoveredId={hoveredId}
-              setHoveredId={setHoveredId}
-              onItemClick={onItemClick}
-            />
+            <div
+              className="outline-overlay-scroll"
+              style={{
+                flex: 1,
+                overflowY: 'auto',
+                minHeight: 0,
+              }}
+            >
+              <OutlineSidebar
+                variant="list"
+                items={items}
+                activeId={activeId}
+                hoveredId={hoveredId}
+                setHoveredId={setHoveredId}
+                onItemClick={onItemClick}
+              />
+            </div>
           </div>
         </div>
       </div>
+      <style>{`
+        .outline-minimap-track::-webkit-scrollbar {
+          display: none !important;
+        }
+        .outline-overlay-scroll::-webkit-scrollbar {
+          display: block;
+          width: 12px;
+        }
+        .outline-overlay-scroll::-webkit-scrollbar-track {
+          background: transparent;
+        }
+        .outline-overlay-scroll::-webkit-scrollbar-thumb {
+          background-color: rgba(156, 163, 175, 0.5);
+          border-radius: 6px;
+          border: 3px solid transparent;
+          background-clip: padding-box;
+        }
+        .outline-overlay-scroll::-webkit-scrollbar-button:single-button:vertical:decrement {
+          display: block;
+          height: 12px;
+          background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath fill='%236b7280' d='M4 1L1 7h6z'/%3E%3C/svg%3E") no-repeat center;
+        }
+        .outline-overlay-scroll::-webkit-scrollbar-button:single-button:vertical:increment {
+          display: block;
+          height: 12px;
+          background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath fill='%236b7280' d='M4 7L7 1H1z'/%3E%3C/svg%3E") no-repeat center;
+        }
+      `}</style>
     </div>
   );
 }

--- a/frontend/src/components/notion/OutlineSidebar.tsx
+++ b/frontend/src/components/notion/OutlineSidebar.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { OutlineItem } from '@/hooks/useOutline';
+
+interface OutlineSidebarProps {
+  variant: 'pills' | 'list';
+  items: OutlineItem[];
+  activeId: string | null;
+  hoveredId?: string | null;
+  setHoveredId?: (id: string | null) => void;
+  onItemClick: (id: string) => void;
+}
+
+/** Notion-style micro-map: H1=24px, H2=16px, H3=8px, right-aligned */
+const THUMB_WIDTH = { 1: 24, 2: 16, 3: 8 } as const;
+
+export default function OutlineSidebar({
+  variant,
+  items,
+  activeId,
+  hoveredId = null,
+  setHoveredId,
+  onItemClick,
+}: OutlineSidebarProps) {
+  if (variant === 'pills') {
+    return (
+      <div
+        className="flex flex-col items-end justify-center flex-1 min-h-0 py-3"
+        style={{ gap: 8, padding: 3 }}
+      >
+        {(items.length ? items : Array(8).fill(null)).map((item, i) => {
+          const level = (item ? item.level : ([1, 2, 3, 1, 2, 3, 1, 2] as const)[i % 8]) as 1 | 2 | 3;
+          const wid = THUMB_WIDTH[level];
+          const isActive = item && activeId === item.id;
+          const isHovered = item && hoveredId === item.id && !isActive;
+          const pillColor = isActive ? '#2383E2' : isHovered ? '#9ca3af' : '#d1d5db';
+          return (
+            <button
+              key={item?.id ?? i}
+              type="button"
+              className="cursor-pointer border-0 bg-transparent p-0 m-0 rounded-full"
+              style={{
+                width: wid,
+                height: 3,
+                background: pillColor,
+              }}
+              onClick={() => item && onItemClick(item.id)}
+              onMouseEnter={() => item && setHoveredId?.(item.id)}
+              onMouseLeave={() => setHoveredId?.(null)}
+              aria-label={item ? item.label || 'Outline item' : undefined}
+            />
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0 py-3">
+      {items.length === 0 ? (
+        <div
+          style={{
+            padding: '12px 20px',
+            fontSize: 12,
+            color: '#9ca3af',
+            fontStyle: 'italic',
+          }}
+        >
+          Add headings to see outline
+        </div>
+      ) : (
+        items.map((item) => {
+          const isActive = activeId === item.id;
+          const isHovered = hoveredId === item.id && !isActive;
+          const bgStyle = isActive ? 'rgba(239, 246, 255, 0.5)' : isHovered ? '#f3f4f6' : 'transparent';
+          const barColor = isActive ? '#3b82f6' : 'transparent';
+          const fontWeight = isActive ? 600 : 400;
+          const textColor = isActive ? '#111' : '#6b7280';
+          return (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => onItemClick(item.id)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                width: '100%',
+                minHeight: 32,
+                padding: '0 12px 0 0',
+                paddingLeft: 0,
+                margin: 0,
+                border: 'none',
+                borderLeft: isActive ? '2px solid #3b82f6' : '2px solid transparent',
+                background: bgStyle,
+                cursor: 'pointer',
+                textAlign: 'left',
+                borderRadius: 0,
+                transition: 'background 0.1s, border-color 0.1s',
+              }}
+              onMouseEnter={() => setHoveredId?.(item.id)}
+              onMouseLeave={() => setHoveredId?.(null)}
+            >
+              <div
+                style={{
+                  width: 3,
+                  alignSelf: 'stretch',
+                  flexShrink: 0,
+                  background: barColor,
+                  borderRadius: '0 2px 2px 0',
+                  marginRight: 0,
+                  transition: 'background 0.15s',
+                }}
+              />
+              <span
+                style={{
+                  paddingLeft: item.level === 1 ? 17 : item.level === 2 ? 29 : 41,
+                  paddingRight: 20,
+                  fontSize: 13,
+                  lineHeight: '1.4',
+                  fontWeight,
+                  color: textColor,
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  flex: 1,
+                  minWidth: 0,
+                }}
+              >
+                {item.label || 'Untitled heading'}
+              </span>
+            </button>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/notion/OutlineSidebar.tsx
+++ b/frontend/src/components/notion/OutlineSidebar.tsx
@@ -10,8 +10,12 @@ interface OutlineSidebarProps {
   onItemClick: (id: string) => void;
 }
 
-/** Notion-style micro-map: H1=24px, H2=16px, H3=8px, right-aligned */
-const THUMB_WIDTH = { 1: 24, 2: 16, 3: 8 } as const;
+const MAX_PILLS = 30;
+const PILL_BG = 'rgba(55,53,47,0.18)';
+const PILL_ACTIVE = 'rgba(55,53,47,0.6)';
+const PILL_HOVER = 'rgba(55,53,47,0.35)';
+/** Notion-style horizontal dashes: L1=16px, L2=12px, L3=8px */
+const PILL_WIDTH_BY_LEVEL = { 1: 16, 2: 12, 3: 8 } as const;
 
 export default function OutlineSidebar({
   variant,
@@ -24,29 +28,44 @@ export default function OutlineSidebar({
   if (variant === 'pills') {
     return (
       <div
-        className="flex flex-col items-end justify-center flex-1 min-h-0 py-3"
-        style={{ gap: 8, padding: 3 }}
+        className="flex flex-col items-end justify-between w-full h-full"
+        style={{ paddingTop: '2vh', paddingBottom: '22vh' }}
       >
-        {(items.length ? items : Array(8).fill(null)).map((item, i) => {
-          const level = (item ? item.level : ([1, 2, 3, 1, 2, 3, 1, 2] as const)[i % 8]) as 1 | 2 | 3;
-          const wid = THUMB_WIDTH[level];
-          const isActive = item && activeId === item.id;
-          const isHovered = item && hoveredId === item.id && !isActive;
-          const pillColor = isActive ? '#2383E2' : isHovered ? '#9ca3af' : '#d1d5db';
+        {Array.from({ length: MAX_PILLS }, (_, i) => {
+          const item = items[i];
+          if (item) {
+            const level = item.level as 1 | 2 | 3;
+            const isActive = activeId === item.id;
+            const isHovered = hoveredId === item.id && !isActive;
+            const pillColor = isActive ? PILL_ACTIVE : isHovered ? PILL_HOVER : PILL_BG;
+            return (
+              <button
+                key={item.id}
+                type="button"
+                className="cursor-pointer border-0 bg-transparent p-0 m-0 h-[3px] rounded-full shrink-0"
+                style={{
+                  width: PILL_WIDTH_BY_LEVEL[level],
+                  background: pillColor,
+                  transition: 'opacity 160ms cubic-bezier(0.4,0,0.2,1), background 160ms cubic-bezier(0.4,0,0.2,1)',
+                }}
+                onClick={() => onItemClick(item.id)}
+                onMouseEnter={() => setHoveredId?.(item.id)}
+                onMouseLeave={() => setHoveredId?.(null)}
+                aria-label={item.label || 'Outline item'}
+              />
+            );
+          }
           return (
             <button
-              key={item?.id ?? i}
+              key={`placeholder-${i}`}
               type="button"
-              className="cursor-pointer border-0 bg-transparent p-0 m-0 rounded-full"
+              disabled
+              className="h-[3px] rounded-full shrink-0 border-0 bg-transparent p-0 m-0"
               style={{
-                width: wid,
-                height: 3,
-                background: pillColor,
+                width: 10,
+                background: 'rgba(55,53,47,0.07)',
+                cursor: 'default',
               }}
-              onClick={() => item && onItemClick(item.id)}
-              onMouseEnter={() => item && setHoveredId?.(item.id)}
-              onMouseLeave={() => setHoveredId?.(null)}
-              aria-label={item ? item.label || 'Outline item' : undefined}
             />
           );
         })}
@@ -55,7 +74,7 @@ export default function OutlineSidebar({
   }
 
   return (
-    <div className="flex flex-col flex-1 min-h-0 py-3">
+    <div className="flex flex-col py-3">
       {items.length === 0 ? (
         <div
           style={{

--- a/frontend/src/hooks/useOutline.ts
+++ b/frontend/src/hooks/useOutline.ts
@@ -1,0 +1,95 @@
+import type { RefObject } from 'react';
+import { useMemo, useRef, useState, useCallback } from 'react';
+import { EditorBlock } from '@/types/notion';
+import useOutlineObserver from './useOutlineObserver';
+
+const HEADING_TYPES = new Set([
+  'heading_1',
+  'heading_2',
+  'heading_3',
+  'heading',
+  'h1',
+  'h2',
+  'h3',
+]);
+
+const headingLevel = (type: string): number => {
+  if (type === 'heading_1' || type === 'h1') return 1;
+  if (type === 'heading_2' || type === 'h2') return 2;
+  return 3;
+};
+
+const stripHtml = (html: string): string => {
+  if (typeof document === 'undefined') return html;
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  return div.textContent || div.innerText || '';
+};
+
+export interface OutlineItem {
+  id: string;
+  label: string;
+  level: number;
+}
+
+export default function useOutline(
+  blocks: EditorBlock[],
+  editorScrollRef: RefObject<HTMLDivElement | null>,
+  scrollReady: boolean
+) {
+  const [activeOutlineId, setActiveOutlineId] = useState<string | null>(null);
+
+  const outlineItems = useMemo<OutlineItem[]>(() => {
+    return blocks
+      .filter((b) => HEADING_TYPES.has(b.type))
+      .map((b) => ({
+        id: b.id,
+        label: stripHtml(b.html),
+        level: headingLevel(b.type),
+      }));
+  }, [blocks]);
+
+  const [hoveredOutlineId, setHoveredOutlineId] = useState<string | null>(null);
+  const scrollLockTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isScrollingRef = useRef(false);
+
+  const handleOutlineClick = useCallback(
+    (blockId: string) => {
+      const container = editorScrollRef.current;
+      if (!container) return;
+
+      setActiveOutlineId(blockId);
+      isScrollingRef.current = true;
+      if (scrollLockTimerRef.current) clearTimeout(scrollLockTimerRef.current);
+
+      const el = document.querySelector(`[data-block-id="${blockId}"]`) as HTMLElement | null;
+      if (el) {
+        const elRect = el.getBoundingClientRect();
+        const containerRect = container.getBoundingClientRect();
+        const scrollTop = container.scrollTop + (elRect.top - containerRect.top);
+        container.scrollTo({ top: scrollTop, behavior: 'instant' });
+      }
+      scrollLockTimerRef.current = setTimeout(() => {
+        isScrollingRef.current = false;
+      }, 150);
+    },
+    [editorScrollRef]
+  );
+
+  useOutlineObserver({
+    outlineItems,
+    setActiveOutlineId,
+    isScrollingRef,
+    scrollRootRef: editorScrollRef,
+    scrollReady,
+  });
+
+  return {
+    outlineItems,
+    activeOutlineId,
+    hoveredOutlineId,
+    setHoveredOutlineId,
+    handleOutlineClick,
+    resetActiveOutlineId: () => setActiveOutlineId(null),
+  };
+}

--- a/frontend/src/hooks/useOutlineObserver.ts
+++ b/frontend/src/hooks/useOutlineObserver.ts
@@ -1,0 +1,87 @@
+import type { Dispatch, RefObject, SetStateAction } from 'react';
+import { useEffect, useRef } from 'react';
+import { OutlineItem } from './useOutline';
+
+interface UseOutlineObserverProps {
+  outlineItems: OutlineItem[];
+  setActiveOutlineId: Dispatch<SetStateAction<string | null>>;
+  isScrollingRef: React.MutableRefObject<boolean>;
+  scrollRootRef: RefObject<HTMLDivElement | null>;
+  scrollReady: boolean;
+}
+
+export default function useOutlineObserver({
+  outlineItems,
+  setActiveOutlineId,
+  isScrollingRef,
+  scrollRootRef,
+  scrollReady,
+}: UseOutlineObserverProps) {
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (outlineItems.length === 0) {
+      setActiveOutlineId(null);
+      return;
+    }
+
+    const root = scrollRootRef.current;
+    if (!scrollReady || !root) {
+      return;
+    }
+
+    if (observerRef.current) observerRef.current.disconnect();
+
+    const visibleMap = new Map<string, number>();
+
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          const id = entry.target.getAttribute('data-block-id');
+          if (!id) return;
+
+          if (entry.isIntersecting) {
+            visibleMap.set(id, entry.intersectionRatio);
+          } else {
+            visibleMap.delete(id);
+          }
+        });
+
+        if (isScrollingRef.current) return;
+
+        if (rafRef.current) cancelAnimationFrame(rafRef.current);
+
+        rafRef.current = requestAnimationFrame(() => {
+          if (visibleMap.size === 0) {
+            setActiveOutlineId(null);
+            return;
+          }
+          const topId = [...visibleMap.entries()]
+            .sort((a, b) => b[1] - a[1])[0][0];
+          setActiveOutlineId((prev: string | null) => (prev !== topId ? topId : prev));
+        });
+      },
+      {
+        root,
+        rootMargin: '0px 0px -70% 0px',
+        threshold: [0, 0.1, 0.5, 1],
+      }
+    );
+
+    const timer = setTimeout(() => {
+      outlineItems.forEach(({ id }) => {
+        const el = document.querySelector(
+          `[data-block-id="${id}"]`
+        );
+        if (el) observerRef.current?.observe(el);
+      });
+    }, 50);
+
+    return () => {
+      clearTimeout(timer);
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      observerRef.current?.disconnect();
+    };
+  }, [outlineItems, scrollReady]);
+}


### PR DESCRIPTION
1.Implemented a fixed right-side minimap with pill-shaped indicators representing document headings
2.Created the panel that expands from the minimap,Custom scrollbar with single up/down arrows (fixed double-arrow bug)
3.useOutline + useOutlineObserver decoupled from editor into independent hooks
4.Removed duplicate <aside> shell from NotionDraftList — parent NotionLayout owns the container
5.Wrapped Notion page with global Layout component to restore navigation sidebar
