### PR TITLE
SMP-499: Enforce minimum approvals before task lock + cross-project approval chain fixes

### DIFF
--- a/backend/task/admin.py
+++ b/backend/task/admin.py
@@ -10,8 +10,9 @@ class ApprovalChainStepInline(admin.TabularInline):
 
 @admin.register(ApprovalChain)
 class ApprovalChainAdmin(admin.ModelAdmin):
-    list_display = ['name', 'project', 'task_type', 'total_steps', 'created_at']
+    list_display = ['name', 'project', 'task_type', 'total_steps', 'required_approvals', 'created_at']
     list_filter = ['task_type', 'project']
+    fields = ['name', 'project', 'task_type', 'required_approvals']
     inlines = [ApprovalChainStepInline]
 
     def total_steps(self, obj):

--- a/backend/task/migrations/0003_approvalchain_required_approvals.py
+++ b/backend/task/migrations/0003_approvalchain_required_approvals.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('task', '0002_add_approval_chain_models'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='approvalchain',
+            name='required_approvals',
+            field=models.PositiveIntegerField(
+                blank=True,
+                null=True,
+                help_text=(
+                    'Minimum number of approved ApprovalRecords required before the task can be locked. '
+                    'Defaults to total_steps (all steps must be approved) when null.'
+                ),
+            ),
+        ),
+    ]

--- a/backend/task/models.py
+++ b/backend/task/models.py
@@ -440,6 +440,14 @@ class ApprovalChain(models.Model):
         blank=True,
         help_text="Task type this chain applies to. Leave blank to apply to all task types."
     )
+    required_approvals = models.PositiveIntegerField(
+        null=True,
+        blank=True,
+        help_text=(
+            "Minimum number of approved ApprovalRecords required before the task can be locked. "
+            "Defaults to total_steps (all steps must be approved) when null."
+        )
+    )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
@@ -460,6 +468,14 @@ class ApprovalChain(models.Model):
     def total_steps(self):
         """Total number of steps in this chain."""
         return self.steps.count()
+
+    @property
+    def effective_required_approvals(self):
+        """
+        The effective minimum approval count before locking is allowed.
+        Falls back to total_steps when required_approvals is not explicitly set.
+        """
+        return self.required_approvals if self.required_approvals is not None else self.total_steps
 
     def get_step(self, step_number):
         """Return the ApprovalChainStep for the given 1-based step number, or None."""

--- a/backend/task/serializers.py
+++ b/backend/task/serializers.py
@@ -37,6 +37,8 @@ class TaskSerializer(serializers.ModelSerializer):
     parent_relationship = serializers.SerializerMethodField()
     order_in_project = serializers.IntegerField(required=False)
     approval_chain_progress = serializers.SerializerMethodField()
+    can_lock = serializers.SerializerMethodField()
+    approvals_summary = serializers.SerializerMethodField()
 
     class Meta:
         model = Task
@@ -47,8 +49,13 @@ class TaskSerializer(serializers.ModelSerializer):
             'content_type', 'object_id', 'start_date', 'due_date',
             'is_subtask', 'parent_relationship', 'order_in_project',
             'anomaly_status', 'approval_chain_progress',
+            'can_lock', 'approvals_summary',
         ]
-        read_only_fields = ['id', 'status', 'owner', 'content_type', 'object_id', 'is_subtask', 'parent_relationship', 'anomaly_status', 'approval_chain_progress']
+        read_only_fields = [
+            'id', 'status', 'owner', 'content_type', 'object_id',
+            'is_subtask', 'parent_relationship', 'anomaly_status',
+            'approval_chain_progress', 'can_lock', 'approvals_summary',
+        ]
 
     def get_approval_chain_progress(self, obj):
         """
@@ -135,7 +142,41 @@ class TaskSerializer(serializers.ModelSerializer):
             'next_approver': UserSummarySerializer(next_step.approver).data if next_step else None,
             'steps': steps,
         }
-    
+
+    def get_can_lock(self, obj):
+        """
+        Returns True if the task is allowed to be locked right now.
+
+        Rules:
+        - Task must be in APPROVED status.
+        - If an approval chain is assigned, the number of approved records
+          must meet the chain's effective_required_approvals threshold.
+        - Legacy tasks (no chain) can always be locked once APPROVED.
+        """
+        if obj.status != 'APPROVED':
+            return False
+        if not obj.approval_chain:
+            return True  # Legacy mode: no minimum required
+        approved_count = obj.approval_records.filter(is_approved=True).count()
+        return approved_count >= obj.approval_chain.effective_required_approvals
+
+    def get_approvals_summary(self, obj):
+        """
+        Returns a human-readable approval progress summary for chain-mode tasks.
+
+        Example: { "approved_count": 1, "required_count": 2, "display": "1 of 2 approvals" }
+        Returns None for legacy tasks (no chain assigned).
+        """
+        if not obj.approval_chain:
+            return None
+        approved_count = obj.approval_records.filter(is_approved=True).count()
+        required = obj.approval_chain.effective_required_approvals
+        return {
+            'approved_count': approved_count,
+            'required_count': required,
+            'display': f'{approved_count} of {required} approvals',
+        }
+
     def create(self, validated_data):
         """Create a new task"""
         user = self.context['request'].user

--- a/backend/task/tests/test_views.py
+++ b/backend/task/tests/test_views.py
@@ -3,7 +3,7 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework.test import APIClient
 from rest_framework import status
-from task.models import Task
+from task.models import Task, ApprovalRecord
 from core.models import Project, Organization, Team, AdChannel, ProjectMember
 from budget_approval.models import BudgetPool, BudgetRequest
 from asset.models import Asset
@@ -70,6 +70,10 @@ class TaskAPITest(TestCase):
         # Setup API client
         self.client = APIClient()
         self.client.force_authenticate(user=self.user)
+
+        # Setup approver client (authenticated as self.approver)
+        self.approver_client = APIClient()
+        self.approver_client.force_authenticate(user=self.approver)
     
     def create_task_with_status(self, status, **kwargs):
         """
@@ -905,14 +909,14 @@ class TaskAPITest(TestCase):
             project=self.project,
             current_approver=self.approver
         )
-        
+
         url = reverse('task-make-approval', kwargs={'pk': task.id})
         data = {
             'action': 'approve',
             'comment': 'Approved for budget allocation'
         }
-        
-        response = self.client.post(url, data, format='json')
+
+        response = self.approver_client.post(url, data, format='json')
         
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         
@@ -971,14 +975,14 @@ class TaskAPITest(TestCase):
             project=self.project,
             current_approver=self.approver
         )
-        
+
         url = reverse('task-make-approval', kwargs={'pk': task.id})
         data = {
             'action': 'reject',
             'comment': 'Insufficient budget documentation'
         }
-        
-        response = self.client.post(url, data, format='json')
+
+        response = self.approver_client.post(url, data, format='json')
         
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         
@@ -1098,15 +1102,15 @@ class TaskAPITest(TestCase):
         # Approve again (second step)
         url = reverse('task-make-approval', kwargs={'pk': task.id})
         data = {'action': 'approve', 'comment': 'Second approval'}
-        
-        response = self.client.post(url, data, format='json')
-        
+
+        response = self.approver_client.post(url, data, format='json')
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        
+
         # Check response contains approval_record and task
         self.assertIn('approval_record', response.data)
         self.assertIn('task', response.data)
-        
+
         # Check approval record data
         approval_record = response.data['approval_record']
         self.assertIn('id', approval_record)
@@ -1114,7 +1118,7 @@ class TaskAPITest(TestCase):
         self.assertIn('is_approved', approval_record)
         self.assertIn('comment', approval_record)
         self.assertIn('step_number', approval_record)
-        
+
         self.assertEqual(approval_record['approved_by']['id'], self.approver.id)
         self.assertTrue(approval_record['is_approved'])
         self.assertEqual(approval_record['comment'], 'Second approval')
@@ -1138,15 +1142,15 @@ class TaskAPITest(TestCase):
             project=self.project,
             current_approver=self.approver
         )
-        
+
         url = reverse('task-make-approval', kwargs={'pk': task.id})
         data = {'action': 'invalid_action', 'comment': 'Should not work'}
-        
-        response = self.client.post(url, data, format='json')
-        
+
+        response = self.approver_client.post(url, data, format='json')
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(task.approval_records.count(), 0)
-    
+
     def test_make_approval_missing_action(self):
         """Test make-approval with missing action"""
         task = self.create_task_with_status(
@@ -1157,12 +1161,12 @@ class TaskAPITest(TestCase):
             project=self.project,
             current_approver=self.approver
         )
-        
+
         url = reverse('task-make-approval', kwargs={'pk': task.id})
         data = {'comment': 'Should not work'}
-        
-        response = self.client.post(url, data, format='json')
-        
+
+        response = self.approver_client.post(url, data, format='json')
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(task.approval_records.count(), 0)
     
@@ -1777,8 +1781,11 @@ class TaskAPITest(TestCase):
         task.current_approval_step = 1
         task.save()
 
+        step1_client = APIClient()
+        step1_client.force_authenticate(user=step1_approver)
+
         url = reverse('task-make-approval', kwargs={'pk': task.id})
-        response = self.client.post(url, {'action': 'approve', 'comment': 'Step 1 done'}, format='json')
+        response = step1_client.post(url, {'action': 'approve', 'comment': 'Step 1 done'}, format='json')
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         task_data = response.data['task']
@@ -1841,8 +1848,11 @@ class TaskAPITest(TestCase):
             step_number=1
         )
 
+        step2_client = APIClient()
+        step2_client.force_authenticate(user=step2_approver)
+
         url = reverse('task-make-approval', kwargs={'pk': task.id})
-        response = self.client.post(url, {'action': 'approve', 'comment': 'Final approval'}, format='json')
+        response = step2_client.post(url, {'action': 'approve', 'comment': 'Final approval'}, format='json')
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         task_data = response.data['task']
@@ -1912,7 +1922,7 @@ class TaskAPITest(TestCase):
         self.assertIn('error', response.data)
 
         # Task status must not have changed
-        task.refresh_from_db()
+        task = Task.objects.get(pk=task.pk)
         self.assertEqual(task.status, Task.Status.APPROVED)
 
     def test_lock_allowed_when_chain_fully_approved(self):
@@ -1965,7 +1975,7 @@ class TaskAPITest(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['task']['status'], 'LOCKED')
 
-        task.refresh_from_db()
+        task = Task.objects.get(pk=task.pk)
         self.assertEqual(task.status, Task.Status.LOCKED)
 
     def test_lock_legacy_mode_no_chain_still_works(self):

--- a/backend/task/tests/test_views.py
+++ b/backend/task/tests/test_views.py
@@ -1858,3 +1858,302 @@ class TaskAPITest(TestCase):
         final_record = task.approval_records.get(step_number=2)
         self.assertTrue(final_record.is_approved)
         self.assertEqual(final_record.comment, 'Final approval')
+
+    # --- SMP-499: Minimum Approvals Before Lock Tests ---
+
+    def test_lock_blocked_when_chain_not_fully_approved(self):
+        """Lock must be blocked when approval chain steps are not all completed."""
+        from task.models import ApprovalChain, ApprovalChainStep
+
+        step1_approver = User.objects.create_user(
+            email='smp499_step1@example.com',
+            username='smp499_step1',
+            password='testpass123'
+        )
+        step2_approver = User.objects.create_user(
+            email='smp499_step2@example.com',
+            username='smp499_step2',
+            password='testpass123'
+        )
+        chain = ApprovalChain.objects.create(
+            name='Buyer → Client',
+            project=self.project,
+            task_type='budget'
+        )
+        ApprovalChainStep.objects.create(chain=chain, order=1, approver=step1_approver)
+        ApprovalChainStep.objects.create(chain=chain, order=2, approver=step2_approver)
+
+        # Task is APPROVED but only step 1 has been approved (step 2 pending)
+        task = self.create_task_with_status(
+            Task.Status.APPROVED,
+            summary='Budget Task Partial',
+            type='budget',
+            owner=self.user,
+            project=self.project,
+        )
+        task.approval_chain = chain
+        task.current_approval_step = 2
+        task.save()
+
+        # Record only step 1 approval
+        ApprovalRecord.objects.create(
+            task=task,
+            approved_by=step1_approver,
+            is_approved=True,
+            comment='Step 1 done',
+            step_number=1
+        )
+
+        url = reverse('task-lock', kwargs={'pk': task.id})
+        response = self.client.post(url, {}, format='json')
+
+        # Must be blocked: only 1 of 2 approvals completed
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('error', response.data)
+
+        # Task status must not have changed
+        task.refresh_from_db()
+        self.assertEqual(task.status, Task.Status.APPROVED)
+
+    def test_lock_allowed_when_chain_fully_approved(self):
+        """Lock must succeed when all chain steps have been approved."""
+        from task.models import ApprovalChain, ApprovalChainStep
+
+        step1_approver = User.objects.create_user(
+            email='smp499_full1@example.com',
+            username='smp499_full1',
+            password='testpass123'
+        )
+        step2_approver = User.objects.create_user(
+            email='smp499_full2@example.com',
+            username='smp499_full2',
+            password='testpass123'
+        )
+        chain = ApprovalChain.objects.create(
+            name='Buyer → Client',
+            project=self.project,
+            task_type='report'
+        )
+        ApprovalChainStep.objects.create(chain=chain, order=1, approver=step1_approver)
+        ApprovalChainStep.objects.create(chain=chain, order=2, approver=step2_approver)
+
+        # Task is APPROVED with both steps approved
+        task = self.create_task_with_status(
+            Task.Status.APPROVED,
+            summary='Report Task Full',
+            type='report',
+            owner=self.user,
+            project=self.project,
+        )
+        task.approval_chain = chain
+        task.current_approval_step = 2
+        task.save()
+
+        ApprovalRecord.objects.create(
+            task=task, approved_by=step1_approver,
+            is_approved=True, comment='Step 1', step_number=1
+        )
+        ApprovalRecord.objects.create(
+            task=task, approved_by=step2_approver,
+            is_approved=True, comment='Step 2', step_number=2
+        )
+
+        url = reverse('task-lock', kwargs={'pk': task.id})
+        response = self.client.post(url, {}, format='json')
+
+        # Must succeed: all 2 of 2 approvals are done
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['task']['status'], 'LOCKED')
+
+        task.refresh_from_db()
+        self.assertEqual(task.status, Task.Status.LOCKED)
+
+    def test_lock_legacy_mode_no_chain_still_works(self):
+        """Legacy tasks (no approval chain) must still be lockable after APPROVED."""
+        task = self.create_task_with_status(
+            Task.Status.APPROVED,
+            summary='Legacy Task',
+            type='budget',
+            owner=self.user,
+            project=self.project,
+            current_approver=self.approver,
+        )
+        # No approval_chain assigned (legacy mode)
+        self.assertIsNone(task.approval_chain)
+
+        url = reverse('task-lock', kwargs={'pk': task.id})
+        response = self.client.post(url, {}, format='json')
+
+        # Must succeed: legacy mode has no minimum requirement
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['task']['status'], 'LOCKED')
+
+    def test_lock_blocked_with_custom_required_approvals(self):
+        """Lock is blocked when required_approvals is set and not yet met."""
+        from task.models import ApprovalChain, ApprovalChainStep
+
+        step1_approver = User.objects.create_user(
+            email='smp499_custom1@example.com',
+            username='smp499_custom1',
+            password='testpass123'
+        )
+        step2_approver = User.objects.create_user(
+            email='smp499_custom2@example.com',
+            username='smp499_custom2',
+            password='testpass123'
+        )
+        step3_approver = User.objects.create_user(
+            email='smp499_custom3@example.com',
+            username='smp499_custom3',
+            password='testpass123'
+        )
+        # 3-step chain but only 2 approvals required (custom required_approvals=2)
+        chain = ApprovalChain.objects.create(
+            name='Buyer → Lead → Client',
+            project=self.project,
+            task_type='experiment',
+            required_approvals=2
+        )
+        ApprovalChainStep.objects.create(chain=chain, order=1, approver=step1_approver)
+        ApprovalChainStep.objects.create(chain=chain, order=2, approver=step2_approver)
+        ApprovalChainStep.objects.create(chain=chain, order=3, approver=step3_approver)
+
+        task = self.create_task_with_status(
+            Task.Status.APPROVED,
+            summary='Experiment Task Custom',
+            type='experiment',
+            owner=self.user,
+            project=self.project,
+        )
+        task.approval_chain = chain
+        task.current_approval_step = 2
+        task.save()
+
+        # Only 1 approval so far — required is 2
+        ApprovalRecord.objects.create(
+            task=task, approved_by=step1_approver,
+            is_approved=True, comment='Step 1', step_number=1
+        )
+
+        url = reverse('task-lock', kwargs={'pk': task.id})
+        response = self.client.post(url, {}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('error', response.data)
+
+    def test_lock_allowed_with_custom_required_approvals_met(self):
+        """Lock is allowed when custom required_approvals threshold is met."""
+        from task.models import ApprovalChain, ApprovalChainStep
+
+        step1_approver = User.objects.create_user(
+            email='smp499_cmet1@example.com',
+            username='smp499_cmet1',
+            password='testpass123'
+        )
+        step2_approver = User.objects.create_user(
+            email='smp499_cmet2@example.com',
+            username='smp499_cmet2',
+            password='testpass123'
+        )
+        step3_approver = User.objects.create_user(
+            email='smp499_cmet3@example.com',
+            username='smp499_cmet3',
+            password='testpass123'
+        )
+        # 3-step chain, only 2 required
+        chain = ApprovalChain.objects.create(
+            name='Buyer → Lead → Client',
+            project=self.project,
+            task_type='scaling',
+            required_approvals=2
+        )
+        ApprovalChainStep.objects.create(chain=chain, order=1, approver=step1_approver)
+        ApprovalChainStep.objects.create(chain=chain, order=2, approver=step2_approver)
+        ApprovalChainStep.objects.create(chain=chain, order=3, approver=step3_approver)
+
+        task = self.create_task_with_status(
+            Task.Status.APPROVED,
+            summary='Scaling Task Custom Met',
+            type='scaling',
+            owner=self.user,
+            project=self.project,
+        )
+        task.approval_chain = chain
+        task.current_approval_step = 2
+        task.save()
+
+        # 2 approvals recorded — required is 2, so threshold is met
+        ApprovalRecord.objects.create(
+            task=task, approved_by=step1_approver,
+            is_approved=True, comment='Step 1', step_number=1
+        )
+        ApprovalRecord.objects.create(
+            task=task, approved_by=step2_approver,
+            is_approved=True, comment='Step 2', step_number=2
+        )
+
+        url = reverse('task-lock', kwargs={'pk': task.id})
+        response = self.client.post(url, {}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['task']['status'], 'LOCKED')
+
+    def test_serializer_can_lock_and_approvals_summary(self):
+        """can_lock and approvals_summary fields are correctly returned in task response."""
+        from task.models import ApprovalChain, ApprovalChainStep
+
+        step1_approver = User.objects.create_user(
+            email='smp499_ser1@example.com',
+            username='smp499_ser1',
+            password='testpass123'
+        )
+        step2_approver = User.objects.create_user(
+            email='smp499_ser2@example.com',
+            username='smp499_ser2',
+            password='testpass123'
+        )
+        chain = ApprovalChain.objects.create(
+            name='Buyer → Client',
+            project=self.project,
+            task_type='alert'
+        )
+        ApprovalChainStep.objects.create(chain=chain, order=1, approver=step1_approver)
+        ApprovalChainStep.objects.create(chain=chain, order=2, approver=step2_approver)
+
+        task = self.create_task_with_status(
+            Task.Status.APPROVED,
+            summary='Alert Task Serializer',
+            type='alert',
+            owner=self.user,
+            project=self.project,
+        )
+        task.approval_chain = chain
+        task.current_approval_step = 2
+        task.save()
+
+        # Only step 1 approved — can_lock should be False
+        ApprovalRecord.objects.create(
+            task=task, approved_by=step1_approver,
+            is_approved=True, comment='Step 1', step_number=1
+        )
+
+        url = reverse('task-detail', kwargs={'pk': task.id})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data['can_lock'])
+        self.assertEqual(response.data['approvals_summary']['approved_count'], 1)
+        self.assertEqual(response.data['approvals_summary']['required_count'], 2)
+        self.assertEqual(response.data['approvals_summary']['display'], '1 of 2 approvals')
+
+        # Now add step 2 approval — can_lock should become True
+        ApprovalRecord.objects.create(
+            task=task, approved_by=step2_approver,
+            is_approved=True, comment='Step 2', step_number=2
+        )
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data['can_lock'])
+        self.assertEqual(response.data['approvals_summary']['approved_count'], 2)
+        self.assertEqual(response.data['approvals_summary']['display'], '2 of 2 approvals')

--- a/backend/task/views.py
+++ b/backend/task/views.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.exceptions import PermissionDenied, ValidationError as DRFValidationError
 from django.core.exceptions import ValidationError
+from django.db.models import Q
 from rest_framework.views import APIView
 from rest_framework.parsers import MultiPartParser, FormParser
 from django.shortcuts import get_object_or_404
@@ -109,13 +110,17 @@ class TaskViewSet(viewsets.ModelViewSet):
             
             # New logic: support all_projects parameter
             if all_projects and accessible_project_ids:
-                queryset = queryset.filter(project_id__in=accessible_project_ids)
+                project_filter = Q(project_id__in=accessible_project_ids)
             elif active_project:
-                queryset = queryset.filter(project_id=active_project.id)
+                project_filter = Q(project_id=active_project.id)
             elif accessible_project_ids:
-                queryset = queryset.filter(project_id__in=accessible_project_ids)
+                project_filter = Q(project_id__in=accessible_project_ids)
             else:
-                return Task.objects.none()
+                project_filter = Q(pk__in=[])  # empty
+
+            # Also include tasks where user is the designated current approver,
+            # even if they are not a member of that project (cross-project approval chain).
+            queryset = queryset.filter(project_filter | Q(current_approver=user))
 
         # Apply filters
         task_type = self.request.query_params.get('type')
@@ -179,14 +184,19 @@ class TaskViewSet(viewsets.ModelViewSet):
         if not user.is_authenticated:
             raise PermissionDenied('Authentication credentials were not provided.')
 
-        # Ensure the user is an active member of the task's project
+        # Ensure the user is an active member of the task's project,
+        # OR is the current designated approver (cross-project approval chain).
         has_membership = ProjectMember.objects.filter(
             user=user,
             project=task.project,
             is_active=True,
         ).exists()
+        is_current_approver = (
+            task.current_approver_id is not None and
+            task.current_approver_id == user.id
+        )
 
-        if not has_membership:
+        if not has_membership and not is_current_approver:
             raise PermissionDenied('You do not have access to this task.')
 
         self.check_object_permissions(self.request, task)
@@ -277,7 +287,14 @@ class TaskViewSet(viewsets.ModelViewSet):
                 {'error': 'Task must be in UNDER_REVIEW status to be approved or rejected'},
                 status=status.HTTP_400_BAD_REQUEST
             )
-        
+
+        # Verify the requesting user is the designated approver for this step
+        if task.current_approver_id and request.user.id != task.current_approver_id:
+            return Response(
+                {'error': 'Only the designated approver for this step can approve or reject.'},
+                status=status.HTTP_403_FORBIDDEN
+            )
+
         # Validate request data
         serializer = TaskApprovalSerializer(data=request.data)
         if not serializer.is_valid():

--- a/backend/task/views.py
+++ b/backend/task/views.py
@@ -98,16 +98,9 @@ class TaskViewSet(viewsets.ModelViewSet):
             if requested_project_id not in accessible_project_ids:
                 raise PermissionDenied('You do not have access to this project.')
 
-            queryset = queryset.filter(project_id=requested_project_id)
+            # User is a member — also include cross-project tasks where they are the current approver.
+            project_filter = Q(project_id=requested_project_id)
         else:
-            # Previous logic (before all_projects support):
-            # if active_project:
-            #     queryset = queryset.filter(project_id=active_project.id)
-            # elif accessible_project_ids:
-            #     queryset = queryset.filter(project_id__in=accessible_project_ids)
-            # else:
-            #     return Task.objects.none()
-            
             # New logic: support all_projects parameter
             if all_projects and accessible_project_ids:
                 project_filter = Q(project_id__in=accessible_project_ids)
@@ -116,11 +109,11 @@ class TaskViewSet(viewsets.ModelViewSet):
             elif accessible_project_ids:
                 project_filter = Q(project_id__in=accessible_project_ids)
             else:
-                project_filter = Q(pk__in=[])  # empty
+                project_filter = Q(pk__in=[])
 
-            # Also include tasks where user is the designated current approver,
-            # even if they are not a member of that project (cross-project approval chain).
-            queryset = queryset.filter(project_filter | Q(current_approver=user))
+        # Always also include tasks where user is the designated current approver,
+        # even across project boundaries (cross-project approval chain support).
+        queryset = queryset.filter(project_filter | Q(current_approver=user))
 
         # Apply filters
         task_type = self.request.query_params.get('type')

--- a/backend/task/views.py
+++ b/backend/task/views.py
@@ -556,7 +556,7 @@ class TaskViewSet(viewsets.ModelViewSet):
     def lock(self, request, pk=None):
         """Lock a task (change status to LOCKED)"""
         task = self.get_object()
-        
+
         # Validate task can be locked
         lockable_statuses = [Task.Status.APPROVED]
         if task.status not in lockable_statuses:
@@ -564,7 +564,22 @@ class TaskViewSet(viewsets.ModelViewSet):
                 {'error': 'Task must be in APPROVED status to be locked'},
                 status=status.HTTP_400_BAD_REQUEST
             )
-        
+
+        # Enforce minimum approval count when an approval chain is assigned
+        if task.approval_chain:
+            approved_count = task.approval_records.filter(is_approved=True).count()
+            required = task.approval_chain.effective_required_approvals
+            if approved_count < required:
+                return Response(
+                    {
+                        'error': (
+                            f'Task requires {required} approval(s) before it can be locked. '
+                            f'{approved_count} of {required} approvals completed.'
+                        )
+                    },
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+
         try:
             # Lock the task
             task.lock()

--- a/backend/task/views.py
+++ b/backend/task/views.py
@@ -805,6 +805,16 @@ class TaskViewSet(viewsets.ModelViewSet):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
+def _user_can_access_task(user, task):
+    """Return True if user is an active project member or the current designated approver.
+
+    Mirrors the same permission check used in TaskViewSet.get_object().
+    """
+    if ProjectMember.objects.filter(user=user, project=task.project, is_active=True).exists():
+        return True
+    return task.current_approver_id is not None and task.current_approver_id == user.id
+
+
 class TaskCommentListView(generics.ListCreateAPIView):
     """
     List comments for a task or create a new task-level comment.
@@ -817,15 +827,7 @@ class TaskCommentListView(generics.ListCreateAPIView):
         task_id = self.kwargs.get('task_id')
         task = get_object_or_404(Task, pk=task_id)
 
-        # Enforce same project-based access control as TaskViewSet
-        user = self.request.user
-        has_membership = ProjectMember.objects.filter(
-            user=user,
-            project=task.project,
-            is_active=True,
-        ).exists()
-
-        if not has_membership:
+        if not _user_can_access_task(self.request.user, task):
             raise PermissionDenied('You do not have access to this task.')
 
         return TaskComment.objects.filter(task_id=task_id)
@@ -834,13 +836,7 @@ class TaskCommentListView(generics.ListCreateAPIView):
         task_id = self.kwargs.get('task_id')
         task = get_object_or_404(Task, pk=task_id)
 
-        has_membership = ProjectMember.objects.filter(
-            user=self.request.user,
-            project=task.project,
-            is_active=True,
-        ).exists()
-
-        if not has_membership:
+        if not _user_can_access_task(self.request.user, task):
             raise PermissionDenied('You do not have access to comment on this task.')
 
         serializer.save(task=task, user=self.request.user)
@@ -859,15 +855,7 @@ class TaskAttachmentListView(generics.ListCreateAPIView):
         task_id = self.kwargs.get('task_id')
         task = get_object_or_404(Task, pk=task_id)
 
-        # Enforce same project-based access control as TaskViewSet
-        user = self.request.user
-        has_membership = ProjectMember.objects.filter(
-            user=user,
-            project=task.project,
-            is_active=True,
-        ).exists()
-
-        if not has_membership:
+        if not _user_can_access_task(self.request.user, task):
             raise PermissionDenied('You do not have access to this task.')
 
         return TaskAttachment.objects.filter(task_id=task_id)
@@ -876,13 +864,7 @@ class TaskAttachmentListView(generics.ListCreateAPIView):
         task_id = self.kwargs.get('task_id')
         task = get_object_or_404(Task, pk=task_id)
 
-        has_membership = ProjectMember.objects.filter(
-            user=self.request.user,
-            project=task.project,
-            is_active=True,
-        ).exists()
-
-        if not has_membership:
+        if not _user_can_access_task(self.request.user, task):
             raise PermissionDenied('You do not have access to upload attachments to this task.')
 
         serializer.save(task=task, uploaded_by=self.request.user)
@@ -899,15 +881,7 @@ class TaskAttachmentDetailView(generics.RetrieveDestroyAPIView):
         task_id = self.kwargs.get('task_id')
         task = get_object_or_404(Task, pk=task_id)
 
-        # Enforce same project-based access control
-        user = self.request.user
-        has_membership = ProjectMember.objects.filter(
-            user=user,
-            project=task.project,
-            is_active=True,
-        ).exists()
-
-        if not has_membership:
+        if not _user_can_access_task(self.request.user, task):
             raise PermissionDenied('You do not have access to this task.')
 
         return TaskAttachment.objects.filter(task_id=task_id)
@@ -931,15 +905,7 @@ class TaskAttachmentDownloadView(APIView):
         # Get the specific attachment
         attachment = get_object_or_404(TaskAttachment, pk=attachment_id, task_id=task_id)
         
-        # Check project membership
-        user = request.user
-        has_membership = ProjectMember.objects.filter(
-            user=user,
-            project=attachment.task.project,
-            is_active=True,
-        ).exists()
-        
-        if not has_membership:
+        if not _user_can_access_task(request.user, attachment.task):
             raise PermissionDenied('You do not have access to this task.')
         
         # Check if the attachment has a file

--- a/frontend/src/components/tasks/TaskDetail.tsx
+++ b/frontend/src/components/tasks/TaskDetail.tsx
@@ -1345,9 +1345,14 @@ export default function TaskDetail({ task, currentUser, onTaskUpdate, onTaskDele
         "Task approved successfully. Status updated to:",
         taskResponse.data.task?.status
       );
-    } catch (error) {
+    } catch (error: any) {
       console.error("Error approving task:", error);
-      toast.error("Failed to approve task. Please try again.");
+      const message =
+        error?.response?.data?.error ||
+        error?.response?.data?.detail ||
+        error?.message ||
+        "Failed to approve task. Please try again.";
+      toast.error(message);
     }
   };
 
@@ -2192,11 +2197,20 @@ export default function TaskDetail({ task, currentUser, onTaskUpdate, onTaskDele
                       <option value="UNDER_REVIEW">Under Review</option>
                       <option value="APPROVED">Approved</option>
                       <option value="REJECTED">Rejected</option>
-                      <option value="LOCKED">Locked</option>
+                      <option value="LOCKED" disabled={task.can_lock === false}>
+                        Locked{task.approvals_summary && task.approvals_summary.approved_count < task.approvals_summary.required_count ? ` (${task.approvals_summary.display})` : ""}
+                      </option>
                       <option value="CANCELLED">Cancelled</option>
                     </select>
                   </div>
                 </div>
+                {/* Approvals progress hint (SMP-499) */}
+                {task.approvals_summary &&
+                  task.approvals_summary.approved_count < task.approvals_summary.required_count && (
+                  <div className="mt-1 text-xs text-amber-600">
+                    {task.approvals_summary.display} required to lock
+                  </div>
+                )}
                 {/* Work type - locked */}
                 <div className={jiraDetailRowClass}>
                   <label className={jiraDetailLabelClass}>

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -51,6 +51,12 @@ export interface TaskData {
   parent_relationship?: any; // Parent relationship if this is a subtask
   order_in_project?: number; // Order of task within its project
   approval_chain_progress?: ApprovalChainProgress | null;
+  can_lock?: boolean;
+  approvals_summary?: {
+    approved_count: number;
+    required_count: number;
+    display: string;
+  } | null;
 }
 
 // Type for creating a new task (current_approver_id is user ID)


### PR DESCRIPTION
## Summary

- Enforce that all approval chain steps must be completed before a task can be locked (SMP-499 core requirement)
- Fix: only the designated approver for each step can approve/reject (previously any user could approve)
- Fix: cross-project approvers can now see and access tasks where they are the `current_approver`, even if they are not a project member
- Fix: Comments and Attachments sub-endpoints now grant access to the current designated approver (mirrors `get_object` permission logic)

## Changes

- `backend/task/views.py`
  - `get_queryset`: always include `Q(current_approver=user)` alongside project filter for cross-project visibility
  - `get_object`: allow access if user is `current_approver`, not just project member
  - `make_approval`: block approval if `request.user != task.current_approver`
  - `lock`: enforce `approved_count >= effective_required_approvals` before allowing lock
  - `_user_can_access_task()`: new helper (project member OR current approver) used by comment/attachment views
- `backend/task/tests/test_views.py`
  - Added `approver_client` fixture; updated approval tests to use designated approver
  - Fixed `refresh_from_db()` → `Task.objects.get(pk=...)` for FSM-protected field compatibility
  - Updated 2 tests to reflect new behaviour for non-member `project_id` filter (still 403)

## Test plan

- [ ] All 2975 backend tests pass (`OK skipped=15`)
- [ ] QA checklist completed by reviewer
- [ ] Approval chain full flow verified: DCDD (Buyer) → caiguanjie (Lead) → caiguanjie (Client) → Lock
- [ ] Non-designated approver correctly blocked with 403
- [ ] Cross-project task visibility confirmed for approvers

🤖 Generated with [Claude Code](https://claude.com/claude-code)