### PR TITLE
SMP-516 Enhance Miro Board Usability with Keyboard Shortcuts, Content Templates, and Advanced Canvas Elements

### DIFF
--- a/backend/miro/migrations/0002_boarditem_emoji_type.py
+++ b/backend/miro/migrations/0002_boarditem_emoji_type.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("miro", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="boarditem",
+            name="type",
+            field=models.CharField(
+                choices=[
+                    ("text", "Text"),
+                    ("shape", "Shape"),
+                    ("sticky_note", "Sticky Note"),
+                    ("frame", "Frame"),
+                    ("line", "Line"),
+                    ("connector", "Connector"),
+                    ("freehand", "Freehand"),
+                    ("emoji", "Emoji"),
+                ],
+                help_text="Type of the board item",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/backend/miro/models.py
+++ b/backend/miro/models.py
@@ -59,6 +59,7 @@ class BoardItem(models.Model):
         LINE = 'line', 'Line'
         CONNECTOR = 'connector', 'Connector'
         FREEHAND = 'freehand', 'Freehand'
+        EMOJI = 'emoji', 'Emoji'
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     board = models.ForeignKey(

--- a/frontend/src/__tests__/components/miro/BoardCanvas.test.tsx
+++ b/frontend/src/__tests__/components/miro/BoardCanvas.test.tsx
@@ -12,6 +12,7 @@ jest.mock('@/components/miro/hooks/useItemDrag', () => ({
     updateDrag: jest.fn(),
     endDrag: jest.fn(),
     getOverridePosition: jest.fn(() => null),
+    isDragging: false,
   })),
 }));
 
@@ -21,6 +22,7 @@ jest.mock('@/components/miro/hooks/useItemResize', () => ({
     updateResize: jest.fn(),
     endResize: jest.fn(),
     getOverrideSize: jest.fn(() => null),
+    isResizing: false,
   })),
 }));
 
@@ -31,7 +33,7 @@ const mockCanvasRef = React.createRef<HTMLDivElement>();
 const defaultProps = {
   viewport: mockViewport,
   items: mockItems,
-  selectedItemId: null,
+  selectedItemIds: [],
   activeTool: 'select' as ToolType,
   onItemSelect: jest.fn(),
   onItemUpdate: jest.fn(),
@@ -41,6 +43,7 @@ const defaultProps = {
   onPanUpdate: jest.fn(),
   onPanEnd: jest.fn(),
   onZoom: jest.fn(),
+  onPanBy: jest.fn(),
   onItemCreate: jest.fn(),
   onFreehandCreate: jest.fn(),
   width: 800,

--- a/frontend/src/__tests__/components/miro/BoardHeader.test.tsx
+++ b/frontend/src/__tests__/components/miro/BoardHeader.test.tsx
@@ -193,6 +193,23 @@ describe('BoardHeader Component', () => {
     });
   });
 
+  describe('Undo/Redo Buttons', () => {
+    test('renders undo/redo when handlers provided', () => {
+      render(
+        <BoardHeader
+          {...defaultProps}
+          onUndo={jest.fn()}
+          onRedo={jest.fn()}
+          canUndo={true}
+          canRedo={false}
+        />
+      );
+      expect(screen.getByTitle('Undo (Cmd/Ctrl+Z)')).toBeInTheDocument();
+      expect(screen.getByTitle('Redo (Cmd+Shift+Z / Ctrl+Y)')).toBeInTheDocument();
+      expect(screen.getByTitle('Redo (Cmd+Shift+Z / Ctrl+Y)')).toBeDisabled();
+    });
+  });
+
   describe('Navigation', () => {
     test('back button calls router.back', () => {
       const mockBack = jest.fn();

--- a/frontend/src/__tests__/components/miro/BoardToolbar.test.tsx
+++ b/frontend/src/__tests__/components/miro/BoardToolbar.test.tsx
@@ -8,6 +8,7 @@ const defaultProps = {
   activeTool: 'select' as ToolType,
   onToolChange: jest.fn(),
   onToolPrimaryAction: jest.fn(),
+  onEmojiInsert: jest.fn(),
   lineVariant: 'straight_solid' as const,
   onLineVariantChange: jest.fn(),
 };
@@ -22,13 +23,15 @@ describe('BoardToolbar Component', () => {
       render(<BoardToolbar {...defaultProps} />);
       
       expect(screen.getByRole('button', { name: 'Select' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Multi-select' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Text' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Shape' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Sticky Note' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Frame' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Line' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Connector' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Connect' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'brush' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Emoji' })).toBeInTheDocument();
     });
 
     test('shows tooltip on hover', () => {
@@ -99,7 +102,7 @@ describe('BoardToolbar Component', () => {
       expect(onToolPrimaryAction).toHaveBeenCalledWith('text');
     });
 
-    test('calls onToolChange only for select/freehand/line', () => {
+    test('calls onToolChange only for select/multi-select/freehand/line', () => {
       const onToolChange = jest.fn();
       const onToolPrimaryAction = jest.fn();
       render(
@@ -110,15 +113,16 @@ describe('BoardToolbar Component', () => {
         />,
       );
       
-      const tools: ToolType[] = ['select', 'text', 'shape', 'sticky_note', 'frame', 'line', 'connector', 'freehand'];
+      const tools: ToolType[] = ['select', 'multi_select', 'text', 'shape', 'sticky_note', 'frame', 'line', 'connect', 'freehand'];
       const toolLabelByType: Record<ToolType, string> = {
         select: 'Select',
+        multi_select: 'Multi-select',
         text: 'Text',
         shape: 'Shape',
         sticky_note: 'Sticky Note',
         frame: 'Frame',
         line: 'Line',
-        connector: 'Connector',
+        connect: 'Connect',
         freehand: 'brush',
       };
       
@@ -127,11 +131,13 @@ describe('BoardToolbar Component', () => {
         fireEvent.click(button);
       });
       
-      expect(onToolChange).toHaveBeenCalledTimes(3);
+      expect(onToolChange).toHaveBeenCalledTimes(5);
       expect(onToolChange).toHaveBeenCalledWith('select');
+      expect(onToolChange).toHaveBeenCalledWith('multi_select');
       expect(onToolChange).toHaveBeenCalledWith('line');
+      expect(onToolChange).toHaveBeenCalledWith('connect');
       expect(onToolChange).toHaveBeenCalledWith('freehand');
-      expect(onToolPrimaryAction).toHaveBeenCalledTimes(5);
+      expect(onToolPrimaryAction).toHaveBeenCalledTimes(4);
     });
   });
 
@@ -186,7 +192,7 @@ describe('BoardToolbar Component', () => {
       // Icons are rendered as SVG elements from lucide-react
       // We can verify they exist by checking the button structure
       const buttons = screen.getAllByRole('button');
-      expect(buttons.length).toBe(8);
+      expect(buttons.length).toBe(10);
     });
   });
 

--- a/frontend/src/__tests__/components/miro/EmojiItem.test.tsx
+++ b/frontend/src/__tests__/components/miro/EmojiItem.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import EmojiItem from "@/components/miro/items/EmojiItem";
+import { BoardItem } from "@/lib/api/miroApi";
+
+function makeItem(overrides: Partial<BoardItem> = {}): BoardItem {
+  return {
+    id: "e1",
+    board_id: "b1",
+    type: "emoji",
+    x: 0,
+    y: 0,
+    width: 64,
+    height: 64,
+    style: {},
+    content: "🎉",
+    z_index: 0,
+    is_deleted: false,
+    created_at: "",
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+describe("EmojiItem", () => {
+  test("renders content emoji", () => {
+    const onSelect = jest.fn();
+    render(
+      <EmojiItem item={makeItem({ content: "⭐" })} isSelected={false} onSelect={onSelect} onUpdate={jest.fn()} />
+    );
+    expect(screen.getByRole("img", { name: "⭐" })).toBeInTheDocument();
+  });
+
+  test("falls back when content empty", () => {
+    render(
+      <EmojiItem item={makeItem({ content: "" })} isSelected={false} onSelect={jest.fn()} onUpdate={jest.fn()} />
+    );
+    expect(screen.getByRole("img", { name: "🙂" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/miro/[boardId]/page.tsx
+++ b/frontend/src/app/miro/[boardId]/page.tsx
@@ -3,16 +3,18 @@
 import React, { useState, useEffect, useCallback, useRef, useLayoutEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Layout from "@/components/layout/Layout";
-import { miroApi, MiroBoard, BoardItem } from "@/lib/api/miroApi";
+import { miroApi, MiroBoard, BoardItem, UpdateBoardItemData } from "@/lib/api/miroApi";
 import { useBoardViewport, Viewport } from "@/components/miro/hooks/useBoardViewport";
 import { useBoardItems } from "@/components/miro/hooks/useBoardItems";
 import { LineVariant, ToolOptions, ToolType } from "@/components/miro/hooks/useToolDnD";
+import { useBoardItemHistory } from "@/components/miro/hooks/useBoardItemHistory";
 import BoardCanvas from "@/components/miro/BoardCanvas";
 import BoardHeader from "@/components/miro/BoardHeader";
 import BoardToolbar from "@/components/miro/BoardToolbar";
 import BoardPropertiesPanel from "@/components/miro/BoardPropertiesPanel";
 import BoardSnapshotsModal from "@/components/miro/BoardSnapshotsModal";
 import BoardPreviewModal from "@/components/miro/BoardPreviewModal";
+import type { AnchorSide } from "@/components/miro/utils/connectorLayout";
 
 export default function MiroBoardPage() {
   const params = useParams();
@@ -57,20 +59,65 @@ export default function MiroBoardPage() {
     startPan,
     updatePan,
     endPan,
+    panBy,
   } = useBoardViewport(initialViewport);
 
   const {
     items,
     loading: itemsLoading,
-    selectedItemId,
-    setSelectedItemId,
+    selectedItemIds,
+    setSelectedItemIds,
     loadItems,
     createItem,
     updateItem,
     updateItemOptimistic,
     updateItemAsync,
     deleteItem,
+    batchUpdateItems,
+    removeItemsOptimistic,
+    restoreItemsOptimistic,
   } = useBoardItems(boardId);
+  const { push, undo, redo, canUndo, canRedo, buildUpdateEntry } = useBoardItemHistory();
+
+  const linkedConnectorSigRef = useRef<Map<string, string>>(new Map());
+
+  // Persist linked connector geometry (and soft-deletes) after layout runs in useBoardItems.
+  useEffect(() => {
+    const t = window.setTimeout(() => {
+      const connectors = items.filter((i) => i.type === "connector" && i.style?.connection);
+      if (connectors.length === 0) return;
+      const updates: Array<{ id: string } & Partial<UpdateBoardItemData>> = [];
+      for (const c of connectors) {
+        const sig = [
+          c.is_deleted,
+          c.x,
+          c.y,
+          c.width,
+          c.height,
+          c.style?.svgPath ?? "",
+          JSON.stringify(c.style?.connection ?? {}),
+        ].join("|");
+        if (linkedConnectorSigRef.current.get(c.id) === sig) continue;
+        linkedConnectorSigRef.current.set(c.id, sig);
+        updates.push({
+          id: c.id,
+          x: c.x,
+          y: c.y,
+          width: c.width,
+          height: c.height,
+          rotation: 0,
+          style: c.style,
+          is_deleted: c.is_deleted,
+        });
+      }
+      if (updates.length > 0) {
+        batchUpdateItems(updates).catch((err) =>
+          console.error("Failed to persist linked connectors:", err)
+        );
+      }
+    }, 220);
+    return () => clearTimeout(t);
+  }, [items, batchUpdateItems]);
 
   // Load board data
   useEffect(() => {
@@ -256,9 +303,18 @@ export default function MiroBoardPage() {
   );
 
   // Handle item selection
-  const handleItemSelect = useCallback((itemId: string | null) => {
-    setSelectedItemId(itemId);
-  }, [setSelectedItemId]);
+  const handleItemSelect = useCallback((itemId: string | null, options?: { shiftKey?: boolean; metaKey?: boolean; ctrlKey?: boolean }) => {
+    if (!itemId) {
+      setSelectedItemIds([]);
+      return;
+    }
+    const additive = Boolean(options?.shiftKey || options?.metaKey || options?.ctrlKey);
+    setSelectedItemIds((prev) => {
+      if (!additive) return [itemId];
+      if (prev.includes(itemId)) return prev.filter((id) => id !== itemId);
+      return [...prev, itemId];
+    });
+  }, [setSelectedItemIds]);
 
   // Handle item update
   const handleItemUpdate = useCallback(
@@ -266,34 +322,70 @@ export default function MiroBoardPage() {
       try {
         // For content edits (typing), update UI immediately and persist in background.
         if (Object.prototype.hasOwnProperty.call(updates, "content")) {
+          const before = items.filter((item) => item.id === itemId);
           const rollback = updateItemOptimistic(itemId, updates);
           updateItemAsync(itemId, updates, rollback).catch((err) => {
             console.error("Failed to persist item update (content):", err);
           });
+          const after = before.map((item) => ({ ...item, ...updates }));
+          push(buildUpdateEntry(before, after, async (snapshot) => {
+            const target = snapshot[0];
+            if (!target) return;
+            await updateItem(target.id, target);
+          }));
           return;
         }
 
+        const before = items.filter((item) => item.id === itemId);
         await updateItem(itemId, updates);
+        const after = items
+          .map((item) => (item.id === itemId ? { ...item, ...updates } : item))
+          .filter((item) => item.id === itemId);
+        push(buildUpdateEntry(before, after, async (snapshot) => {
+          const target = snapshot[0];
+          if (!target) return;
+          await updateItem(target.id, target);
+        }));
       } catch (err) {
         console.error("Failed to update item:", err);
       }
     },
-    [updateItem, updateItemOptimistic, updateItemAsync]
+    [updateItem, updateItemOptimistic, updateItemAsync, items, push, buildUpdateEntry]
   );
 
   // Handle item delete
   const handleItemDelete = useCallback(async () => {
-    if (!selectedItemId) return;
+    if (selectedItemIds.length === 0) return;
+    let rollback: (() => void) | undefined;
     try {
-      await deleteItem(selectedItemId);
-      setSelectedItemId(null);
+      const deletingIds = selectedItemIds.slice();
+      rollback = removeItemsOptimistic(deletingIds);
+      await Promise.all(deletingIds.map((id) => deleteItem(id)));
+      const redoDelete = async () => {
+        await Promise.all(deletingIds.map((id) => deleteItem(id)));
+      };
+      const undoDelete = async () => {
+        const restoreRollback = restoreItemsOptimistic(deletingIds);
+        try {
+          await Promise.all(deletingIds.map((id) => updateItem(id, { is_deleted: false })));
+        } catch (err) {
+          restoreRollback();
+          throw err;
+        }
+      };
+      push({ undo: undoDelete, redo: redoDelete });
+      setSelectedItemIds([]);
     } catch (err) {
+      rollback?.();
       console.error("Failed to delete item:", err);
     }
-  }, [selectedItemId, deleteItem, setSelectedItemId]);
+  }, [selectedItemIds, deleteItem, setSelectedItemIds, push, removeItemsOptimistic, restoreItemsOptimistic, updateItem]);
 
   const resolveToolCreateSpec = useCallback(
-    (toolType: ToolType, options?: ToolOptions) => {
+    (toolType: ToolType, options?: ToolOptions): {
+      resolvedType: BoardItem["type"];
+      style: Record<string, any>;
+    } => {
       const lv = options?.lineVariant ?? lineVariant;
       if (toolType === "line") {
         const strokeDasharray =
@@ -307,8 +399,8 @@ export default function MiroBoardPage() {
         return { resolvedType, style: { strokeColor: "#111827", strokeWidth: 4, strokeDasharray } };
       }
 
-      if (toolType === "connector") {
-        return { resolvedType: toolType as BoardItem["type"], style: { strokeColor: "#111827", strokeWidth: 4 } };
+      if (toolType === "emoji") {
+        return { resolvedType: "emoji", style: {} as Record<string, any> };
       }
 
       return { resolvedType: toolType as BoardItem["type"], style: {} as Record<string, any> };
@@ -319,7 +411,7 @@ export default function MiroBoardPage() {
   // Handle item creation via drag-and-drop
   const handleItemCreate = useCallback(
     async (toolType: ToolType, worldX: number, worldY: number, options?: ToolOptions) => {
-      if (toolType === "select") return;
+      if (toolType === "select" || toolType === "multi_select" || toolType === "connect") return;
 
       const defaultSizes: Record<string, { width: number; height: number }> = {
         text: { width: 200, height: 50 },
@@ -329,33 +421,99 @@ export default function MiroBoardPage() {
         line: { width: 200, height: 20 },
         connector: { width: 200, height: 20 },
         freehand: { width: 100, height: 100 },
+        emoji: { width: 64, height: 64 },
       };
 
       const { resolvedType, style } = resolveToolCreateSpec(toolType, options);
       const size = defaultSizes[resolvedType] || { width: 100, height: 100 };
 
+      const initialContent =
+        toolType === "text" || toolType === "sticky_note"
+          ? ""
+          : toolType === "emoji"
+            ? options?.emoji ?? "😀"
+            : "";
+
       try {
-        await createItem({
+        const created = await createItem({
           type: resolvedType,
           x: worldX,
           y: worldY,
           width: size.width,
           height: size.height,
-          content: toolType === "text" || toolType === "sticky_note" ? "" : "",
+          content: initialContent,
           style,
           z_index: 0,
+        });
+        push({
+          undo: async () => {
+            await updateItem(created.id, { is_deleted: true });
+          },
+          redo: async () => {
+            await updateItem(created.id, { is_deleted: false });
+          },
         });
         // Keep tool selected for potential repeated use
       } catch (err) {
         console.error("Failed to create item:", err);
       }
     },
-    [createItem, resolveToolCreateSpec]
+    [createItem, resolveToolCreateSpec, push, updateItem]
+  );
+
+  const handleEmojiInsert = useCallback(
+    async (emoji: string) => {
+      let w = canvasSize.width;
+      let h = canvasSize.height;
+      if ((w <= 0 || h <= 0) && canvasContainerRef.current) {
+        w = canvasContainerRef.current.clientWidth;
+        h = canvasContainerRef.current.clientHeight;
+      }
+      if (w <= 0 || h <= 0) return;
+
+      const size = { width: 64, height: 64 };
+      const centerWorld = screenToWorld(w / 2, h / 2);
+      const x = centerWorld.x - size.width / 2;
+      const y = centerWorld.y - size.height / 2;
+
+      try {
+        const created = await createItem({
+          type: "emoji",
+          x,
+          y,
+          width: size.width,
+          height: size.height,
+          content: emoji,
+          style: {},
+          z_index: 0,
+        });
+        push({
+          undo: async () => {
+            await updateItem(created.id, { is_deleted: true });
+          },
+          redo: async () => {
+            await updateItem(created.id, { is_deleted: false });
+          },
+        });
+        setSelectedItemIds([created.id]);
+      } catch (err) {
+        console.error("Failed to create emoji:", err);
+      }
+    },
+    [canvasSize.height, canvasSize.width, createItem, push, screenToWorld, updateItem, setSelectedItemIds]
   );
 
   const createAtViewportCenter = useCallback(
     async (toolType: ToolType, options?: ToolOptions) => {
-      if (toolType === "select" || toolType === "freehand") return;
+      if (
+        toolType === "select" ||
+        toolType === "multi_select" ||
+        toolType === "freehand" ||
+        toolType === "emoji" ||
+        toolType === "connect"
+      ) {
+        return;
+      }
 
       // Use live ref dimensions when state is still 0 (e.g. before first layout effect runs).
       let w = canvasSize.width;
@@ -379,6 +537,7 @@ export default function MiroBoardPage() {
         line: { width: 200, height: 20 },
         connector: { width: 200, height: 20 },
         freehand: { width: 100, height: 100 },
+        emoji: { width: 64, height: 64 },
       };
 
       const { resolvedType, style } = resolveToolCreateSpec(toolType, options);
@@ -388,7 +547,7 @@ export default function MiroBoardPage() {
       const y = centerWorld.y - size.height / 2;
 
       try {
-        await createItem({
+        const created = await createItem({
           type: resolvedType,
           x,
           y,
@@ -398,16 +557,68 @@ export default function MiroBoardPage() {
           style,
           z_index: 0,
         });
+        push({
+          undo: async () => {
+            await updateItem(created.id, { is_deleted: true });
+          },
+          redo: async () => {
+            await updateItem(created.id, { is_deleted: false });
+          },
+        });
       } catch (err) {
         console.error("Failed to create item:", err);
       } finally {
         setActiveTool("select");
       }
     },
-    [canvasSize.height, canvasSize.width, createItem, resolveToolCreateSpec, screenToWorld]
+    [canvasSize.height, canvasSize.width, createItem, resolveToolCreateSpec, screenToWorld, push, updateItem]
   );
 
   // Handle freehand creation
+  const handleLinkedConnectorCreate = useCallback(
+    async (payload: {
+      fromItemId: string;
+      toItemId: string;
+      fromAnchor: AnchorSide;
+      toAnchor: AnchorSide;
+    }) => {
+      try {
+        const created = await createItem({
+          type: "connector",
+          x: 0,
+          y: 0,
+          width: 120,
+          height: 40,
+          content: "",
+          rotation: 0,
+          style: {
+            strokeColor: "#111827",
+            strokeWidth: 4,
+            connection: {
+              fromItemId: payload.fromItemId,
+              toItemId: payload.toItemId,
+              fromAnchor: payload.fromAnchor,
+              toAnchor: payload.toAnchor,
+            },
+          },
+          z_index: 0,
+        });
+        push({
+          undo: async () => {
+            await updateItem(created.id, { is_deleted: true });
+          },
+          redo: async () => {
+            await updateItem(created.id, { is_deleted: false });
+          },
+        });
+        setSelectedItemIds([created.id]);
+      } catch (err) {
+        console.error("Failed to create linked connector:", err);
+      }
+    },
+    [createItem, push, updateItem, setSelectedItemIds]
+  );
+
   const handleFreehandCreate = useCallback(
     async (data: {
       x: number;
@@ -417,7 +628,7 @@ export default function MiroBoardPage() {
       style: { svgPath: string; strokeColor: string; strokeWidth: number };
     }) => {
       try {
-        await createItem({
+        const created = await createItem({
           type: "freehand",
           x: data.x,
           y: data.y,
@@ -427,11 +638,19 @@ export default function MiroBoardPage() {
           style: data.style,
           z_index: 0,
         });
+        push({
+          undo: async () => {
+            await updateItem(created.id, { is_deleted: true });
+          },
+          redo: async () => {
+            await updateItem(created.id, { is_deleted: false });
+          },
+        });
       } catch (err) {
         console.error("Failed to create freehand:", err);
       }
     },
-    [createItem]
+    [createItem, push, updateItem]
   );
 
 
@@ -577,7 +796,64 @@ export default function MiroBoardPage() {
     [zoomAtPoint]
   );
 
-  const selectedItem = items.find((item) => item.id === selectedItemId) || null;
+  const selectedItem = selectedItemIds.length === 1
+    ? items.find((item) => item.id === selectedItemIds[0]) || null
+    : null;
+
+  const applySnapshot = useCallback(async (snapshot: BoardItem[]) => {
+    await Promise.all(snapshot.map((item) => updateItem(item.id, item)));
+  }, [updateItem]);
+
+  const handleItemsBatchUpdate = useCallback(async (updates: Array<{ id: string } & Partial<BoardItem>>) => {
+    const before = items.filter((item) => updates.some((u) => u.id === item.id));
+    await batchUpdateItems(updates);
+    const after = before.map((item) => {
+      const update = updates.find((u) => u.id === item.id);
+      return update ? { ...item, ...update } : item;
+    });
+    push(buildUpdateEntry(before, after, applySnapshot));
+  }, [items, batchUpdateItems, push, buildUpdateEntry, applySnapshot]);
+
+  useEffect(() => {
+    const isEditableTarget = (target: EventTarget | null): boolean => {
+      const element = target as HTMLElement | null;
+      if (!element) return false;
+      return Boolean(element.closest("input, textarea, select, [contenteditable='true']"));
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (isEditableTarget(event.target) || isPreviewOpen || isSnapshotsModalOpen) return;
+      const key = event.key.toLowerCase();
+      const mod = event.metaKey || event.ctrlKey;
+      if ((key === "delete" || key === "backspace") && selectedItemIds.length > 0) {
+        event.preventDefault();
+        handleItemDelete();
+        return;
+      }
+      if (key === "escape" && selectedItemIds.length > 0) {
+        event.preventDefault();
+        setSelectedItemIds([]);
+        return;
+      }
+      if (mod && key === "z" && event.shiftKey) {
+        event.preventDefault();
+        redo();
+        return;
+      }
+      if (mod && key === "z") {
+        event.preventDefault();
+        undo();
+        return;
+      }
+      if (!event.metaKey && event.ctrlKey && key === "y") {
+        event.preventDefault();
+        redo();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [selectedItemIds, handleItemDelete, redo, undo, setSelectedItemIds, isPreviewOpen, isSnapshotsModalOpen]);
 
   if (loading) {
     return (
@@ -622,6 +898,10 @@ export default function MiroBoardPage() {
           shareToken={board.share_token}
           onSnapshotClick={handleSnapshotsClick}
           onPreviewClick={handlePreviewClick}
+          onUndo={undo}
+          onRedo={redo}
+          canUndo={canUndo}
+          canRedo={canRedo}
         />
 
         <div className="flex flex-1 overflow-hidden min-h-0">
@@ -629,6 +909,7 @@ export default function MiroBoardPage() {
             activeTool={activeTool}
             onToolChange={setActiveTool}
             onToolPrimaryAction={createAtViewportCenter}
+            onEmojiInsert={handleEmojiInsert}
             lineVariant={lineVariant}
             onLineVariantChange={setLineVariant}
           />
@@ -637,7 +918,7 @@ export default function MiroBoardPage() {
             <BoardCanvas
               viewport={viewport}
               items={items}
-              selectedItemId={selectedItemId}
+              selectedItemIds={selectedItemIds}
               activeTool={activeTool}
               onItemSelect={handleItemSelect}
               onItemUpdate={handleItemUpdate}
@@ -647,8 +928,11 @@ export default function MiroBoardPage() {
               onPanUpdate={handlePanUpdate}
               onPanEnd={handlePanEnd}
               onZoom={handleZoom}
+              onPanBy={panBy}
               onItemCreate={handleItemCreate}
               onFreehandCreate={handleFreehandCreate}
+              onLinkedConnectorCreate={handleLinkedConnectorCreate}
+              onItemsBatchUpdate={handleItemsBatchUpdate}
               width={canvasSize.width}
               height={canvasSize.height}
               canvasRef={canvasRef}
@@ -658,6 +942,7 @@ export default function MiroBoardPage() {
 
           <BoardPropertiesPanel
             selectedItem={selectedItem}
+            selectedItemsCount={selectedItemIds.length}
             activeTool={activeTool}
             brushSettings={brushSettings}
             onBrushSettingsChange={setBrushSettings}

--- a/frontend/src/components/miro/BoardCanvas.tsx
+++ b/frontend/src/components/miro/BoardCanvas.tsx
@@ -5,17 +5,24 @@ import { BoardItem } from "@/lib/api/miroApi";
 import { Viewport } from "./hooks/useBoardViewport";
 import { useItemDrag } from "./hooks/useItemDrag";
 import { useItemResize } from "./hooks/useItemResize";
+import { useLineEndpointDrag } from "./hooks/useLineEndpointDrag";
 import { useFreehandDrawing } from "./hooks/useFreehandDrawing";
 import BoardItemContainer from "./items/BoardItemContainer";
 import InlineContentEditor from "./InlineContentEditor";
 import { TOOL_DND_MIME, ToolOptions, ToolType } from "./hooks/useToolDnD";
+import { getSelectionBounds } from "./utils/selectionBounds";
+import {
+  anchorWorldPoint,
+  itemSupportsConnectAnchors,
+  type AnchorSide,
+} from "./utils/connectorLayout";
 
 interface BoardCanvasProps {
   viewport: Viewport;
   items: BoardItem[];
-  selectedItemId: string | null;
+  selectedItemIds: string[];
   activeTool: ToolType;
-  onItemSelect: (itemId: string | null) => void;
+  onItemSelect: (itemId: string | null, options?: { shiftKey?: boolean; metaKey?: boolean; ctrlKey?: boolean }) => void;
   onItemUpdate: (itemId: string, updates: Partial<BoardItem>) => void;
   onItemUpdateOptimistic: (itemId: string, updates: Partial<BoardItem>) => () => void;
   onItemUpdateAsync: (itemId: string, updates: Partial<BoardItem>, rollback: () => void) => Promise<BoardItem>;
@@ -23,8 +30,16 @@ interface BoardCanvasProps {
   onPanUpdate: (x: number, y: number) => void;
   onPanEnd: () => void;
   onZoom: (mouseX: number, mouseY: number, delta: number) => void;
+  onPanBy: (dx: number, dy: number) => void;
   onItemCreate?: (toolType: ToolType, worldX: number, worldY: number, options?: ToolOptions) => void;
   onFreehandCreate?: (data: { x: number; y: number; width: number; height: number; style: { svgPath: string; strokeColor: string; strokeWidth: number } }) => void;
+  onLinkedConnectorCreate?: (payload: {
+    fromItemId: string;
+    toItemId: string;
+    fromAnchor: AnchorSide;
+    toAnchor: AnchorSide;
+  }) => void;
+  onItemsBatchUpdate?: (updates: Array<{ id: string } & Partial<BoardItem>>) => void;
   width: number;
   height: number;
   canvasRef: React.RefObject<HTMLDivElement>;
@@ -37,7 +52,7 @@ interface BoardCanvasProps {
 export default function BoardCanvas({
   viewport,
   items,
-  selectedItemId,
+  selectedItemIds,
   activeTool,
   onItemSelect,
   onItemUpdate,
@@ -47,14 +62,31 @@ export default function BoardCanvas({
   onPanUpdate,
   onPanEnd,
   onZoom,
+  onPanBy,
   onItemCreate,
   onFreehandCreate,
+  onLinkedConnectorCreate,
+  onItemsBatchUpdate,
   width,
   height,
   canvasRef,
   brushSettings,
 }: BoardCanvasProps) {
   const isPanningRef = useRef(false);
+  const [marqueeRect, setMarqueeRect] = useState<{ startX: number; startY: number; currentX: number; currentY: number } | null>(null);
+  const groupDragStartRef = useRef<Map<string, { x: number; y: number }>>(new Map());
+
+  const [connectionDraft, setConnectionDraft] = useState<{
+    fromItemId: string;
+    fromAnchor: AnchorSide;
+    fromWorld: { x: number; y: number };
+  } | null>(null);
+  const [draftPointerWorld, setDraftPointerWorld] = useState<{ x: number; y: number } | null>(null);
+  const connectionDraftRef = useRef<{
+    fromItemId: string;
+    fromAnchor: AnchorSide;
+    fromWorld: { x: number; y: number };
+  } | null>(null);
   
   // Inline editing state
   const [editingItemId, setEditingItemId] = useState<string | null>(null);
@@ -78,17 +110,11 @@ export default function BoardCanvas({
       return;
     }
 
-    // Optimistic update
-    const rollback = onItemUpdateOptimistic(editingItemId, { content: draftContent });
-
-    // Async update
-    onItemUpdateAsync(editingItemId, { content: draftContent }, rollback).catch((err) => {
-      console.error("Failed to persist content edit:", err);
-    });
+    onItemUpdate(editingItemId, { content: draftContent });
 
     setEditingItemId(null);
     setDraftContent("");
-  }, [editingItemId, draftContent, items, onItemUpdateOptimistic, onItemUpdateAsync]);
+  }, [editingItemId, draftContent, items, onItemUpdate]);
 
   // Cancel editing (discard changes)
   const cancelEditing = useCallback(() => {
@@ -112,6 +138,21 @@ export default function BoardCanvas({
     isResizing,
   } = useItemResize();
 
+  const {
+    startDrag: startLineEndpointDrag,
+    updateDrag: updateLineEndpointDrag,
+    endDrag: endLineEndpointDrag,
+    getOverride: getLineEndpointOverride,
+    lineEndpointDragTick,
+  } = useLineEndpointDrag();
+
+  const handleLineEndpointDragEnd = useCallback(() => {
+    const result = endLineEndpointDrag();
+    if (!result) return;
+    const { id, x, y, width, height, rotation } = result;
+    onItemUpdate(id, { x, y, width, height, rotation });
+  }, [endLineEndpointDrag, onItemUpdate]);
+
   // Compute editor screen position for editing item
   const editorRect = useMemo(() => {
     if (!editingItemId || !canvasRef.current) return null;
@@ -120,8 +161,18 @@ export default function BoardCanvas({
     if (!editingItem) return null;
 
     const canvasRect = canvasRef.current.getBoundingClientRect();
-    const overridePosition = getOverridePosition(editingItemId);
-    const overrideSize = getOverrideSize(editingItemId, viewport.zoom, editingItem.type);
+    const lineOv = getLineEndpointOverride(editingItemId);
+    const overridePosition = lineOv
+      ? { x: lineOv.x as number, y: lineOv.y as number }
+      : getOverridePosition(editingItemId);
+    const overrideSize = lineOv
+      ? {
+          x: lineOv.x as number,
+          y: lineOv.y as number,
+          width: lineOv.width as number,
+          height: lineOv.height as number,
+        }
+      : getOverrideSize(editingItemId, viewport.zoom, editingItem.type);
 
     const itemX = overrideSize?.x ?? overridePosition?.x ?? editingItem.x;
     const itemY = overrideSize?.y ?? overridePosition?.y ?? editingItem.y;
@@ -141,7 +192,16 @@ export default function BoardCanvas({
       width: screenWidth,
       height: screenHeight,
     };
-  }, [editingItemId, items, viewport, canvasRef, getOverridePosition, getOverrideSize]);
+  }, [
+    editingItemId,
+    items,
+    viewport,
+    canvasRef,
+    getOverridePosition,
+    getOverrideSize,
+    getLineEndpointOverride,
+    lineEndpointDragTick,
+  ]);
 
   // Viewport culling: only render visible items
   // Sort items so that frames render first, then their children render on top
@@ -217,25 +277,39 @@ export default function BoardCanvas({
     });
   }, [items, viewport, width, height]);
 
+  // Trackpad: two-finger scroll pans via deltaX/deltaY; pinch-zoom (e.g. macOS) often sends
+  // ctrlKey+wheel, which we treat as zoom-at-cursor. Brush/freehand is unaffected (separate handlers).
   // Handle mouse wheel zoom (native listener, non-passive so preventDefault works)
   useEffect(() => {
     const el = canvasRef.current;
     if (!el) return;
 
     const wheelHandler = (e: WheelEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (
+        target?.closest(
+          "input, textarea, select, [contenteditable='true'], input[type='range'], [data-radix-scroll-area-viewport], [data-radix-popover-content], [role='dialog']"
+        )
+      ) {
+        return;
+      }
       e.preventDefault();
 
       const rect = el.getBoundingClientRect();
       const mouseX = e.clientX - rect.left;
       const mouseY = e.clientY - rect.top;
 
-      const zoomDelta = -e.deltaY * 0.001;
-      onZoom(mouseX, mouseY, zoomDelta);
+      if (e.ctrlKey) {
+        const zoomDelta = -e.deltaY * 0.001;
+        onZoom(mouseX, mouseY, zoomDelta);
+        return;
+      }
+      onPanBy(e.deltaX, e.deltaY);
     };
 
     el.addEventListener("wheel", wheelHandler, { passive: false });
     return () => el.removeEventListener("wheel", wheelHandler as any);
-  }, [onZoom]);
+  }, [onZoom, onPanBy]);
 
   // Convert screen coordinates to world coordinates
   const screenToWorld = useCallback(
@@ -257,6 +331,66 @@ export default function BoardCanvas({
       };
     },
     [viewport]
+  );
+
+  // screenToWorld expects coordinates relative to the canvas element (same space as viewport.x/y).
+  // e.clientX/Y are viewport coordinates — offset by the canvas bounding rect first.
+  const clientToWorld = useCallback(
+    (clientX: number, clientY: number) => {
+      const el = canvasRef.current;
+      if (!el) {
+        return screenToWorld(clientX, clientY);
+      }
+      const rect = el.getBoundingClientRect();
+      return screenToWorld(clientX - rect.left, clientY - rect.top);
+    },
+    [canvasRef, screenToWorld]
+  );
+
+  const handleConnectAnchorPointerDown = useCallback(
+    (itemId: string, anchor: AnchorSide, e: React.PointerEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+      const item = items.find((i) => i.id === itemId);
+      if (!item) return;
+      const fromWorld = anchorWorldPoint(item, anchor);
+      const draft = { fromItemId: itemId, fromAnchor: anchor, fromWorld };
+      connectionDraftRef.current = draft;
+      setConnectionDraft(draft);
+      const w = clientToWorld(e.clientX, e.clientY);
+      setDraftPointerWorld(w);
+
+      const move = (ev: PointerEvent) => {
+        const p = clientToWorld(ev.clientX, ev.clientY);
+        setDraftPointerWorld(p);
+      };
+      const up = (ev: PointerEvent) => {
+        window.removeEventListener("pointermove", move);
+        window.removeEventListener("pointerup", up);
+        const d = connectionDraftRef.current;
+        connectionDraftRef.current = null;
+        setConnectionDraft(null);
+        setDraftPointerWorld(null);
+        if (!d || !onLinkedConnectorCreate) return;
+        const el = document.elementFromPoint(ev.clientX, ev.clientY);
+        const h = el?.closest?.("[data-connect-anchor]") as HTMLElement | null;
+        if (h) {
+          const toId = h.getAttribute("data-item-id");
+          const toAnchor = h.getAttribute("data-anchor") as AnchorSide | null;
+          if (toId && toAnchor && toId !== d.fromItemId) {
+            onLinkedConnectorCreate({
+              fromItemId: d.fromItemId,
+              fromAnchor: d.fromAnchor,
+              toItemId: toId,
+              toAnchor,
+            });
+          }
+        }
+      };
+      window.addEventListener("pointermove", move);
+      window.addEventListener("pointerup", up);
+    },
+    [items, clientToWorld, onLinkedConnectorCreate]
   );
 
   // Freehand drawing hook
@@ -319,18 +453,28 @@ export default function BoardCanvas({
         e.preventDefault();
         return;
       }
-      
+
+      if (activeTool === "connect" && isBackground) {
+        onItemSelect(null);
+        e.preventDefault();
+        return;
+      }
+
       if (isBackground) {
         // In select mode, clicking background should clear selection (and allow drag-to-pan immediately).
         if (activeTool === "select") {
           onItemSelect(null);
+        } else if (activeTool === "multi_select") {
+          const world = clientToWorld(e.clientX, e.clientY);
+          setMarqueeRect({ startX: world.x, startY: world.y, currentX: world.x, currentY: world.y });
+          return;
         }
         isPanningRef.current = true;
         onPanStart(e.clientX, e.clientY);
         e.preventDefault();
       }
     },
-    [editingItemId, commitEditing, isDragging, activeTool, onItemSelect, onPanStart, handleFreehandMouseDown]
+    [editingItemId, commitEditing, isDragging, activeTool, onItemSelect, onPanStart, handleFreehandMouseDown, clientToWorld]
   );
 
   const handleMouseMove = useCallback(
@@ -343,8 +487,12 @@ export default function BoardCanvas({
       if (isPanningRef.current) {
         onPanUpdate(e.clientX, e.clientY);
       }
+      if (marqueeRect) {
+        const world = clientToWorld(e.clientX, e.clientY);
+        setMarqueeRect((prev) => (prev ? { ...prev, currentX: world.x, currentY: world.y } : prev));
+      }
     },
-    [onPanUpdate, handleFreehandMouseMove]
+    [onPanUpdate, handleFreehandMouseMove, marqueeRect, clientToWorld]
   );
 
   const handleMouseUp = useCallback(
@@ -358,8 +506,30 @@ export default function BoardCanvas({
         isPanningRef.current = false;
         onPanEnd();
       }
+      if (marqueeRect) {
+        const end = clientToWorld(e.clientX, e.clientY);
+        const minX = Math.min(marqueeRect.startX, end.x);
+        const maxX = Math.max(marqueeRect.startX, end.x);
+        const minY = Math.min(marqueeRect.startY, end.y);
+        const maxY = Math.max(marqueeRect.startY, end.y);
+        const selected = items
+          .filter((item) => !item.is_deleted)
+          .filter((item) => {
+            const itemRight = item.x + item.width;
+            const itemBottom = item.y + item.height;
+            return itemRight >= minX && item.x <= maxX && itemBottom >= minY && item.y <= maxY;
+          })
+          .map((item) => item.id);
+        if (selected.length > 0) {
+          onItemSelect(selected[0]);
+          selected.slice(1).forEach((id) => onItemSelect(id, { shiftKey: true }));
+        } else {
+          onItemSelect(null);
+        }
+        setMarqueeRect(null);
+      }
     },
-    [onPanEnd, handleFreehandMouseUp]
+    [onPanEnd, handleFreehandMouseUp, marqueeRect, items, onItemSelect, clientToWorld]
   );
 
   // Handle canvas click (deselect)
@@ -367,9 +537,9 @@ export default function BoardCanvas({
     (e: React.MouseEvent<HTMLDivElement>) => {
       const targetEl = e.target as HTMLElement | null;
       const isBackground = !targetEl?.closest?.('[data-board-item="true"]');
-      if (isBackground) onItemSelect(null);
+      if (isBackground && activeTool !== "multi_select") onItemSelect(null);
     },
-    [onItemSelect]
+    [onItemSelect, activeTool]
   );
 
   // Handle drop to create item
@@ -473,14 +643,8 @@ export default function BoardCanvas({
         : result.newHeight,
           };
 
-    // Optimistic update
-    const rollback = onItemUpdateOptimistic(result.itemId, updates);
-
-    // Async PATCH
-    onItemUpdateAsync(result.itemId, updates, rollback).catch((err) => {
-      console.error('Failed to persist item resize:', err);
-    });
-  }, [endResize, onItemUpdateOptimistic, onItemUpdateAsync, items]);
+    onItemUpdate(result.itemId, updates);
+  }, [endResize, items, onItemUpdate]);
 
   // Handle item drag commit (optimistic update + async PATCH)
   const handleItemDragEnd = useCallback(() => {
@@ -498,6 +662,23 @@ export default function BoardCanvas({
     };
 
     // If item is a frame, move all its children with it
+    if (selectedItemIds.length > 1 && selectedItemIds.includes(result.itemId) && onItemsBatchUpdate) {
+      const selectedSet = new Set(selectedItemIds);
+      const original = groupDragStartRef.current;
+      const baseStart = original.get(result.itemId) ?? { x: movedItem.x, y: movedItem.y };
+      const deltaX = result.newX - baseStart.x;
+      const deltaY = result.newY - baseStart.y;
+      const updates = items
+        .filter((i) => selectedSet.has(i.id))
+        .map((i) => {
+          const start = original.get(i.id) ?? { x: i.x, y: i.y };
+          return { id: i.id, x: start.x + deltaX, y: start.y + deltaY };
+        });
+      onItemsBatchUpdate(updates);
+      groupDragStartRef.current.clear();
+      return;
+    }
+
     if (movedItem.type === 'frame') {
       const deltaX = result.newX - movedItem.x;
       const deltaY = result.newY - movedItem.y;
@@ -507,42 +688,19 @@ export default function BoardCanvas({
         (i) => i.parent_item_id === movedItem.id && !i.is_deleted
       );
 
-      // Optimistically update frame position
-      const frameRollback = onItemUpdateOptimistic(result.itemId, {
-        x: result.newX,
-        y: result.newY,
-      });
-
-      // Optimistically update all children and collect rollbacks
-      const childRollbacksMap = new Map<string, () => void>();
-      childItems.forEach((child) => {
-        const childRollback = onItemUpdateOptimistic(child.id, {
+      const updates = [
+        { id: movedItem.id, x: result.newX, y: result.newY },
+        ...childItems.map((child) => ({
+          id: child.id,
           x: child.x + deltaX,
           y: child.y + deltaY,
-        });
-        childRollbacksMap.set(child.id, childRollback);
-      });
-
-      // Async update frame
-      onItemUpdateAsync(result.itemId, {
-        x: result.newX,
-        y: result.newY,
-      }, frameRollback).catch((err) => {
-        console.error('Failed to persist frame move:', err);
-      });
-
-      // Async update all children
-      childItems.forEach((child) => {
-        const childRollback = childRollbacksMap.get(child.id);
-        if (!childRollback) return;
-        
-        onItemUpdateAsync(child.id, {
-          x: child.x + deltaX,
-          y: child.y + deltaY,
-        }, childRollback).catch((err) => {
-          console.error(`Failed to persist child ${child.id} move:`, err);
-        });
-      });
+        })),
+      ];
+      if (onItemsBatchUpdate) {
+        onItemsBatchUpdate(updates);
+      } else {
+        updates.forEach(({ id, ...update }) => onItemUpdate(id, update));
+      }
     } else {
       // For non-frame items, check if they're inside a frame
       const containingFrame = findContainingFrame(newItemData);
@@ -551,23 +709,15 @@ export default function BoardCanvas({
       // Only update parent if it changed
       const needsParentUpdate = movedItem.parent_item_id !== newParentId;
       
-      // Optimistically update position
-      const positionRollback = onItemUpdateOptimistic(result.itemId, {
+      onItemUpdate(result.itemId, {
         x: result.newX,
         y: result.newY,
         ...(needsParentUpdate && { parent_item_id: newParentId }),
-      });
-
-      // Async update
-      onItemUpdateAsync(result.itemId, {
-        x: result.newX,
-        y: result.newY,
-        ...(needsParentUpdate && { parent_item_id: newParentId }),
-      }, positionRollback).catch((err) => {
-        console.error('Failed to persist item move:', err);
       });
     }
-  }, [endDrag, onItemUpdateOptimistic, onItemUpdateAsync, items, findContainingFrame]);
+  }, [endDrag, items, findContainingFrame, selectedItemIds, onItemsBatchUpdate, onItemUpdate]);
+
+  const selectionBounds = useMemo(() => getSelectionBounds(items, selectedItemIds), [items, selectedItemIds]);
 
   const canvasStyle: React.CSSProperties = {
     transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
@@ -608,24 +758,76 @@ export default function BoardCanvas({
       >
         {/* Render visible items */}
         {visibleItems.map((item) => {
-          const overridePosition = getOverridePosition(item.id);
-          const overrideSize = getOverrideSize(item.id, viewport.zoom, item.type);
+          const lineOv = getLineEndpointOverride(item.id);
+          const posOv = getOverridePosition(item.id);
+          const sizeOv = getOverrideSize(item.id, viewport.zoom, item.type);
+          const overridePosition = lineOv
+            ? { x: lineOv.x as number, y: lineOv.y as number }
+            : posOv;
+          const overrideSize = lineOv
+            ? {
+                x: lineOv.x as number,
+                y: lineOv.y as number,
+                width: lineOv.width as number,
+                height: lineOv.height as number,
+              }
+            : sizeOv;
+          const overrideRotation =
+            lineOv?.rotation !== undefined && lineOv.rotation !== null
+              ? lineOv.rotation
+              : undefined;
           const isEditing = editingItemId === item.id;
+          const canLineEndpoints =
+            (item.type === "line" || (item.type === "connector" && !item.style?.connection)) &&
+            selectedItemIds.length === 1 &&
+            selectedItemIds.includes(item.id);
           return (
             <BoardItemContainer
             key={item.id}
             item={item}
               viewport={viewport}
               canvasRef={canvasRef}
-            isSelected={selectedItemId === item.id}
+            isSelected={selectedItemIds.includes(item.id)}
+              selectionCount={selectedItemIds.length}
               overridePosition={overridePosition}
               overrideSize={overrideSize}
+              overrideRotation={overrideRotation}
               activeTool={activeTool}
+              onLineEndpointDragStart={
+                canLineEndpoints
+                  ? (endpoint) => startLineEndpointDrag(item, endpoint)
+                  : undefined
+              }
+              onLineEndpointDragMove={canLineEndpoints ? updateLineEndpointDrag : undefined}
+              onLineEndpointDragEnd={canLineEndpoints ? handleLineEndpointDragEnd : undefined}
               // Allow dragging items with any tool (freehand tool handles background drawing separately)
               // Only disable dragging when editing item content
-              disableDrag={isEditing}
-              disableResize={isEditing}
-            onSelect={() => onItemSelect(item.id)}
+              disableDrag={
+                isEditing || (item.type === "connector" && Boolean(item.style?.connection))
+              }
+              disableResize={
+                isEditing || (item.type === "connector" && Boolean(item.style?.connection))
+              }
+              showConnectAnchors={
+                (activeTool === "connect" || connectionDraft !== null) &&
+                itemSupportsConnectAnchors(item.type)
+              }
+              onConnectAnchorPointerDown={
+                activeTool === "connect" || connectionDraft !== null
+                  ? handleConnectAnchorPointerDown
+                  : undefined
+              }
+            onSelect={(event) => {
+              if (selectedItemIds.length > 1 && selectedItemIds.includes(item.id)) {
+                const selectedSet = new Set(selectedItemIds);
+                groupDragStartRef.current = new Map(
+                  items.filter((i) => selectedSet.has(i.id)).map((i) => [i.id, { x: i.x, y: i.y }])
+                );
+              } else {
+                groupDragStartRef.current.clear();
+              }
+              onItemSelect(item.id, event);
+            }}
             onUpdate={(updates) => onItemUpdate(item.id, updates)}
               onRequestEdit={() => startEditing(item)}
               onDragStart={startDrag}
@@ -637,7 +839,68 @@ export default function BoardCanvas({
           />
           );
         })}
+        {connectionDraft && draftPointerWorld && (() => {
+          const x1 = connectionDraft.fromWorld.x;
+          const y1 = connectionDraft.fromWorld.y;
+          const x2 = draftPointerWorld.x;
+          const y2 = draftPointerWorld.y;
+          const minX = Math.min(x1, x2) - 4;
+          const minY = Math.min(y1, y2) - 4;
+          const maxX = Math.max(x1, x2) + 4;
+          const maxY = Math.max(y1, y2) + 4;
+          const w = Math.max(maxX - minX, 8);
+          const h = Math.max(maxY - minY, 8);
+          return (
+            <svg
+              style={{
+                position: "absolute",
+                left: minX,
+                top: minY,
+                width: w,
+                height: h,
+                pointerEvents: "none",
+                zIndex: 50,
+                overflow: "visible",
+              }}
+            >
+              <line
+                x1={x1 - minX}
+                y1={y1 - minY}
+                x2={x2 - minX}
+                y2={y2 - minY}
+                stroke="#3b82f6"
+                strokeWidth={2 / viewport.zoom}
+              />
+            </svg>
+          );
+        })()}
       </div>
+
+      {selectionBounds && selectedItemIds.length > 1 && (
+        <div
+          className="absolute border-2 border-blue-500/80 pointer-events-none"
+          style={{
+            left: selectionBounds.x * viewport.zoom + viewport.x,
+            top: selectionBounds.y * viewport.zoom + viewport.y,
+            width: selectionBounds.width * viewport.zoom,
+            height: selectionBounds.height * viewport.zoom,
+            zIndex: 60,
+          }}
+        />
+      )}
+
+      {marqueeRect && (
+        <div
+          className="absolute border border-blue-500 bg-blue-100/20 pointer-events-none"
+          style={{
+            left: Math.min(marqueeRect.startX, marqueeRect.currentX) * viewport.zoom + viewport.x,
+            top: Math.min(marqueeRect.startY, marqueeRect.currentY) * viewport.zoom + viewport.y,
+            width: Math.abs(marqueeRect.currentX - marqueeRect.startX) * viewport.zoom,
+            height: Math.abs(marqueeRect.currentY - marqueeRect.startY) * viewport.zoom,
+            zIndex: 70,
+          }}
+        />
+      )}
 
       {/* Freehand draft overlay (in screen coordinates, not world) */}
       {freehandDraft.length > 0 && brushSettings && (

--- a/frontend/src/components/miro/BoardHeader.tsx
+++ b/frontend/src/components/miro/BoardHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { ZoomIn, ZoomOut, Maximize2, Share2, ArrowLeft, Save, Camera, Eye } from "lucide-react";
+import { ZoomIn, ZoomOut, Maximize2, Share2, ArrowLeft, Save, Camera, Eye, Undo2, Redo2 } from "lucide-react";
 import { Viewport } from "./hooks/useBoardViewport";
 import { useRouter } from "next/navigation";
 
@@ -17,6 +17,10 @@ interface BoardHeaderProps {
   shareToken: string;
   onSnapshotClick?: () => void;
   onPreviewClick?: () => void;
+  onUndo?: () => void;
+  onRedo?: () => void;
+  canUndo?: boolean;
+  canRedo?: boolean;
 }
 
 export default function BoardHeader({
@@ -31,6 +35,10 @@ export default function BoardHeader({
   shareToken,
   onSnapshotClick,
   onPreviewClick,
+  onUndo,
+  onRedo,
+  canUndo = false,
+  canRedo = false,
 }: BoardHeaderProps) {
   const router = useRouter();
 
@@ -92,6 +100,26 @@ export default function BoardHeader({
             title="Preview"
           >
             <Eye className="w-4 h-4" />
+          </button>
+        )}
+        {onUndo && (
+          <button
+            onClick={onUndo}
+            disabled={!canUndo}
+            className={`p-2 rounded ${canUndo ? "hover:bg-gray-100" : "opacity-40 cursor-not-allowed"}`}
+            title="Undo (Cmd/Ctrl+Z)"
+          >
+            <Undo2 className="w-4 h-4" />
+          </button>
+        )}
+        {onRedo && (
+          <button
+            onClick={onRedo}
+            disabled={!canRedo}
+            className={`p-2 rounded ${canRedo ? "hover:bg-gray-100" : "opacity-40 cursor-not-allowed"}`}
+            title="Redo (Cmd+Shift+Z / Ctrl+Y)"
+          >
+            <Redo2 className="w-4 h-4" />
           </button>
         )}
         <button

--- a/frontend/src/components/miro/BoardPropertiesPanel.tsx
+++ b/frontend/src/components/miro/BoardPropertiesPanel.tsx
@@ -1,12 +1,20 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
+import dynamic from "next/dynamic";
 import { BoardItem } from "@/lib/api/miroApi";
 import { Trash2 } from "lucide-react";
 import { ToolType } from "./hooks/useToolDnD";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import type { EmojiClickData } from "emoji-picker-react";
+
+const EmojiPicker = dynamic(() => import("emoji-picker-react").then((m) => m.default), {
+  ssr: false,
+});
 
 interface BoardPropertiesPanelProps {
   selectedItem: BoardItem | null;
+  selectedItemsCount?: number;
   activeTool?: ToolType;
   brushSettings?: {
     strokeColor: string;
@@ -19,12 +27,15 @@ interface BoardPropertiesPanelProps {
 
 export default function BoardPropertiesPanel({
   selectedItem,
+  selectedItemsCount = 0,
   activeTool,
   brushSettings,
   onBrushSettingsChange,
   onUpdate,
   onDelete,
 }: BoardPropertiesPanelProps) {
+  const [emojiReplaceOpen, setEmojiReplaceOpen] = useState(false);
+
   // Show brush configuration when freehand tool is active and no item is selected
   if (!selectedItem && activeTool === "freehand" && brushSettings && onBrushSettingsChange) {
     return (
@@ -71,6 +82,21 @@ export default function BoardPropertiesPanel({
   }
 
   if (!selectedItem) {
+    if (selectedItemsCount > 1) {
+      return (
+        <div className="w-64 border-l bg-white p-4 overflow-y-auto">
+          <h3 className="text-sm font-semibold text-gray-700 mb-4">Multi-selection</h3>
+          <p className="text-sm text-gray-500 mb-4">{selectedItemsCount} items selected</p>
+          <button
+            onClick={onDelete}
+            className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-red-50 text-red-700 rounded hover:bg-red-100"
+          >
+            <Trash2 className="w-4 h-4" />
+            <span className="text-sm">Delete Selected</span>
+          </button>
+        </div>
+      );
+    }
     return (
       <div className="w-64 border-l bg-white p-4">
         <h3 className="text-sm font-semibold text-gray-700 mb-4">
@@ -135,6 +161,106 @@ export default function BoardPropertiesPanel({
             />
           </div>
         </div>
+
+        {selectedItem.type === "emoji" && (
+          <div>
+            <label className="text-xs font-medium text-gray-600">Emoji</label>
+            <div className="flex gap-2 mt-1 items-center">
+              <input
+                type="text"
+                value={selectedItem.content || ""}
+                onChange={(e) => onUpdate({ content: e.target.value })}
+                className="flex-1 text-sm border rounded px-2 py-1"
+                placeholder="Paste or type an emoji"
+              />
+              <Popover open={emojiReplaceOpen} onOpenChange={setEmojiReplaceOpen}>
+                <PopoverTrigger asChild>
+                  <button
+                    type="button"
+                    className="text-xs px-2 py-1 border rounded bg-white hover:bg-gray-50 shrink-0"
+                  >
+                    Replace…
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent
+                  className="w-auto max-h-[min(420px,70vh)] overflow-y-auto p-0 border-0 shadow-lg"
+                  align="end"
+                  onOpenAutoFocus={(e) => e.preventDefault()}
+                >
+                  <EmojiPicker
+                    onEmojiClick={(data: EmojiClickData) => {
+                      onUpdate({ content: data.emoji });
+                      setEmojiReplaceOpen(false);
+                    }}
+                    width={280}
+                    height={360}
+                  />
+                </PopoverContent>
+              </Popover>
+            </div>
+            <p className="text-[11px] text-gray-500 mt-1">
+              Resize the box to scale; optional fixed size below overrides auto sizing.
+            </p>
+            <label className="text-xs font-medium text-gray-600 mt-2 block">
+              Font size:{" "}
+              {typeof selectedItem.style?.fontSize === "number"
+                ? `${selectedItem.style.fontSize}px`
+                : `Auto (${Math.round(
+                    Math.max(16, Math.min(selectedItem.height * 0.72, selectedItem.width * 0.72))
+                  )}px preview)`}
+            </label>
+            <input
+              type="range"
+              min={8}
+              max={200}
+              value={
+                typeof selectedItem.style?.fontSize === "number"
+                  ? selectedItem.style.fontSize
+                  : Math.round(
+                      Math.max(16, Math.min(selectedItem.height * 0.72, selectedItem.width * 0.72))
+                    )
+              }
+              onChange={(e) => {
+                const n = parseInt(e.target.value, 10);
+                onUpdate({
+                  style: {
+                    ...selectedItem.style,
+                    fontSize: n,
+                  },
+                });
+              }}
+              className="w-full mt-1"
+            />
+            <input
+              type="number"
+              min={8}
+              max={200}
+              value={
+                typeof selectedItem.style?.fontSize === "number"
+                  ? selectedItem.style.fontSize
+                  : ""
+              }
+              placeholder="Auto"
+              onChange={(e) => {
+                const v = e.target.value;
+                if (v === "") {
+                  const { fontSize: _f, ...rest } = selectedItem.style || {};
+                  onUpdate({ style: rest });
+                  return;
+                }
+                const n = parseInt(v, 10);
+                if (!Number.isFinite(n)) return;
+                onUpdate({
+                  style: {
+                    ...selectedItem.style,
+                    fontSize: n,
+                  },
+                });
+              }}
+              className="w-full text-sm border rounded px-2 py-1 mt-1"
+            />
+          </div>
+        )}
 
         {/* Content (for text, sticky notes, and shapes) */}
         {(selectedItem.type === "text" || selectedItem.type === "sticky_note" || selectedItem.type === "shape") && (
@@ -590,6 +716,13 @@ export default function BoardPropertiesPanel({
         {/* Connector properties */}
         {selectedItem.type === "connector" && (
           <>
+            {selectedItem.style?.connection && (
+              <p className="text-xs text-gray-500 mb-2">
+                Linked connector — moving attached items updates the curve. Adjust stroke below.
+              </p>
+            )}
+            {!selectedItem.style?.connection && (
+            <>
             <div>
               <label className="text-xs font-medium text-gray-600">Content</label>
               <textarea
@@ -690,6 +823,8 @@ export default function BoardPropertiesPanel({
                 min="1"
               />
             </div>
+            </>
+            )}
             <div>
               <label className="text-xs font-medium text-gray-600">Stroke Color</label>
               <input

--- a/frontend/src/components/miro/BoardToolbar.tsx
+++ b/frontend/src/components/miro/BoardToolbar.tsx
@@ -1,14 +1,22 @@
 "use client";
 
-import React from "react";
-import { Type, Square, StickyNote, Frame, Minus, GitBranch, PenTool, ArrowUpLeft } from "lucide-react";
+import React, { useState } from "react";
+import dynamic from "next/dynamic";
+import { Type, Square, StickyNote, Frame, Minus, Link2, PenTool, ArrowUpLeft, ScanSearch, Smile } from "lucide-react";
 import { LineVariant, ToolOptions, ToolType, useToolDnD } from "./hooks/useToolDnD";
 import { Tooltip } from "@/components/overlay/OverlayPrimitives";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import type { EmojiClickData } from "emoji-picker-react";
+
+const EmojiPicker = dynamic(() => import("emoji-picker-react").then((m) => m.default), {
+  ssr: false,
+});
 
 interface BoardToolbarProps {
   activeTool: ToolType;
   onToolChange: (tool: ToolType) => void;
   onToolPrimaryAction: (tool: ToolType, options?: ToolOptions) => void;
+  onEmojiInsert: (emoji: string) => void;
   lineVariant: LineVariant;
   onLineVariantChange: (variant: LineVariant) => void;
 }
@@ -17,13 +25,16 @@ export default function BoardToolbar({
   activeTool,
   onToolChange,
   onToolPrimaryAction,
+  onEmojiInsert,
   lineVariant,
   onLineVariantChange,
 }: BoardToolbarProps) {
   const { handleDragStart, handleDragEnd } = useToolDnD();
+  const [emojiOpen, setEmojiOpen] = useState(false);
 
   const tools: Array<{ type: ToolType; icon: React.ReactNode; label: string }> = [
     { type: "select", icon: <ArrowUpLeft className="w-5 h-5" />, label: "Select" },
+    { type: "multi_select", icon: <ScanSearch className="w-5 h-5" />, label: "Multi-select" },
     { type: "text", icon: <Type className="w-5 h-5" />, label: "Text" },
     { type: "shape", icon: <Square className="w-5 h-5" />, label: "Shape" },
     {
@@ -34,23 +45,79 @@ export default function BoardToolbar({
     { type: "frame", icon: <Frame className="w-5 h-5" />, label: "Frame" },
     { type: "line", icon: <Minus className="w-5 h-5" />, label: "Line" },
     {
-      type: "connector",
-      icon: <GitBranch className="w-5 h-5" />,
-      label: "Connector",
+      type: "connect",
+      icon: <Link2 className="w-5 h-5" />,
+      label: "Connect",
     },
     {
       type: "freehand",
       icon: <PenTool className="w-5 h-5" />,
       label: "brush",
     },
+    { type: "emoji", icon: <Smile className="w-5 h-5" />, label: "Emoji" },
   ];
 
   return (
     <div className="w-16 border-r bg-white flex flex-col items-center py-4 gap-2">
       {tools.map((tool) => {
-        const isSelect = tool.type === "select";
+        if (tool.type === "emoji") {
+          return (
+            <div key="emoji" className="flex flex-col items-center">
+              <Popover
+                open={emojiOpen}
+                onOpenChange={(open) => {
+                  setEmojiOpen(open);
+                  if (open) onToolChange("emoji");
+                }}
+              >
+                <Tooltip content={tool.label} side="right">
+                  <PopoverTrigger asChild>
+                    <button
+                      type="button"
+                      draggable
+                      onDragStart={(e) =>
+                        handleDragStart(e, "emoji", { emoji: "😀" })
+                      }
+                      onDragEnd={handleDragEnd}
+                      className={`p-2 rounded cursor-move ${
+                        activeTool === "emoji"
+                          ? "bg-blue-100 text-blue-700"
+                          : "hover:bg-gray-100 text-gray-600"
+                      }`}
+                      aria-label={tool.label}
+                    >
+                      {tool.icon}
+                    </button>
+                  </PopoverTrigger>
+                </Tooltip>
+                <PopoverContent
+                  side="right"
+                  align="start"
+                  className="w-auto max-h-[min(420px,70vh)] overflow-y-auto p-0 border-0 shadow-lg"
+                  onOpenAutoFocus={(e) => e.preventDefault()}
+                >
+                  <EmojiPicker
+                    onEmojiClick={(data: EmojiClickData) => {
+                      onEmojiInsert(data.emoji);
+                      setEmojiOpen(false);
+                      onToolChange("select");
+                    }}
+                    width={320}
+                    height={400}
+                  />
+                </PopoverContent>
+              </Popover>
+            </div>
+          );
+        }
+
+        const isSelect = tool.type === "select" || tool.type === "multi_select";
         const isPrimaryClickCreate =
-          tool.type !== "select" && tool.type !== "freehand" && tool.type !== "line";
+          tool.type !== "select" &&
+          tool.type !== "multi_select" &&
+          tool.type !== "freehand" &&
+          tool.type !== "line" &&
+          tool.type !== "connect";
         const lineToolIsActive = tool.type === "line" && activeTool === "line";
         return (
           <div key={tool.type} className="flex flex-col items-center">

--- a/frontend/src/components/miro/hooks/useBoardItemHistory.ts
+++ b/frontend/src/components/miro/hooks/useBoardItemHistory.ts
@@ -1,0 +1,77 @@
+import { useCallback, useMemo, useState } from "react";
+import { BoardItem } from "@/lib/api/miroApi";
+
+type HistoryEntry = {
+  undo: () => Promise<void>;
+  redo: () => Promise<void>;
+};
+
+export function useBoardItemHistory() {
+  const [undoStack, setUndoStack] = useState<HistoryEntry[]>([]);
+  const [redoStack, setRedoStack] = useState<HistoryEntry[]>([]);
+  const [isApplying, setIsApplying] = useState(false);
+
+  const canUndo = useMemo(() => undoStack.length > 0 && !isApplying, [undoStack.length, isApplying]);
+  const canRedo = useMemo(() => redoStack.length > 0 && !isApplying, [redoStack.length, isApplying]);
+
+  const push = useCallback((entry: HistoryEntry) => {
+    setUndoStack((prev) => [...prev, entry]);
+    setRedoStack([]);
+  }, []);
+
+  const runWithLock = useCallback(async (fn: () => Promise<void>) => {
+    if (isApplying) return;
+    setIsApplying(true);
+    try {
+      await fn();
+    } finally {
+      setIsApplying(false);
+    }
+  }, [isApplying]);
+
+  const undo = useCallback(async () => {
+    const entry = undoStack[undoStack.length - 1];
+    if (!entry || isApplying) return;
+
+    await runWithLock(async () => {
+      await entry.undo();
+      setUndoStack((prev) => prev.slice(0, -1));
+      setRedoStack((prev) => [...prev, entry]);
+    });
+  }, [undoStack, runWithLock, isApplying]);
+
+  const redo = useCallback(async () => {
+    const entry = redoStack[redoStack.length - 1];
+    if (!entry || isApplying) return;
+
+    await runWithLock(async () => {
+      await entry.redo();
+      setRedoStack((prev) => prev.slice(0, -1));
+      setUndoStack((prev) => [...prev, entry]);
+    });
+  }, [redoStack, runWithLock, isApplying]);
+
+  const buildUpdateEntry = useCallback(
+    (
+      before: BoardItem[],
+      after: BoardItem[],
+      applySnapshot: (items: BoardItem[]) => Promise<void>
+    ) => {
+      return {
+        undo: async () => applySnapshot(before),
+        redo: async () => applySnapshot(after),
+      } satisfies HistoryEntry;
+    },
+    []
+  );
+
+  return {
+    push,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    isApplyingHistory: isApplying,
+    buildUpdateEntry,
+  };
+}

--- a/frontend/src/components/miro/hooks/useBoardItems.ts
+++ b/frontend/src/components/miro/hooks/useBoardItems.ts
@@ -1,11 +1,12 @@
 import { useState, useCallback } from 'react';
 import { miroApi, BoardItem, CreateBoardItemData, UpdateBoardItemData } from '@/lib/api/miroApi';
+import { applyConnectorLayouts } from '@/components/miro/utils/connectorLayout';
 
 export function useBoardItems(boardId: string) {
   const [items, setItems] = useState<BoardItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
+  const [selectedItemIds, setSelectedItemIds] = useState<string[]>([]);
 
   // Load items
   const loadItems = useCallback(async () => {
@@ -13,7 +14,7 @@ export function useBoardItems(boardId: string) {
     setError(null);
     try {
       const boardItems = await miroApi.getBoardItems(boardId);
-      setItems(boardItems);
+      setItems(applyConnectorLayouts(boardItems));
     } catch (err: any) {
       console.error('Failed to load board items:', err);
       setError(err instanceof Error ? err.message : 'Failed to load items');
@@ -27,7 +28,7 @@ export function useBoardItems(boardId: string) {
     async (data: CreateBoardItemData) => {
       try {
         const newItem = await miroApi.createBoardItem(boardId, data);
-        setItems((prev) => [...prev, newItem]);
+        setItems((prev) => applyConnectorLayouts([...prev, newItem]));
         return newItem;
       } catch (err: any) {
         console.error('Failed to create item:', err);
@@ -44,7 +45,9 @@ export function useBoardItems(boardId: string) {
         throw new Error('updateItem called without itemId');
       }
       const updatedItem = await miroApi.updateBoardItem(itemId, data);
-      setItems((prev) => prev.map((item) => (item.id === itemId ? updatedItem : item)));
+      setItems((prev) =>
+        applyConnectorLayouts(prev.map((item) => (item.id === itemId ? updatedItem : item)))
+      );
       return updatedItem;
     } catch (err: any) {
       console.error('Failed to update item:', err);
@@ -67,15 +70,17 @@ export function useBoardItems(boardId: string) {
         return prev;
       }
       previousItem = item;
-      return prev.map((i) =>
-        i.id === itemId ? { ...i, ...data } : i
+      return applyConnectorLayouts(
+        prev.map((i) => (i.id === itemId ? { ...i, ...data } : i))
       );
     });
 
     // Return rollback function
     return () => {
       if (previousItem) {
-        setItems((prev) => prev.map((item) => (item.id === itemId ? previousItem! : item)));
+        setItems((prev) =>
+          applyConnectorLayouts(prev.map((item) => (item.id === itemId ? previousItem! : item)))
+        );
       }
     };
   }, []);
@@ -88,7 +93,9 @@ export function useBoardItems(boardId: string) {
   ) => {
     try {
       const updatedItem = await miroApi.updateBoardItem(itemId, data);
-      setItems((prev) => prev.map((item) => (item.id === itemId ? updatedItem : item)));
+      setItems((prev) =>
+        applyConnectorLayouts(prev.map((item) => (item.id === itemId ? updatedItem : item)))
+      );
       return updatedItem;
     } catch (err: any) {
       console.error('Failed to update item (rolling back):', err);
@@ -105,15 +112,15 @@ export function useBoardItems(boardId: string) {
       }
       // Use PATCH to set is_deleted=true instead of DELETE
       const updatedItem = await miroApi.updateBoardItem(itemId, { is_deleted: true });
-      setItems((prev) => prev.map((item) => (item.id === itemId ? updatedItem : item)));
-      if (selectedItemId === itemId) {
-        setSelectedItemId(null);
-      }
+      setItems((prev) =>
+        applyConnectorLayouts(prev.map((item) => (item.id === itemId ? updatedItem : item)))
+      );
+      setSelectedItemIds((prev) => prev.filter((id) => id !== itemId));
     } catch (err: any) {
       console.error('Failed to delete item:', err);
       throw err;
     }
-  }, [selectedItemId]);
+  }, []);
 
   // Batch update items
   const batchUpdateItems = useCallback(
@@ -123,7 +130,7 @@ export function useBoardItems(boardId: string) {
         // Update local state with successful updates
         setItems((prev) => {
           const updatedMap = new Map(result.updated.map((item) => [item.id, item]));
-          return prev.map((item) => updatedMap.get(item.id) || item);
+          return applyConnectorLayouts(prev.map((item) => updatedMap.get(item.id) || item));
         });
         return result;
       } catch (err: any) {
@@ -134,12 +141,62 @@ export function useBoardItems(boardId: string) {
     [boardId]
   );
 
+  const removeItemsOptimistic = useCallback((itemIds: string[]) => {
+    const idSet = new Set(itemIds);
+    const previousItems = new Map<string, BoardItem>();
+    setItems((prev) =>
+      applyConnectorLayouts(
+        prev.map((item) => {
+          if (!idSet.has(item.id)) return item;
+          previousItems.set(item.id, item);
+          return { ...item, is_deleted: true };
+        })
+      )
+    );
+    setSelectedItemIds((prev) => prev.filter((id) => !idSet.has(id)));
+
+    return () => {
+      setItems((prev) =>
+        applyConnectorLayouts(
+          prev.map((item) => {
+            const previous = previousItems.get(item.id);
+            return previous ?? item;
+          })
+        )
+      );
+    };
+  }, []);
+
+  const restoreItemsOptimistic = useCallback((itemIds: string[]) => {
+    const idSet = new Set(itemIds);
+    const previousItems = new Map<string, BoardItem>();
+    setItems((prev) =>
+      applyConnectorLayouts(
+        prev.map((item) => {
+          if (!idSet.has(item.id)) return item;
+          previousItems.set(item.id, item);
+          return { ...item, is_deleted: false };
+        })
+      )
+    );
+    return () => {
+      setItems((prev) =>
+        applyConnectorLayouts(
+          prev.map((item) => {
+            const previous = previousItems.get(item.id);
+            return previous ?? item;
+          })
+        )
+      );
+    };
+  }, []);
+
   return {
     items,
     loading,
     error,
-    selectedItemId,
-    setSelectedItemId,
+    selectedItemIds,
+    setSelectedItemIds,
     loadItems,
     createItem,
     updateItem,
@@ -147,6 +204,8 @@ export function useBoardItems(boardId: string) {
     updateItemAsync,
     deleteItem,
     batchUpdateItems,
+    removeItemsOptimistic,
+    restoreItemsOptimistic,
   };
 }
 

--- a/frontend/src/components/miro/hooks/useBoardViewport.ts
+++ b/frontend/src/components/miro/hooks/useBoardViewport.ts
@@ -95,6 +95,14 @@ export function useBoardViewport(initialViewport: Viewport) {
     isPanningRef.current = false;
   }, []);
 
+  const panBy = useCallback((dx: number, dy: number) => {
+    _setViewport((prev) => ({
+      ...prev,
+      x: prev.x - dx,
+      y: prev.y - dy,
+    }));
+  }, []);
+
   return {
     viewport,
     setViewport,
@@ -104,6 +112,7 @@ export function useBoardViewport(initialViewport: Viewport) {
     startPan,
     updatePan,
     endPan,
+    panBy,
   };
 }
 

--- a/frontend/src/components/miro/hooks/useLineEndpointDrag.ts
+++ b/frontend/src/components/miro/hooks/useLineEndpointDrag.ts
@@ -1,0 +1,90 @@
+import { useCallback, useRef, useState } from "react";
+import { BoardItem } from "@/lib/api/miroApi";
+import { lineEndpointsWorld, lineItemFromPivotAndEndWorld } from "../utils/lineEndpointMath";
+
+export type LineEndpoint = "start" | "end";
+
+type DragState = {
+  itemId: string;
+  moving: LineEndpoint;
+  fixedWorld: { x: number; y: number };
+  height: number;
+};
+
+export function useLineEndpointDrag() {
+  const dragRef = useRef<DragState | null>(null);
+  const [tick, setTick] = useState(0);
+  const currentWorldRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+
+  const startDrag = useCallback((item: BoardItem, moving: LineEndpoint) => {
+    const { start, end } = lineEndpointsWorld(item);
+    const fixedWorld = moving === "end" ? start : end;
+    dragRef.current = {
+      itemId: item.id,
+      moving,
+      fixedWorld,
+      height: item.height,
+    };
+    currentWorldRef.current = moving === "end" ? { ...end } : { ...start };
+    setTick((t) => t + 1);
+  }, []);
+
+  const updateDrag = useCallback((worldX: number, worldY: number) => {
+    if (!dragRef.current) return;
+    currentWorldRef.current = { x: worldX, y: worldY };
+    setTick((t) => t + 1);
+  }, []);
+
+  const endDrag = useCallback((): (Partial<BoardItem> & { id: string }) | null => {
+    const d = dragRef.current;
+    if (!d) return null;
+    const { moving, fixedWorld, height } = d;
+    const cur = currentWorldRef.current;
+    const geom =
+      moving === "end"
+        ? lineItemFromPivotAndEndWorld(fixedWorld, cur, height)
+        : lineItemFromPivotAndEndWorld(cur, fixedWorld, height);
+    dragRef.current = null;
+    setTick((t) => t + 1);
+    return {
+      id: d.itemId,
+      x: geom.x,
+      y: geom.y,
+      width: geom.width,
+      height: geom.height,
+      rotation: geom.rotation,
+    };
+  }, []);
+
+  const getOverride = useCallback(
+    (itemId: string): Partial<BoardItem> | null => {
+      const d = dragRef.current;
+      if (!d || d.itemId !== itemId) return null;
+      const { moving, fixedWorld, height } = d;
+      const cur = currentWorldRef.current;
+      const geom =
+        moving === "end"
+          ? lineItemFromPivotAndEndWorld(fixedWorld, cur, height)
+          : lineItemFromPivotAndEndWorld(cur, fixedWorld, height);
+      return {
+        x: geom.x,
+        y: geom.y,
+        width: geom.width,
+        height: geom.height,
+        rotation: geom.rotation,
+      };
+    },
+    [tick]
+  );
+
+  const isDragging = dragRef.current !== null;
+
+  return {
+    startDrag,
+    updateDrag,
+    endDrag,
+    getOverride,
+    isDragging,
+    lineEndpointDragTick: tick,
+  };
+}

--- a/frontend/src/components/miro/hooks/useToolDnD.ts
+++ b/frontend/src/components/miro/hooks/useToolDnD.ts
@@ -2,13 +2,15 @@ import { useCallback } from 'react';
 
 export type ToolType =
   | "select"
+  | "multi_select"
   | "text"
   | "shape"
   | "sticky_note"
   | "frame"
   | "line"
-  | "connector"
-  | "freehand";
+  | "connect"
+  | "freehand"
+  | "emoji";
 
 export type LineVariant =
   | "straight_solid"
@@ -19,13 +21,15 @@ export type LineVariant =
 
 export type ToolOptions = {
   lineVariant?: LineVariant;
+  /** Default emoji when dragging the emoji tool onto the canvas */
+  emoji?: string;
 };
 
 export const TOOL_DND_MIME = "application/x-miro-tool";
 
 export function useToolDnD() {
   const handleDragStart = useCallback((e: React.DragEvent, toolType: ToolType, options?: ToolOptions) => {
-    if (toolType === "select") {
+    if (toolType === "select" || toolType === "multi_select") {
       e.preventDefault();
       return;
     }

--- a/frontend/src/components/miro/items/BoardItemContainer.tsx
+++ b/frontend/src/components/miro/items/BoardItemContainer.tsx
@@ -5,6 +5,10 @@ import { BoardItem } from "@/lib/api/miroApi";
 import { Viewport } from "../hooks/useBoardViewport";
 import { ToolType } from "../hooks/useToolDnD";
 import BoardItemRenderer from "./BoardItemRenderer";
+import { usesLinePivotTransform } from "../utils/lineEndpointMath";
+import type { LineEndpoint } from "../hooks/useLineEndpointDrag";
+import type { AnchorSide } from "../utils/connectorLayout";
+import { itemSupportsConnectAnchors } from "../utils/connectorLayout";
 
 type ResizeCorner = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 
@@ -13,12 +17,17 @@ interface BoardItemContainerProps {
   viewport: Viewport;
   canvasRef: React.RefObject<HTMLDivElement>;
   isSelected: boolean;
+  selectionCount?: number;
   overridePosition: { x: number; y: number } | null;
   overrideSize?: { x: number; y: number; width: number; height: number } | null;
+  overrideRotation?: number | null;
   activeTool?: ToolType;
   disableDrag?: boolean;
   disableResize?: boolean;
-  onSelect: () => void;
+  onLineEndpointDragStart?: (endpoint: LineEndpoint) => void;
+  onLineEndpointDragMove?: (worldX: number, worldY: number) => void;
+  onLineEndpointDragEnd?: () => void;
+  onSelect: (event?: { shiftKey: boolean; metaKey: boolean; ctrlKey: boolean }) => void;
   onUpdate: (updates: Partial<BoardItem>) => void;
   onRequestEdit?: () => void;
   onDragStart: (itemId: string, itemX: number, itemY: number, worldX: number, worldY: number) => void;
@@ -27,6 +36,8 @@ interface BoardItemContainerProps {
   onResizeStart: (itemId: string, corner: ResizeCorner, itemX: number, itemY: number, itemWidth: number, itemHeight: number, clientX: number, clientY: number) => void;
   onResizeMove: (clientX: number, clientY: number) => void;
   onResizeEnd: () => void;
+  showConnectAnchors?: boolean;
+  onConnectAnchorPointerDown?: (itemId: string, anchor: AnchorSide, e: React.PointerEvent) => void;
 }
 
 const BoardItemContainer = memo(function BoardItemContainer({
@@ -34,11 +45,16 @@ const BoardItemContainer = memo(function BoardItemContainer({
   viewport,
   canvasRef,
   isSelected,
+  selectionCount = 1,
   overridePosition,
   overrideSize,
+  overrideRotation,
   activeTool,
   disableDrag = false,
   disableResize = false,
+  onLineEndpointDragStart,
+  onLineEndpointDragMove,
+  onLineEndpointDragEnd,
   onSelect,
   onUpdate,
   onRequestEdit,
@@ -48,6 +64,8 @@ const BoardItemContainer = memo(function BoardItemContainer({
   onResizeStart,
   onResizeMove,
   onResizeEnd,
+  showConnectAnchors = false,
+  onConnectAnchorPointerDown,
 }: BoardItemContainerProps) {
   // Treat pointer interaction as click by default; only become a drag after moving past a small threshold.
   const isDraggingRef = React.useRef(false);
@@ -58,6 +76,7 @@ const BoardItemContainer = memo(function BoardItemContainer({
   // Resize state
   const isResizingRef = React.useRef(false);
   const resizeCornerRef = React.useRef<ResizeCorner | null>(null);
+  const isLineEndpointDraggingRef = React.useRef(false);
 
   const cleanupPointerInteraction = useCallback((target: Element, pointerId?: number) => {
     isDraggingRef.current = false;
@@ -118,8 +137,51 @@ const BoardItemContainer = memo(function BoardItemContainer({
     [item, overridePosition, overrideSize, onResizeStart]
   );
 
+  const handleLineEndpointPointerDown = useCallback(
+    (e: React.PointerEvent, endpoint: LineEndpoint) => {
+      e.stopPropagation();
+      e.preventDefault();
+      if (!onLineEndpointDragStart || !onLineEndpointDragMove || !onLineEndpointDragEnd) return;
+      isLineEndpointDraggingRef.current = true;
+      onLineEndpointDragStart(endpoint);
+      const w = screenToWorld(e.clientX, e.clientY);
+      onLineEndpointDragMove(w.x, w.y);
+      e.currentTarget.setPointerCapture(e.pointerId);
+    },
+    [onLineEndpointDragStart, onLineEndpointDragMove, onLineEndpointDragEnd, screenToWorld]
+  );
+
+  const handleLineEndpointPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isLineEndpointDraggingRef.current || !onLineEndpointDragMove) return;
+      const w = screenToWorld(e.clientX, e.clientY);
+      onLineEndpointDragMove(w.x, w.y);
+    },
+    [onLineEndpointDragMove, screenToWorld]
+  );
+
+  const handleLineEndpointPointerUp = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isLineEndpointDraggingRef.current) return;
+      isLineEndpointDraggingRef.current = false;
+      onLineEndpointDragEnd?.();
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        // ignore
+      }
+    },
+    [onLineEndpointDragEnd]
+  );
+
   const handlePointerDown = useCallback(
     (e: React.PointerEvent) => {
+      if ((e.target as HTMLElement).closest(".connect-anchor-handle")) {
+        return;
+      }
+      if ((e.target as HTMLElement).classList.contains("line-endpoint-handle")) {
+        return;
+      }
       // Don't start drag if clicking on a resize handle
       if ((e.target as HTMLElement).classList.contains('resize-handle')) {
         return;
@@ -129,13 +191,13 @@ const BoardItemContainer = memo(function BoardItemContainer({
       // Allow events to bubble to BoardCanvas for freehand drawing handling
       if (activeTool === "freehand") {
         // Still allow selection on click
-        onSelect();
+        onSelect({ shiftKey: e.shiftKey, metaKey: e.metaKey, ctrlKey: e.ctrlKey });
         return;
       }
 
       e.stopPropagation();
       // Select immediately so properties panel opens without waiting for click.
-      onSelect();
+      onSelect({ shiftKey: e.shiftKey, metaKey: e.metaKey, ctrlKey: e.ctrlKey });
 
       if (disableDrag) {
         return;
@@ -242,13 +304,16 @@ const BoardItemContainer = memo(function BoardItemContainer({
   const currentWidth = overrideSize?.width ?? item.width;
   const currentHeight = overrideSize?.height ?? item.height;
 
+  const rotationDeg = overrideRotation ?? item.rotation ?? 0;
+
   const itemStyle: React.CSSProperties = {
     position: "absolute",
     left: `${currentX}px`,
     top: `${currentY}px`,
     width: `${currentWidth}px`,
     height: `${currentHeight}px`,
-    transform: `rotate(${item.rotation || 0}deg)`,
+    transform: `rotate(${rotationDeg}deg)`,
+    transformOrigin: usesLinePivotTransform(item) ? "0 50%" : "50% 50%",
     zIndex: item.z_index,
     cursor: "move",
   };
@@ -274,8 +339,115 @@ const BoardItemContainer = memo(function BoardItemContainer({
     [item.type, onRequestEdit]
   );
 
+  const showLineEndpoints =
+    isSelected &&
+    !disableResize &&
+    selectionCount === 1 &&
+    onLineEndpointDragStart &&
+    onLineEndpointDragMove &&
+    onLineEndpointDragEnd &&
+    (item.type === "line" || (item.type === "connector" && !item.style?.connection));
+
+  const renderLineEndpointHandles = () => {
+    if (!showLineEndpoints) return null;
+    const midY = "50%";
+    return (
+      <>
+        <div
+          className="line-endpoint-handle"
+          style={{
+            position: "absolute",
+            left: `${HANDLE_OFFSET}px`,
+            top: midY,
+            width: `${HANDLE_SIZE}px`,
+            height: `${HANDLE_SIZE}px`,
+            marginTop: `${HANDLE_OFFSET}px`,
+            backgroundColor: "#3b82f6",
+            border: "1px solid white",
+            borderRadius: "50%",
+            cursor: "grab",
+            zIndex: 1000,
+          }}
+          onPointerDown={(e) => handleLineEndpointPointerDown(e, "start")}
+          onPointerMove={handleLineEndpointPointerMove}
+          onPointerUp={handleLineEndpointPointerUp}
+          onPointerCancel={handleLineEndpointPointerUp}
+          onLostPointerCapture={handleLineEndpointPointerUp}
+        />
+        <div
+          className="line-endpoint-handle"
+          style={{
+            position: "absolute",
+            left: `calc(100% + ${HANDLE_OFFSET}px)`,
+            top: midY,
+            width: `${HANDLE_SIZE}px`,
+            height: `${HANDLE_SIZE}px`,
+            marginTop: `${HANDLE_OFFSET}px`,
+            backgroundColor: "#3b82f6",
+            border: "1px solid white",
+            borderRadius: "50%",
+            cursor: "grab",
+            zIndex: 1000,
+          }}
+          onPointerDown={(e) => handleLineEndpointPointerDown(e, "end")}
+          onPointerMove={handleLineEndpointPointerMove}
+          onPointerUp={handleLineEndpointPointerUp}
+          onPointerCancel={handleLineEndpointPointerUp}
+          onLostPointerCapture={handleLineEndpointPointerUp}
+        />
+      </>
+    );
+  };
+
+  const ANCHOR_SIZE = 11;
+  const ANCHOR_OFF = -ANCHOR_SIZE / 2;
+
+  const renderConnectAnchors = () => {
+    if (!showConnectAnchors || !onConnectAnchorPointerDown || !itemSupportsConnectAnchors(item.type)) {
+      return null;
+    }
+    const sides: AnchorSide[] = ["left", "right", "top", "bottom"];
+    const styleFor = (side: AnchorSide): React.CSSProperties => {
+      const base: React.CSSProperties = {
+        position: "absolute",
+        width: `${ANCHOR_SIZE}px`,
+        height: `${ANCHOR_SIZE}px`,
+        borderRadius: "50%",
+        border: "2px solid #3b82f6",
+        backgroundColor: "rgba(255,255,255,0.95)",
+        boxSizing: "border-box",
+        cursor: "crosshair",
+        zIndex: 1001,
+        pointerEvents: "auto",
+      };
+      if (side === "left")
+        return { ...base, left: ANCHOR_OFF, top: "50%", marginTop: ANCHOR_OFF };
+      if (side === "right")
+        return { ...base, right: ANCHOR_OFF, top: "50%", marginTop: ANCHOR_OFF };
+      if (side === "top")
+        return { ...base, top: ANCHOR_OFF, left: "50%", marginLeft: ANCHOR_OFF };
+      return { ...base, bottom: ANCHOR_OFF, left: "50%", marginLeft: ANCHOR_OFF };
+    };
+    return (
+      <>
+        {sides.map((side) => (
+          <div
+            key={side}
+            className="connect-anchor-handle"
+            data-connect-anchor="true"
+            data-item-id={item.id}
+            data-anchor={side}
+            style={styleFor(side)}
+            onPointerDown={(e) => onConnectAnchorPointerDown(item.id, side, e)}
+          />
+        ))}
+      </>
+    );
+  };
+
   const renderResizeHandles = () => {
     if (!isSelected || disableResize) return null;
+    if (showLineEndpoints) return renderLineEndpointHandles();
 
     const handles: Array<{ corner: ResizeCorner; style: React.CSSProperties }> = [
       {
@@ -375,6 +547,7 @@ const BoardItemContainer = memo(function BoardItemContainer({
         onSelect={onSelect}
         onUpdate={onUpdate}
       />
+      {renderConnectAnchors()}
       {renderResizeHandles()}
     </div>
   );

--- a/frontend/src/components/miro/items/BoardItemRenderer.tsx
+++ b/frontend/src/components/miro/items/BoardItemRenderer.tsx
@@ -9,6 +9,7 @@ import FreehandItem from "./FreehandItem";
 import FrameItem from "./FrameItem";
 import ConnectorItem from "./ConnectorItem";
 import LineItem from "./LineItem";
+import EmojiItem from "./EmojiItem";
 
 interface BoardItemRendererProps {
   item: BoardItem;
@@ -45,6 +46,8 @@ export default function BoardItemRenderer({
       return <ConnectorItem {...commonProps} />;
     case "freehand":
       return <FreehandItem {...commonProps} />;
+    case "emoji":
+      return <EmojiItem {...commonProps} />;
     default:
       return (
         <div

--- a/frontend/src/components/miro/items/ConnectorItem.tsx
+++ b/frontend/src/components/miro/items/ConnectorItem.tsx
@@ -20,11 +20,13 @@ export default function ConnectorItem({
   const strokeDasharray = item.style?.strokeDasharray;
   const width = item.width || 200;
   const height = item.height || 20;
+  const linkedPath = typeof item.style?.svgPath === "string" ? item.style.svgPath : null;
+  const isLinked = Boolean(item.style?.connection && linkedPath);
 
   // Arrow marker ID (unique per item)
   const markerId = `connectorArrow-${item.id}`;
 
-  // Line goes from left edge to right edge, centered vertically
+  // Line goes from left edge to right edge, centered vertically (free / arrow tool)
   const lineY = height / 2;
 
   const content = item.content || "";
@@ -57,9 +59,9 @@ export default function ConnectorItem({
           </marker>
         </defs>
 
-        {/* Line with arrow */}
+        {/* Linked: curved path in local box coords; free: straight horizontal */}
         <path
-          d={`M 0 ${lineY} L ${width} ${lineY}`}
+          d={isLinked ? linkedPath! : `M 0 ${lineY} L ${width} ${lineY}`}
           fill="none"
           stroke={strokeColor}
           strokeWidth={strokeWidth}

--- a/frontend/src/components/miro/items/EmojiItem.tsx
+++ b/frontend/src/components/miro/items/EmojiItem.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import React from "react";
+import { BoardItem } from "@/lib/api/miroApi";
+
+interface EmojiItemProps {
+  item: BoardItem;
+  isSelected: boolean;
+  onSelect: () => void;
+  onUpdate: (updates: Partial<BoardItem>) => void;
+}
+
+export default function EmojiItem({ item, isSelected, onSelect }: EmojiItemProps) {
+  const emoji = item.content?.trim() || "🙂";
+  const fontSize =
+    typeof item.style?.fontSize === "number"
+      ? item.style.fontSize
+      : Math.max(16, Math.min(item.height * 0.72, item.width * 0.72));
+
+  return (
+    <div
+      role="img"
+      aria-label={emoji}
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        border: isSelected ? "2px solid #3b82f6" : "none",
+        borderRadius: "4px",
+        cursor: "pointer",
+        userSelect: "none",
+        fontSize: `${fontSize}px`,
+        lineHeight: 1,
+      }}
+      onClick={onSelect}
+    >
+      {emoji}
+    </div>
+  );
+}

--- a/frontend/src/components/miro/utils/connectorLayout.test.ts
+++ b/frontend/src/components/miro/utils/connectorLayout.test.ts
@@ -1,0 +1,258 @@
+import { anchorWorldPoint, applyConnectorLayouts, computeLinkedConnectorGeometry } from "./connectorLayout";
+import { BoardItem } from "@/lib/api/miroApi";
+
+function item(partial: Partial<BoardItem> & Pick<BoardItem, "id" | "type" | "x" | "y" | "width" | "height">): BoardItem {
+  return {
+    board_id: "b",
+    style: {},
+    content: "",
+    z_index: 0,
+    is_deleted: false,
+    created_at: "",
+    updated_at: "",
+    ...partial,
+  } as BoardItem;
+}
+
+function parseLinkedPath(path: string) {
+  const m = path.match(
+    /^M\s+([\d.-]+)\s+([\d.-]+)\s+L\s+([\d.-]+)\s+([\d.-]+)\s+C\s+([\d.-]+)\s+([\d.-]+)\s+([\d.-]+)\s+([\d.-]+)\s+([\d.-]+)\s+([\d.-]+)\s+L\s+([\d.-]+)\s+([\d.-]+)$/
+  );
+  expect(m).not.toBeNull();
+  return {
+    s: { x: Number(m![1]), y: Number(m![2]) },
+    s2: { x: Number(m![3]), y: Number(m![4]) },
+    c1: { x: Number(m![5]), y: Number(m![6]) },
+    c2: { x: Number(m![7]), y: Number(m![8]) },
+    e2: { x: Number(m![9]), y: Number(m![10]) },
+    e: { x: Number(m![11]), y: Number(m![12]) },
+  };
+}
+
+describe("anchorWorldPoint", () => {
+  test("midpoints on edges", () => {
+    const b = item({ id: "a", type: "shape", x: 10, y: 20, width: 100, height: 40 });
+    expect(anchorWorldPoint(b, "left")).toEqual({ x: 10, y: 40 });
+    expect(anchorWorldPoint(b, "right")).toEqual({ x: 110, y: 40 });
+    expect(anchorWorldPoint(b, "top")).toEqual({ x: 60, y: 20 });
+    expect(anchorWorldPoint(b, "bottom")).toEqual({ x: 60, y: 60 });
+  });
+});
+
+describe("computeLinkedConnectorGeometry", () => {
+  test("returns bbox and path for two items", () => {
+    const a = item({ id: "a", type: "shape", x: 0, y: 0, width: 50, height: 50 });
+    const b = item({ id: "b", type: "shape", x: 200, y: 0, width: 50, height: 50 });
+    const c = item({
+      id: "c",
+      type: "connector",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      style: {
+        connection: {
+          fromItemId: "a",
+          toItemId: "b",
+          fromAnchor: "right",
+          toAnchor: "left",
+        },
+      },
+    });
+    const map = new Map<string, BoardItem>([
+      ["a", a],
+      ["b", b],
+    ]);
+    const g = computeLinkedConnectorGeometry(c, map);
+    expect(g).not.toBeNull();
+    expect(g!.svgPath).toMatch(/^M /);
+    expect(g!.width).toBeGreaterThan(0);
+    expect(g!.height).toBeGreaterThan(0);
+  });
+
+  test("control handles align with edge normals (perpendicular approach at anchors)", () => {
+    const a = item({ id: "a", type: "shape", x: 0, y: 0, width: 50, height: 50 });
+    const b = item({ id: "b", type: "shape", x: 200, y: 0, width: 50, height: 50 });
+    const c = item({
+      id: "c",
+      type: "connector",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      style: {
+        connection: {
+          fromItemId: "a",
+          toItemId: "b",
+          fromAnchor: "right",
+          toAnchor: "left",
+        },
+      },
+    });
+    const map = new Map<string, BoardItem>([
+      ["a", a],
+      ["b", b],
+    ]);
+    const g = computeLinkedConnectorGeometry(c, map)!;
+    const p = parseLinkedPath(g.svgPath);
+    // Stub segments enforce perpendicular entry/exit at both ends.
+    expect(p.s2.y).toBeCloseTo(p.s.y, 5);
+    expect(p.e.y).toBeCloseTo(p.e2.y, 5);
+    // And the cubic itself leaves/arrives horizontally for left/right anchors.
+    // B'(0) ∥ (c1 - s2), B'(1) ∥ (e2 - c2)
+    expect(p.c1.y).toBeCloseTo(p.s2.y, 5);
+    expect(p.e2.y).toBeCloseTo(p.c2.y, 5);
+  });
+
+  test("connector curve does not enter endpoint item boxes", () => {
+    const fromItem = item({ id: "a", type: "shape", x: 0, y: 0, width: 50, height: 50 });
+    const toItem = item({ id: "b", type: "shape", x: 200, y: 0, width: 50, height: 50 });
+
+    // Connect from `fromItem.right` to `toItem.left`.
+    // Historically the tangent selection could pull the bezier handle into `toItem`.
+    const connector = item({
+      id: "c",
+      type: "connector",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      style: {
+        strokeWidth: 4,
+        connection: {
+          fromItemId: "a",
+          toItemId: "b",
+          fromAnchor: "right",
+          toAnchor: "left",
+        },
+      },
+    });
+
+    const map = new Map<string, BoardItem>([
+      ["a", fromItem],
+      ["b", toItem],
+    ]);
+    const g = computeLinkedConnectorGeometry(connector, map);
+    expect(g).not.toBeNull();
+
+    const isStrictlyInside = (p: { x: number; y: number }, r: BoardItem, margin: number) => {
+      return (
+        p.x > r.x + margin &&
+        p.x < r.x + r.width - margin &&
+        p.y > r.y + margin &&
+        p.y < r.y + r.height - margin
+      );
+    };
+
+    const p = parseLinkedPath(g!.svgPath);
+    const toWorld = (pt: { x: number; y: number }) => ({ x: pt.x + g!.x, y: pt.y + g!.y });
+    const S2 = toWorld(p.s2);
+    const C1 = toWorld(p.c1);
+    const C2 = toWorld(p.c2);
+    const E2 = toWorld(p.e2);
+
+    const cubicAt = (t: number) => {
+      const mt = 1 - t;
+      const a = mt * mt * mt;
+      const b = 3 * mt * mt * t;
+      const c = 3 * mt * t * t;
+      const d = t * t * t;
+      return {
+        x: a * S2.x + b * C1.x + c * C2.x + d * E2.x,
+        y: a * S2.y + b * C1.y + c * C2.y + d * E2.y,
+      };
+    };
+
+    // Use a small margin to avoid "failing" on boundary points caused by floating error.
+    const margin = 0.25;
+    for (let i = 0; i <= 50; i++) {
+      const t = i / 50;
+      const p = cubicAt(t);
+      expect(isStrictlyInside(p, fromItem, margin)).toBe(false);
+      expect(isStrictlyInside(p, toItem, margin)).toBe(false);
+    }
+  });
+
+  test("bottom-anchor target does not curl into target box", () => {
+    const fromItem = item({ id: "a", type: "sticky_note", x: 40, y: 140, width: 120, height: 120 });
+    const toItem = item({ id: "b", type: "shape", x: 360, y: 120, width: 90, height: 90 });
+
+    const connector = item({
+      id: "c",
+      type: "connector",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      style: {
+        strokeWidth: 4,
+        connection: {
+          fromItemId: "a",
+          toItemId: "b",
+          fromAnchor: "right",
+          toAnchor: "bottom",
+        },
+      },
+    });
+
+    const map = new Map<string, BoardItem>([
+      ["a", fromItem],
+      ["b", toItem],
+    ]);
+    const g = computeLinkedConnectorGeometry(connector, map);
+    expect(g).not.toBeNull();
+    const p = parseLinkedPath(g!.svgPath);
+    const toWorld = (pt: { x: number; y: number }) => ({ x: pt.x + g!.x, y: pt.y + g!.y });
+    const p0 = toWorld(p.s2);
+    const p1 = toWorld(p.c1);
+    const p2 = toWorld(p.c2);
+    const p3 = toWorld(p.e2);
+
+    const cubicAt = (t: number) => {
+      const mt = 1 - t;
+      const a = mt * mt * mt;
+      const b = 3 * mt * mt * t;
+      const c = 3 * mt * t * t;
+      const d = t * t * t;
+      return {
+        x: a * p0.x + b * p1.x + c * p2.x + d * p3.x,
+        y: a * p0.y + b * p1.y + c * p2.y + d * p3.y,
+      };
+    };
+
+    const isInside = (p: { x: number; y: number }, r: BoardItem, margin: number) => {
+      return p.x > r.x + margin && p.x < r.x + r.width - margin && p.y > r.y + margin && p.y < r.y + r.height - margin;
+    };
+
+    for (let i = 0; i <= 80; i++) {
+      const p = cubicAt(i / 80);
+      expect(isInside(p, fromItem, 0.25)).toBe(false);
+      expect(isInside(p, toItem, 0.25)).toBe(false);
+    }
+  });
+});
+
+describe("applyConnectorLayouts", () => {
+  test("soft-deletes connector when endpoint missing", () => {
+    const c = item({
+      id: "c",
+      type: "connector",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      style: {
+        connection: {
+          fromItemId: "missing",
+          toItemId: "b",
+          fromAnchor: "right",
+          toAnchor: "left",
+        },
+      },
+    });
+    const b = item({ id: "b", type: "shape", x: 100, y: 0, width: 40, height: 40 });
+    const next = applyConnectorLayouts([c, b]);
+    const updated = next.find((i) => i.id === "c");
+    expect(updated?.is_deleted).toBe(true);
+  });
+});

--- a/frontend/src/components/miro/utils/connectorLayout.ts
+++ b/frontend/src/components/miro/utils/connectorLayout.ts
@@ -1,0 +1,303 @@
+import { BoardItem } from "@/lib/api/miroApi";
+
+export type AnchorSide = "left" | "right" | "top" | "bottom";
+
+export function itemSupportsConnectAnchors(type: BoardItem["type"]): boolean {
+  return type !== "line" && type !== "freehand" && type !== "connector";
+}
+
+export interface ConnectionStyle {
+  fromItemId: string;
+  toItemId: string;
+  fromAnchor: AnchorSide;
+  toAnchor: AnchorSide;
+}
+
+const EPS = 1e-6;
+
+export function anchorWorldPoint(item: BoardItem, side: AnchorSide): { x: number; y: number } {
+  const { x, y, width: w, height: h } = item;
+  switch (side) {
+    case "left":
+      return { x, y: y + h / 2 };
+    case "right":
+      return { x: x + w, y: y + h / 2 };
+    case "top":
+      return { x: x + w / 2, y };
+    case "bottom":
+      return { x: x + w / 2, y: y + h };
+    default:
+      return { x: x + w / 2, y: y + h / 2 };
+  }
+}
+
+function anchorOutwardNormal(side: AnchorSide): { x: number; y: number } {
+  switch (side) {
+    case "left":
+      return { x: -1, y: 0 };
+    case "right":
+      return { x: 1, y: 0 };
+    case "top":
+      return { x: 0, y: -1 };
+    case "bottom":
+      return { x: 0, y: 1 };
+  }
+}
+
+/**
+ * Unit outward tangent ⊥ edge at anchor.
+ * Points away from the item's interior so the connector curve doesn't "pull into"
+ * the source/target boxes near the anchors.
+ */
+function outwardPerpendicularTangentAlongSide(side: AnchorSide): { x: number; y: number } {
+  return anchorOutwardNormal(side);
+}
+
+function sampleCubicBezier(
+  p0: { x: number; y: number },
+  p1: { x: number; y: number },
+  p2: { x: number; y: number },
+  p3: { x: number; y: number },
+  steps: number
+): { x: number; y: number }[] {
+  const out: { x: number; y: number }[] = [];
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps;
+    const mt = 1 - t;
+    const a = mt * mt * mt;
+    const b = 3 * mt * mt * t;
+    const c = 3 * mt * t * t;
+    const d = t * t * t;
+    out.push({
+      x: a * p0.x + b * p1.x + c * p2.x + d * p3.x,
+      y: a * p0.y + b * p1.y + c * p2.y + d * p3.y,
+    });
+  }
+  return out;
+}
+
+function sampleLine(p0: { x: number; y: number }, p1: { x: number; y: number }, steps: number): { x: number; y: number }[] {
+  const out: { x: number; y: number }[] = [];
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps;
+    out.push({
+      x: p0.x + (p1.x - p0.x) * t,
+      y: p0.y + (p1.y - p0.y) * t,
+    });
+  }
+  return out;
+}
+
+export interface LinkedConnectorGeometry {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  svgPath: string;
+}
+
+/**
+ * Compute axis-aligned bbox and local SVG path for a linked connector (world → local).
+ */
+export function computeLinkedConnectorGeometry(
+  connector: BoardItem,
+  itemsById: Map<string, BoardItem>
+): LinkedConnectorGeometry | null {
+  const conn = connector.style?.connection as ConnectionStyle | undefined;
+  if (!conn) return null;
+
+  const fromItem = itemsById.get(conn.fromItemId);
+  const toItem = itemsById.get(conn.toItemId);
+  if (!fromItem || !toItem) return null;
+
+  const strokeWidth = typeof connector.style?.strokeWidth === "number" ? connector.style.strokeWidth : 4;
+  // Keep visual stroke (and arrow tip region) from appearing inside attached items.
+  const endpointClearance = strokeWidth / 2 + 1;
+  const fromBase = anchorWorldPoint(fromItem, conn.fromAnchor);
+  const toBase = anchorWorldPoint(toItem, conn.toAnchor);
+  const fromNormal = anchorOutwardNormal(conn.fromAnchor);
+  const toNormal = anchorOutwardNormal(conn.toAnchor);
+  const S = {
+    x: fromBase.x + fromNormal.x * endpointClearance,
+    y: fromBase.y + fromNormal.y * endpointClearance,
+  };
+  const E = {
+    x: toBase.x + toNormal.x * endpointClearance,
+    y: toBase.y + toNormal.y * endpointClearance,
+  };
+
+  const dx = E.x - S.x;
+  const dy = E.y - S.y;
+  const len = Math.hypot(dx, dy) || 1;
+  const t0 = outwardPerpendicularTangentAlongSide(conn.fromAnchor);
+  const t1 = outwardPerpendicularTangentAlongSide(conn.toAnchor);
+  const pad = strokeWidth / 2 + 14;
+
+  // Keep the curve's centerline out of the endpoint boxes (avoid "passing through")
+  // by shrinking bezier handles when needed.
+  // Clearance for avoiding "inside box" intersection. We use a small value
+  // to match the visual expectation: don't let the connector centerline go
+  // through the boxes.
+  const clearance = 0.25;
+
+  const handleMax = Math.min(len * 0.4, 140);
+  const handleScales = [1, 0.85, 0.7, 0.55, 0.4, 0.3, 0.2, 0.15, 0.1, 0.07, 0.05];
+
+  const pointInsideRect = (p: { x: number; y: number }, r: BoardItem) => {
+    return (
+      p.x > r.x + clearance &&
+      p.x < r.x + r.width - clearance &&
+      p.y > r.y + clearance &&
+      p.y < r.y + r.height - clearance
+    );
+  };
+
+  let chosenC1: { x: number; y: number } | null = null;
+  let chosenC2: { x: number; y: number } | null = null;
+  let chosenPts: { x: number; y: number }[] | null = null;
+  let bestIntersectionCount = Number.POSITIVE_INFINITY;
+
+  const CHECK_STEPS = 80;
+  const LINE_SAMPLE_STEPS = 12;
+
+  // Ensure the path is perpendicular at both ends by adding short straight stubs
+  // along the anchor outward normals, then curving between the stub endpoints.
+  const stubLen = Math.min(40, Math.max(12, strokeWidth * 3 + 6, len * 0.12));
+  const S2 = { x: S.x + t0.x * stubLen, y: S.y + t0.y * stubLen };
+  // End stub should approach the item boundary; place E2 farther out so the final
+  // straight segment runs toward the attached item.
+  const E2 = { x: E.x + t1.x * stubLen, y: E.y + t1.y * stubLen };
+
+  for (const scale of handleScales) {
+    const handle = handleMax * scale;
+    const C1 = { x: S2.x + t0.x * handle, y: S2.y + t0.y * handle };
+    // Match the direction of the final approach segment (E2 -> E) which is along -t1.
+    const C2 = { x: E2.x + t1.x * handle, y: E2.y + t1.y * handle };
+    const curvePts = sampleCubicBezier(S2, C1, C2, E2, CHECK_STEPS);
+    const pts = [
+      ...sampleLine(S, S2, LINE_SAMPLE_STEPS),
+      ...curvePts,
+      ...sampleLine(E2, E, LINE_SAMPLE_STEPS),
+    ];
+
+    const intersectionCount = pts.reduce((count, p) => {
+      return count + (pointInsideRect(p, fromItem) || pointInsideRect(p, toItem) ? 1 : 0);
+    }, 0);
+    const intersectsEndpointBoxes = intersectionCount > 0;
+    if (!intersectsEndpointBoxes) {
+      chosenC1 = C1;
+      chosenC2 = C2;
+      chosenPts = pts;
+      bestIntersectionCount = 0;
+      break;
+    }
+
+    // If all candidates intersect, keep the least intersecting one.
+    if (intersectionCount < bestIntersectionCount) {
+      chosenC1 = C1;
+      chosenC2 = C2;
+      chosenPts = pts;
+      bestIntersectionCount = intersectionCount;
+    }
+  }
+
+  const fallbackScale = handleScales[handleScales.length - 1];
+  const C1 = chosenC1 || { x: S2.x + t0.x * handleMax * fallbackScale, y: S2.y + t0.y * handleMax * fallbackScale };
+  const C2 = chosenC2 || { x: E2.x + t1.x * handleMax * fallbackScale, y: E2.y + t1.y * handleMax * fallbackScale };
+  const pts =
+    chosenPts ||
+    [
+      ...sampleLine(S, S2, LINE_SAMPLE_STEPS),
+      ...sampleCubicBezier(S2, C1, C2, E2, CHECK_STEPS),
+      ...sampleLine(E2, E, LINE_SAMPLE_STEPS),
+    ];
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const p of pts) {
+    minX = Math.min(minX, p.x);
+    minY = Math.min(minY, p.y);
+    maxX = Math.max(maxX, p.x);
+    maxY = Math.max(maxY, p.y);
+  }
+
+  minX -= pad;
+  minY -= pad;
+  maxX += pad;
+  maxY += pad;
+
+  const w = Math.max(maxX - minX, 8);
+  const h = Math.max(maxY - minY, 8);
+
+  const loc = (p: { x: number; y: number }) => ({ x: p.x - minX, y: p.y - minY });
+  const s = loc(S);
+  const s2 = loc(S2);
+  const c1 = loc(C1);
+  const c2 = loc(C2);
+  const e2 = loc(E2);
+  const e = loc(E);
+
+  const svgPath = `M ${s.x} ${s.y} L ${s2.x} ${s2.y} C ${c1.x} ${c1.y} ${c2.x} ${c2.y} ${e2.x} ${e2.y} L ${e.x} ${e.y}`;
+
+  return {
+    x: minX,
+    y: minY,
+    width: w,
+    height: h,
+    svgPath,
+  };
+}
+
+export function applyConnectorLayouts(items: BoardItem[]): BoardItem[] {
+  const active = items.filter((i) => !i.is_deleted);
+  const byId = new Map(active.map((i) => [i.id, i]));
+
+  let anyChanged = false;
+  const next = items.map((item) => {
+    if (item.type !== "connector" || item.is_deleted || !item.style?.connection) {
+      return item;
+    }
+
+    const conn = item.style.connection as ConnectionStyle;
+    const fromItem = byId.get(conn.fromItemId);
+    const toItem = byId.get(conn.toItemId);
+    if (!fromItem || !toItem) {
+      anyChanged = true;
+      return { ...item, is_deleted: true };
+    }
+
+    const geom = computeLinkedConnectorGeometry(item, byId);
+    if (!geom) {
+      anyChanged = true;
+      return { ...item, is_deleted: true };
+    }
+
+    const { x, y, width, height, svgPath } = geom;
+    const same =
+      Math.abs(item.x - x) < EPS &&
+      Math.abs(item.y - y) < EPS &&
+      Math.abs(item.width - width) < EPS &&
+      Math.abs(item.height - height) < EPS &&
+      item.style?.svgPath === svgPath &&
+      (item.rotation ?? 0) === 0;
+
+    if (same) return item;
+
+    anyChanged = true;
+    return {
+      ...item,
+      x,
+      y,
+      width,
+      height,
+      rotation: 0,
+      style: {
+        ...item.style,
+        svgPath,
+      },
+    };
+  });
+
+  return anyChanged ? next : items;
+}

--- a/frontend/src/components/miro/utils/lineEndpointMath.test.ts
+++ b/frontend/src/components/miro/utils/lineEndpointMath.test.ts
@@ -1,0 +1,55 @@
+import { lineEndpointsWorld, lineItemFromPivotAndEndWorld } from "./lineEndpointMath";
+import { BoardItem } from "@/lib/api/miroApi";
+
+function lineItem(partial: Partial<BoardItem> & Pick<BoardItem, "x" | "y" | "width" | "height">): BoardItem {
+  return {
+    id: "1",
+    board_id: "b",
+    type: "line",
+    x: partial.x,
+    y: partial.y,
+    width: partial.width,
+    height: partial.height,
+    rotation: partial.rotation ?? 0,
+    style: {},
+    content: "",
+    z_index: 0,
+    is_deleted: false,
+    created_at: "",
+    updated_at: "",
+  };
+}
+
+describe("lineEndpointsWorld", () => {
+  test("horizontal line to the right from origin", () => {
+    const { start, end } = lineEndpointsWorld(lineItem({ x: 0, y: 0, width: 100, height: 20, rotation: 0 }));
+    expect(start).toEqual({ x: 0, y: 10 });
+    expect(end.x).toBeCloseTo(100);
+    expect(end.y).toBeCloseTo(10);
+  });
+
+  test("90 degree rotation", () => {
+    const { start, end } = lineEndpointsWorld(
+      lineItem({ x: 0, y: 0, width: 100, height: 20, rotation: 90 })
+    );
+    expect(start).toEqual({ x: 0, y: 10 });
+    expect(end.x).toBeCloseTo(0);
+    expect(end.y).toBeCloseTo(110);
+  });
+});
+
+describe("lineItemFromPivotAndEndWorld", () => {
+  test("reconstructs horizontal segment", () => {
+    const g = lineItemFromPivotAndEndWorld({ x: 0, y: 10 }, { x: 50, y: 10 }, 20);
+    expect(g.x).toBe(0);
+    expect(g.y).toBe(0);
+    expect(g.width).toBe(50);
+    expect(g.height).toBe(20);
+    expect(g.rotation).toBeCloseTo(0);
+  });
+
+  test("enforces minimum length", () => {
+    const g = lineItemFromPivotAndEndWorld({ x: 0, y: 10 }, { x: 0, y: 10 }, 20);
+    expect(g.width).toBeGreaterThanOrEqual(20);
+  });
+});

--- a/frontend/src/components/miro/utils/lineEndpointMath.ts
+++ b/frontend/src/components/miro/utils/lineEndpointMath.ts
@@ -1,0 +1,40 @@
+import { BoardItem } from "@/lib/api/miroApi";
+
+const MIN_LINE_LENGTH = 20;
+
+/** World-space endpoints with transform-origin at left center (0, height/2). */
+export function lineEndpointsWorld(item: BoardItem): { start: { x: number; y: number }; end: { x: number; y: number } } {
+  const h = item.height;
+  const w = item.width;
+  const rad = ((item.rotation ?? 0) * Math.PI) / 180;
+  const px = item.x;
+  const py = item.y + h / 2;
+  return {
+    start: { x: px, y: py },
+    end: { x: px + w * Math.cos(rad), y: py + w * Math.sin(rad) },
+  };
+}
+
+export function lineItemFromPivotAndEndWorld(
+  pivotWorld: { x: number; y: number },
+  endWorld: { x: number; y: number },
+  height: number
+): { x: number; y: number; width: number; height: number; rotation: number } {
+  const dx = endWorld.x - pivotWorld.x;
+  const dy = endWorld.y - pivotWorld.y;
+  const width = Math.max(MIN_LINE_LENGTH, Math.hypot(dx, dy));
+  const rotation = (Math.atan2(dy, dx) * 180) / Math.PI;
+  return {
+    x: pivotWorld.x,
+    y: pivotWorld.y - height / 2,
+    width,
+    height,
+    rotation,
+  };
+}
+
+export function usesLinePivotTransform(item: BoardItem): boolean {
+  if (item.type === "line") return true;
+  if (item.type === "connector" && !item.style?.connection) return true;
+  return false;
+}

--- a/frontend/src/components/miro/utils/selectionBounds.ts
+++ b/frontend/src/components/miro/utils/selectionBounds.ts
@@ -1,0 +1,33 @@
+import { BoardItem } from "@/lib/api/miroApi";
+
+export type Rect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export function getSelectionBounds(items: BoardItem[], selectedItemIds: string[]): Rect | null {
+  if (selectedItemIds.length === 0) return null;
+  const selected = items.filter((item) => selectedItemIds.includes(item.id) && !item.is_deleted);
+  if (selected.length === 0) return null;
+
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+
+  selected.forEach((item) => {
+    minX = Math.min(minX, item.x);
+    minY = Math.min(minY, item.y);
+    maxX = Math.max(maxX, item.x + item.width);
+    maxY = Math.max(maxY, item.y + item.height);
+  });
+
+  return {
+    x: minX,
+    y: minY,
+    width: maxX - minX,
+    height: maxY - minY,
+  };
+}

--- a/frontend/src/lib/api/miroApi.ts
+++ b/frontend/src/lib/api/miroApi.ts
@@ -61,7 +61,7 @@ export interface UpdateMiroBoardData {
 export interface BoardItem {
   id: string;
   board_id: string;
-  type: 'text' | 'shape' | 'sticky_note' | 'frame' | 'line' | 'connector' | 'freehand';
+  type: 'text' | 'shape' | 'sticky_note' | 'frame' | 'line' | 'connector' | 'freehand' | 'emoji';
   parent_item_id?: string | null;
   x: number;
   y: number;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -24,5 +24,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "cypress.config.ts", "cypress/**/*.ts"]
 }


### PR DESCRIPTION
Add a set of usability and productivity improvements to the Miro-style board experience, including keyboard-based deletion, undo/redo support, Esc-to-deselect behavior, Mac-style touchpad gesture support, multi-select, emoji support, line tool rotation, and proper connectors.