### PR TITLE
UI-fix2: remove filter tabs and fix chart tooltip

### DIFF
--- a/frontend/src/app/tasks/page.js
+++ b/frontend/src/app/tasks/page.js
@@ -2047,12 +2047,6 @@ function TasksPageContent() {
                   </div>
                 </div>
 
-                <div className="mt-4 flex items-center gap-4 border-b border-gray-200 pb-2">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-amber-600">Pinned</span>
-                  <span className="text-xs font-semibold uppercase tracking-wide text-gray-400">Recent</span>
-                  <span className="text-xs font-semibold uppercase tracking-wide text-gray-400">All projects</span>
-                </div>
-
                 <div className="mt-4">
                   {projectOptionsLoading && (
                     <div className="py-8 text-center text-sm text-gray-500">

--- a/frontend/src/components/agent/overview/CampaignRanking.tsx
+++ b/frontend/src/components/agent/overview/CampaignRanking.tsx
@@ -46,6 +46,7 @@ export function CampaignRanking({ topCampaigns = [] }: CampaignRankingProps) {
 
   const topData = topCampaigns.map((c) => ({
     name: truncateName(c.name),
+    fullName: c.name,
     roas: c.roas,
   }))
 
@@ -67,8 +68,23 @@ export function CampaignRanking({ topCampaigns = [] }: CampaignRankingProps) {
                 <XAxis type="number" hide />
                 <YAxis type="category" dataKey="name" width={120} tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} />
                 <Tooltip
-                  contentStyle={{ backgroundColor: "hsl(var(--card))", border: "1px solid hsl(var(--border))", borderRadius: 8, fontSize: 12 }}
-                  formatter={(value) => [`${Number(value).toFixed(2)}x`, "ROAS"]}
+                  content={({ active, payload }) => {
+                    if (!active || !payload?.length) return null
+                    const data = payload[0].payload
+                    return (
+                      <div style={{
+                        backgroundColor: "hsl(var(--card))",
+                        border: "1px solid hsl(var(--border))",
+                        borderRadius: 8,
+                        padding: "8px 12px",
+                        fontSize: 12,
+                        maxWidth: 320,
+                      }}>
+                        <p style={{ fontWeight: 600, marginBottom: 4 }}>{data.fullName}</p>
+                        <p>ROAS: {Number(data.roas).toFixed(2)}x</p>
+                      </div>
+                    )
+                  }}
                 />
                 <Bar dataKey="roas" radius={[0, 4, 4, 0]} maxBarSize={20}>
                   {topData.map((_, i) => (


### PR DESCRIPTION
## Summary
- Remove unused PINNED/RECENT/ALL PROJECTS filter tabs from Tasks page project selector
- Fix CampaignRanking bar chart tooltip to show full campaign name instead of truncated text

## Files Changed
- frontend/src/app/tasks/page.js — delete decorative filter tabs div
- frontend/src/components/agent/overview/CampaignRanking.tsx — add fullName to chart data, custom tooltip renderer

## Test Plan
- Tasks page: project selector no longer shows PINNED/RECENT/ALL PROJECTS tabs
- Agent Overview: hover bar chart shows full campaign name + ROAS value in tooltip