### PR TITLE
AGENT-QuickFix1: fix theme, URL routing, chart colors, English response

### DIFF
--- a/backend/agent/views.py
+++ b/backend/agent/views.py
@@ -39,6 +39,13 @@ from . import data_service
 logger = logging.getLogger(__name__)
 
 
+class EnglishResponseMixin:
+    """Force English for DRF validation messages in all agent views."""
+    def initial(self, request, *args, **kwargs):
+        activate_language('en')
+        super().initial(request, *args, **kwargs)
+
+
 def _get_user_project(request):
     """Get the active project for the current user, with membership check."""
     project_id = request.headers.get('X-Project-Id') or request.query_params.get('project_id')
@@ -53,7 +60,7 @@ def _get_user_project(request):
     return getattr(request.user, 'active_project', None)
 
 
-class AgentSessionViewSet(viewsets.ModelViewSet):
+class AgentSessionViewSet(EnglishResponseMixin, viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     pagination_class = None
     http_method_names = ['get', 'post', 'patch', 'delete', 'head', 'options']
@@ -89,12 +96,11 @@ class AgentSessionViewSet(viewsets.ModelViewSet):
         instance.save()
 
 
-class ChatView(APIView):
+class ChatView(EnglishResponseMixin, APIView):
     permission_classes = [IsAuthenticated]
     renderer_classes = [EventStreamRenderer, JSONRenderer]
 
     def post(self, request, session_id):
-        activate_language('en')
         serializer = ChatInputSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
@@ -183,7 +189,7 @@ class ChatView(APIView):
         return response
 
 
-class SpreadsheetListView(APIView):
+class SpreadsheetListView(EnglishResponseMixin, APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
@@ -201,7 +207,7 @@ class SpreadsheetListView(APIView):
 
 
 
-class DataReportListView(APIView):
+class DataReportListView(EnglishResponseMixin, APIView):
     """GET /api/agent/data/reports/ — list imported CSV files."""
     permission_classes = [IsAuthenticated]
 
@@ -216,7 +222,7 @@ class DataReportListView(APIView):
         return Response(reports)
 
 
-class DataReportDetailView(APIView):
+class DataReportDetailView(EnglishResponseMixin, APIView):
     """GET/DELETE /api/agent/data/reports/<uuid:file_id>/"""
     permission_classes = [IsAuthenticated]
 
@@ -251,7 +257,7 @@ class DataReportDetailView(APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class DataUploadView(APIView):
+class DataUploadView(EnglishResponseMixin, APIView):
     """POST /api/agent/data/upload/ — upload a CSV file."""
     permission_classes = [IsAuthenticated]
     parser_classes = [MultiPartParser, FormParser]
@@ -294,14 +300,13 @@ class DataUploadView(APIView):
         return Response(result, status=status.HTTP_201_CREATED)
 
 
-class FileUploadAnalyzeView(APIView):
+class FileUploadAnalyzeView(EnglishResponseMixin, APIView):
     """POST /api/agent/upload-analyze/ — upload a file and stream analysis."""
     permission_classes = [IsAuthenticated]
     parser_classes = [MultiPartParser, FormParser]
     renderer_classes = [EventStreamRenderer, JSONRenderer]
 
     def post(self, request):
-        activate_language('en')
         project = _get_user_project(request)
         if not project:
             return Response(
@@ -418,7 +423,7 @@ class FileUploadAnalyzeView(APIView):
         return response
 
 
-class DataReportSummaryView(APIView):
+class DataReportSummaryView(EnglishResponseMixin, APIView):
     """GET /api/agent/data/reports/summary/ — aggregated KPI data."""
     permission_classes = [IsAuthenticated]
 
@@ -435,7 +440,7 @@ class DataReportSummaryView(APIView):
         return Response(summary)
 
 
-class DecisionStatsView(APIView):
+class DecisionStatsView(EnglishResponseMixin, APIView):
     """GET /api/agent/decisions/stats/ — Decision status counts."""
     permission_classes = [IsAuthenticated]
 
@@ -455,7 +460,7 @@ class DecisionStatsView(APIView):
         return Response(stats)
 
 
-class DecisionRecentView(APIView):
+class DecisionRecentView(EnglishResponseMixin, APIView):
     """GET /api/agent/decisions/recent/ — latest 5 decisions."""
     permission_classes = [IsAuthenticated]
 
@@ -483,7 +488,7 @@ class DecisionRecentView(APIView):
         return Response(result)
 
 
-class AnomalyLatestView(APIView):
+class AnomalyLatestView(EnglishResponseMixin, APIView):
     """GET /api/agent/anomalies/latest/ — latest anomalies from most recent analysis."""
     permission_classes = [IsAuthenticated]
 

--- a/frontend/src/components/agent/AgentLayoutContext.tsx
+++ b/frontend/src/components/agent/AgentLayoutContext.tsx
@@ -36,15 +36,15 @@ interface AgentLayoutContextType {
 const AgentLayoutContext = createContext<AgentLayoutContextType | null>(null)
 
 function getSystemTheme(): "light" | "dark" {
-  if (typeof window === "undefined") return "dark"
+  if (typeof window === "undefined") return "light"
   return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
 }
 
 export function AgentLayoutProvider({ children }: { children: ReactNode }) {
   const [activeView, setActiveViewState] = useState<AgentView>("overview")
   const [isRightPanelOpen, setIsRightPanelOpen] = useState(true)
-  const [theme, setThemeState] = useState<AgentTheme>("dark")
-  const [systemTheme, setSystemTheme] = useState<"light" | "dark">("dark")
+  const [theme, setThemeState] = useState<AgentTheme>("light")
+  const [systemTheme, setSystemTheme] = useState<"light" | "dark">("light")
   const [isInSnapZone, setIsInSnapZone] = useState(false)
   const [pendingDecisionId, setPendingDecisionId] = useState<number | null>(null)
 
@@ -69,27 +69,31 @@ export function AgentLayoutProvider({ children }: { children: ReactNode }) {
     } else if (storedView && ["overview", "spreadsheets", "decisions", "tasks"].includes(storedView)) {
       setActiveViewState(storedView as AgentView)
     }
-    const stored = localStorage.getItem("agent-theme") as AgentTheme | null
-    if (stored && ["light", "dark", "system"].includes(stored)) {
-      setThemeState(stored)
-    }
-    setSystemTheme(getSystemTheme())
+    // Theme forced to light — MediaJira does not support dark mode yet
+    // const stored = localStorage.getItem("agent-theme") as AgentTheme | null
+    // if (stored && ["light", "dark", "system"].includes(stored)) {
+    //   setThemeState(stored)
+    // }
+    // setSystemTheme(getSystemTheme())
   }, [])
 
-  // Listen for OS theme changes
-  useEffect(() => {
-    const mql = window.matchMedia("(prefers-color-scheme: dark)")
-    const handler = (e: MediaQueryListEvent) => setSystemTheme(e.matches ? "dark" : "light")
-    mql.addEventListener("change", handler)
-    return () => mql.removeEventListener("change", handler)
-  }, [])
+  // Listen for OS theme changes — disabled while theme is forced to light
+  // useEffect(() => {
+  //   const mql = window.matchMedia("(prefers-color-scheme: dark)")
+  //   const handler = (e: MediaQueryListEvent) => setSystemTheme(e.matches ? "dark" : "light")
+  //   mql.addEventListener("change", handler)
+  //   return () => mql.removeEventListener("change", handler)
+  // }, [])
 
+  // Currently inactive — resolvedTheme is hardcoded to "light" and localStorage read is disabled.
+  // Retained for future dark mode re-enable; remove this comment when restoring theme support.
   const setTheme = (t: AgentTheme) => {
     setThemeState(t)
     localStorage.setItem("agent-theme", t)
   }
 
-  const resolvedTheme = theme === "system" ? systemTheme : theme
+  // Force light — when MediaJira supports dark mode, restore: theme === "system" ? systemTheme : theme
+  const resolvedTheme: "light" | "dark" = "light"
 
   // --- Floating chat controls ---
 

--- a/frontend/src/components/agent/layout/TopBar.tsx
+++ b/frontend/src/components/agent/layout/TopBar.tsx
@@ -3,6 +3,7 @@
 import { PanelRightClose, PanelRightOpen, ChevronRight } from "lucide-react"
 import { useAgentLayout, type AgentView } from "../AgentLayoutContext"
 import { Button } from "@/components/ui/button"
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { ThemeToggle } from "./ThemeToggle"
 
 const viewLabels: Record<AgentView, string> = {
@@ -26,7 +27,7 @@ export function TopBar() {
 
       {/* Right Controls */}
       <div className="flex items-center gap-1">
-        <ThemeToggle />
+        {/* <ThemeToggle /> — disabled until MediaJira supports dark mode */}
         <Button
           variant="ghost"
           size="sm"

--- a/frontend/src/components/agent/overview/PerformanceChart.tsx
+++ b/frontend/src/components/agent/overview/PerformanceChart.tsx
@@ -68,17 +68,17 @@ export function PerformanceChart() {
           ) : (
             <ChartContainer config={chartConfig} className="h-full w-full">
               <LineChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
                 <XAxis
                   dataKey="date"
-                  stroke="#71717a"
+                  stroke="hsl(var(--muted-foreground))"
                   fontSize={12}
                   tickLine={false}
                   axisLine={false}
                 />
                 <YAxis
                   yAxisId="left"
-                  stroke="#71717a"
+                  stroke="hsl(var(--muted-foreground))"
                   fontSize={12}
                   tickLine={false}
                   axisLine={false}
@@ -87,7 +87,7 @@ export function PerformanceChart() {
                 <YAxis
                   yAxisId="right"
                   orientation="right"
-                  stroke="#71717a"
+                  stroke="hsl(var(--muted-foreground))"
                   fontSize={12}
                   tickLine={false}
                   axisLine={false}

--- a/frontend/src/components/agent/overview/TaskStatusChart.tsx
+++ b/frontend/src/components/agent/overview/TaskStatusChart.tsx
@@ -12,7 +12,7 @@ import { PieChart, Pie, Cell, Label } from "recharts"
 import { AgentAPI } from "@/lib/api/agentApi"
 
 const STATUS_CONFIG: Record<string, { label: string; color: string }> = {
-  draft: { label: "Draft", color: "#71717a" },
+  draft: { label: "Draft", color: "#52525b" },
   awaiting_approval: { label: "Awaiting Approval", color: "#f59e0b" },
   committed: { label: "Committed", color: "#3b82f6" },
   reviewed: { label: "Reviewed", color: "#22c55e" },
@@ -38,7 +38,7 @@ export function TaskStatusChart() {
           .map(([status, count]) => ({
             name: status,
             value: count as number,
-            color: STATUS_CONFIG[status]?.color || "#71717a",
+            color: STATUS_CONFIG[status]?.color || "#52525b",
           }))
         setData(chartData)
       } catch {

--- a/frontend/src/components/agent/taskboard/TaskDetailModal.tsx
+++ b/frontend/src/components/agent/taskboard/TaskDetailModal.tsx
@@ -90,7 +90,7 @@ export function TaskDetailModal({ task, onClose }: TaskDetailModalProps) {
                 size="sm"
                 variant="outline"
                 onClick={() => {
-                  window.location.href = `/tasks?taskId=${task.id}`
+                  window.location.href = `/tasks/${task.id}`
                 }}
               >
                 View Full Detail


### PR DESCRIPTION
## Summary
- Lock Agent theme to light mode (disable toggle, localStorage read, OS listener)
- Fix TaskDetailModal 'View Full Detail' URL: query param → dynamic route
- Replace hardcoded dark-theme hex colors with CSS variables in PerformanceChart
- Improve TaskStatusChart draft color contrast (WCAG AA compliant)
- Add EnglishResponseMixin to all 11 agent views for consistent English DRF messages

## Files Changed (6 files, +47 -37)
- backend/agent/views.py
- frontend/src/components/agent/AgentLayoutContext.tsx
- frontend/src/components/agent/layout/TopBar.tsx
- frontend/src/components/agent/overview/PerformanceChart.tsx
- frontend/src/components/agent/overview/TaskStatusChart.tsx
- frontend/src/components/agent/taskboard/TaskDetailModal.tsx

## Test Plan
- [x] Theme: Agent page always renders light mode, ThemeToggle hidden
- [x] URL: Task detail modal 'View Full Detail' navigat to /tasks/{id}
- [x] Charts: PerformanceChart grid/axis colors adapt to theme via CSS variables
- [x] Charts: TaskStatusChart draft color #52525b passes WCAG AA on white
- [x] Toast: Django shell verified EnglishResponseMixin produces English validation errors
- [x] WebSocket: Chat/Asset/Retrospective unaffected (Daphne + Channels unchanged)