### PR TITLE
AGENT-Build1: Add pre-draft status for AI-generated decisions

### DIFF
--- a/backend/agent/executors.py
+++ b/backend/agent/executors.py
@@ -159,6 +159,7 @@ class CreateDecisionExecutor(BaseStepExecutor):
                 author=user,
                 created_by_agent=True,
                 agent_session_id=self.orchestrator.session.id,
+                is_pre_draft=True,
             )
 
             for anomaly in analysis.get('anomalies', []):

--- a/backend/agent/services.py
+++ b/backend/agent/services.py
@@ -1115,7 +1115,7 @@ class AgentOrchestrator:
 
     def create_decision_draft(self, analysis_result, workflow_run=None):
         """Create a Decision draft with Signals and Options from analysis."""
-        yield {"type": "text", "content": "Creating decision draft..."}
+        yield {"type": "text", "content": "Creating decision pre-draft..."}
 
         if workflow_run:
             workflow_run.status = 'creating_decision'
@@ -1139,6 +1139,7 @@ class AgentOrchestrator:
             author=self.user,
             created_by_agent=True,
             agent_session_id=self.session.id,
+            is_pre_draft=True,
         )
 
         # Create signals from anomalies

--- a/backend/agent/urls.py
+++ b/backend/agent/urls.py
@@ -12,6 +12,7 @@ from .views import (
     FileUploadAnalyzeView,
     DecisionStatsView,
     DecisionRecentView,
+    DecisionPromoteView,
     AnomalyLatestView,
     WorkflowStepView,
     StepReorderView,
@@ -36,5 +37,6 @@ urlpatterns = [
     path('upload-analyze/', FileUploadAnalyzeView.as_view(), name='agent-upload-analyze'),
     path('decisions/stats/', DecisionStatsView.as_view(), name='agent-decision-stats'),
     path('decisions/recent/', DecisionRecentView.as_view(), name='agent-decision-recent'),
+    path('decisions/<int:decision_id>/promote/', DecisionPromoteView.as_view(), name='agent-decision-promote'),
     path('anomalies/latest/', AnomalyLatestView.as_view(), name='agent-anomaly-latest'),
 ]

--- a/backend/agent/views.py
+++ b/backend/agent/views.py
@@ -498,7 +498,7 @@ class DecisionStatsView(EnglishResponseMixin, APIView):
                 {"detail": "No active project."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        qs = Decision.objects.filter(project=project, is_deleted=False)
+        qs = Decision.objects.filter(project=project, is_deleted=False, is_pre_draft=False)
 
         counts = qs.values('status').annotate(count=Count('id'))
         stats = {}
@@ -531,8 +531,42 @@ class DecisionRecentView(EnglishResponseMixin, APIView):
                 'confidence': d.confidence,
                 'author': d.author.get_full_name() if d.author else 'AI Agent',
                 'created_at': d.created_at.isoformat(),
+                'is_pre_draft': d.is_pre_draft,
             })
         return Response(result)
+
+
+class DecisionPromoteView(EnglishResponseMixin, APIView):
+    """POST /api/agent/decisions/<id>/promote/ — promote a pre-draft to a real draft."""
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, decision_id):
+        project = _get_user_project(request)
+        if not project:
+            return Response(
+                {"detail": "No active project."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            decision = Decision.objects.get(
+                id=decision_id,
+                project=project,
+                is_pre_draft=True,
+                is_deleted=False,
+            )
+        except Decision.DoesNotExist:
+            return Response(
+                {"detail": "Pre-draft decision not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        decision.is_pre_draft = False
+        decision.save(update_fields=['is_pre_draft', 'updated_at'])
+        return Response({
+            'id': decision.id,
+            'title': decision.title,
+            'status': decision.status,
+            'is_pre_draft': False,
+        })
 
 
 class AnomalyLatestView(EnglishResponseMixin, APIView):

--- a/backend/decision/migrations/0003_decision_is_pre_draft.py
+++ b/backend/decision/migrations/0003_decision_is_pre_draft.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('decision', '0002_decision_agent_fields'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='decision',
+            name='is_pre_draft',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/backend/decision/models.py
+++ b/backend/decision/models.py
@@ -45,6 +45,7 @@ class Decision(TimeStampedModel):
     is_reference_case = models.BooleanField(default=False)
     created_by_agent = models.BooleanField(default=False)
     agent_session_id = models.UUIDField(null=True, blank=True)
+    is_pre_draft = models.BooleanField(default=False)
     project = models.ForeignKey(
         Project,
         on_delete=models.CASCADE,

--- a/backend/decision/views.py
+++ b/backend/decision/views.py
@@ -181,7 +181,7 @@ class DecisionViewSet(
     http_method_names = ["get", "post", "put", "patch", "delete", "head", "options"]
 
     def get_queryset(self):
-        base = Decision.objects.filter(is_deleted=False).order_by("-updated_at")
+        base = Decision.objects.filter(is_deleted=False, is_pre_draft=False).order_by("-updated_at")
 
         if self.action == "list":
             base = base.select_related("project")
@@ -516,6 +516,11 @@ class DecisionViewSet(
     @action(detail=True, methods=['post'])
     def commit(self, request, pk=None):
         decision = self.get_object()
+        if decision.is_pre_draft:
+            return Response(
+                {"detail": "Pre-draft must be promoted before committing."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         if decision.status != Decision.Status.DRAFT:
             return invalid_state_response(
                 current_status=decision.status,

--- a/frontend/src/components/agent/chat/AgentChatPage.tsx
+++ b/frontend/src/components/agent/chat/AgentChatPage.tsx
@@ -71,7 +71,7 @@ function restoreMessage(m: AgentMessage): ChatMessage {
   } else if (m.message_type === "decision_draft" || m.data?.decision_id) {
     type = "decision_created"
     navigateTo = "decisions"
-    navigateLabel = "Go to Decisions"
+    navigateLabel = "Review Pre-Draft"
   } else if (m.message_type === "task_created" || m.data?.task_ids) {
     type = "tasks_created"
     navigateTo = "tasks"
@@ -510,7 +510,7 @@ export function AgentChatPage() {
             content: contentParts.join("\n"),
             type: "decision_created",
             navigateTo: "decisions",
-            navigateLabel: "Go to Decisions",
+            navigateLabel: "Review Pre-Draft",
             decisionId: decisionId ? Number(decisionId) : undefined,
           })
         }
@@ -608,7 +608,7 @@ export function AgentChatPage() {
             content: contentParts.join("\n"),
             type: "decision_created",
             navigateTo: "decisions",
-            navigateLabel: "Go to Decisions",
+            navigateLabel: "Review Pre-Draft",
             decisionId: decisionId ? Number(decisionId) : undefined,
           })
         }

--- a/frontend/src/components/agent/decision/DecisionEditor.tsx
+++ b/frontend/src/components/agent/decision/DecisionEditor.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 // useCallback removed — only used by batch manage
 import {
   Plus,
@@ -66,6 +66,7 @@ interface DecisionListItem {
   risk_level: string
   author: string
   created_at: string
+  is_pre_draft?: boolean
 }
 
 const signalIcons = {
@@ -82,6 +83,7 @@ const riskColors: Record<string, string> = {
 
 const statusStyles: Record<string, string> = {
   draft: "bg-muted/50 text-muted-foreground border-input",
+  pre_draft: "bg-violet-500/10 text-violet-400 border-violet-500/20",
   committed: "bg-blue-500/10 text-blue-400 border-blue-500/20",
   awaiting_approval: "bg-amber-500/10 text-amber-400 border-amber-500/20",
   reviewed: "bg-emerald-500/10 text-emerald-400 border-emerald-500/20",
@@ -117,6 +119,7 @@ export function DecisionEditor() {
   // Editing state
   const [editingDecisionId, setEditingDecisionId] = useState<number | null>(null)
   const [editingStatus, setEditingStatus] = useState<string>("draft")
+  const [isPreDraft, setIsPreDraft] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
   const activeProject = useProjectStore((s) => s.activeProject)
 
@@ -170,6 +173,7 @@ export function DecisionEditor() {
     setSelectedOption("")
     setEditingDecisionId(d.id)
     setEditingStatus(d.status || "draft")
+    setIsPreDraft(d.is_pre_draft ?? false)
     setViewMode("edit")
 
     // Fetch full decision detail to populate context, reasoning, signals, options
@@ -229,19 +233,6 @@ export function DecisionEditor() {
     } catch {
       // Keep what we have from the list item
     }
-  }
-
-  const createNew = () => {
-    setTitle("")
-    setContext("")
-    setReasoning("")
-    setSignals([])
-    setOptions([])
-    setSelectedOption("")
-    setPriority("medium")
-    setEditingDecisionId(null)
-    setEditingStatus("draft")
-    setViewMode("edit")
   }
 
   // ─── Validation ─────────────────────────────────────
@@ -348,7 +339,7 @@ export function DecisionEditor() {
       }
 
       await DecisionAPI.patchDraft(id!, payload, activeProject?.id)
-      toast.success("Draft saved")
+      toast.success(isPreDraft ? "Pre-draft saved" : "Draft saved")
       await refreshList()
       return id
     } catch (err: any) {
@@ -377,6 +368,26 @@ export function DecisionEditor() {
     }
   }
 
+  const submitAsDraft = async () => {
+    setIsSaving(true)
+    try {
+      const id = await saveDraft(true)
+      if (!id) return
+      await AgentAPI.promoteDecision(id)
+      toast.success("Pre-draft submitted as draft")
+      await refreshList()
+      setViewMode("list")
+    } catch (err: any) {
+      const detail = err?.response?.data?.detail || err?.message || "Failed to promote"
+      toast.error(detail)
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const preDrafts = useMemo(() => decisionList.filter((d) => d.is_pre_draft), [decisionList])
+  const drafts = useMemo(() => decisionList.filter((d) => !d.is_pre_draft), [decisionList])
+
   // ─── Consume pendingDecisionId from context ───────────────────
 
   const { pendingDecisionId, setPendingDecisionId } = useAgentLayout()
@@ -387,7 +398,7 @@ export function DecisionEditor() {
     if (found) {
       loadDecision(found)
     } else {
-      loadDecision({ id: pendingDecisionId, title: "", status: "draft", risk_level: "", author: "", created_at: "" })
+      loadDecision({ id: pendingDecisionId, title: "", status: "draft", risk_level: "", author: "", created_at: "", is_pre_draft: true })
     }
     setPendingDecisionId(null)
   }, [pendingDecisionId, listLoading, decisionList])
@@ -404,50 +415,86 @@ export function DecisionEditor() {
               <h1 className="text-xl font-bold text-foreground">Decisions</h1>
               <p className="text-sm text-muted-foreground mt-1">View and manage advertising decisions</p>
             </div>
-            <div className="flex items-center gap-2">
-              <Button size="sm" className="bg-blue-600 hover:bg-blue-700 text-white" onClick={createNew}>
-                <Plus className="w-3.5 h-3.5 mr-1.5" />
-                New Decision
-              </Button>
-            </div>
+            <div className="flex items-center gap-2" />
           </div>
 
           {listLoading ? (
             <div className="text-center py-8 text-muted-foreground text-sm">Loading decisions...</div>
           ) : decisionList.length === 0 ? (
             <div className="text-center py-8 text-muted-foreground text-sm">
-              No decisions yet. Create one or run an AI analysis.
+              No decisions yet. Run an AI analysis to generate one.
             </div>
           ) : (
-            <div className="space-y-2">
-              {decisionList.map((d) => (
-                <div key={d.id}>
-                  <Card
-                    className="bg-card border-border cursor-pointer transition-colors hover:border-input"
-                    onClick={() => loadDecision(d)}
-                  >
-                    <CardContent className="py-3 px-4">
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-3">
-                          <span className="text-xs text-muted-foreground/60 font-mono">#{d.id}</span>
-                          <span className="text-sm text-foreground">{d.title}</span>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <Badge variant="outline" className={cn("text-[10px]", statusStyles[d.status] || statusStyles.draft)}>
-                            {d.status}
-                          </Badge>
-                          {d.risk_level && (
-                            <Badge variant="outline" className={cn("text-[10px]", riskColors[d.risk_level] || "")}>
-                              {d.risk_level}
+            <div className="space-y-4">
+              {/* Pre-drafts section */}
+              {preDrafts.length > 0 && (
+                <div className="space-y-2">
+                  <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Pre-Drafts</h2>
+                  {preDrafts.map((d) => (
+                    <Card
+                      key={d.id}
+                      className="bg-card border-border cursor-pointer transition-colors hover:border-input"
+                      onClick={() => loadDecision(d)}
+                    >
+                      <CardContent className="py-3 px-4">
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center gap-3">
+                            <span className="text-xs text-muted-foreground/60 font-mono">#{d.id}</span>
+                            <span className="text-sm text-foreground">{d.title}</span>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <Badge variant="outline" className={cn("text-[10px]", statusStyles.pre_draft)}>
+                              pre-draft
                             </Badge>
-                          )}
-                          <span className="text-xs text-muted-foreground">{d.author}</span>
+                            {d.risk_level && (
+                              <Badge variant="outline" className={cn("text-[10px]", riskColors[d.risk_level] || "")}>
+                                {d.risk_level}
+                              </Badge>
+                            )}
+                            <span className="text-xs text-muted-foreground">{d.author}</span>
+                          </div>
                         </div>
-                      </div>
-                    </CardContent>
-                  </Card>
+                      </CardContent>
+                    </Card>
+                  ))}
                 </div>
-              ))}
+              )}
+
+              {/* Drafts section */}
+              {drafts.length > 0 && (
+                <div className="space-y-2">
+                  <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Drafts</h2>
+                  {drafts.map((d) => (
+                    <Card
+                      key={d.id}
+                      className="bg-card border-border cursor-pointer transition-colors hover:border-input"
+                      onClick={() => {
+                        window.location.href = `/decisions/${d.id}?project_id=${activeProject?.id || ""}`
+                      }}
+                    >
+                      <CardContent className="py-3 px-4">
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center gap-3">
+                            <span className="text-xs text-muted-foreground/60 font-mono">#{d.id}</span>
+                            <span className="text-sm text-foreground">{d.title}</span>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <Badge variant="outline" className={cn("text-[10px]", statusStyles[d.status] || statusStyles.draft)}>
+                              {d.status}
+                            </Badge>
+                            {d.risk_level && (
+                              <Badge variant="outline" className={cn("text-[10px]", riskColors[d.risk_level] || "")}>
+                                {d.risk_level}
+                              </Badge>
+                            )}
+                            <span className="text-xs text-muted-foreground">{d.author}</span>
+                          </div>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -499,20 +546,31 @@ export function DecisionEditor() {
                 onClick={() => saveDraft()}
                 disabled={isSaving}
               >
-                {isSaving ? "Saving..." : "Save Draft"}
+                {isSaving ? "Saving..." : isPreDraft ? "Save as Pre-Draft" : "Save Draft"}
               </Button>
-              <Button
-                size="sm"
-                disabled={!allPassed || isSaving}
-                onClick={submitForReview}
-                className={cn(
-                  allPassed && !isSaving
-                    ? "bg-blue-600 hover:bg-blue-700 text-white"
-                    : "bg-input text-muted-foreground cursor-not-allowed"
-                )}
-              >
-                Submit for Review
-              </Button>
+              {isPreDraft ? (
+                <Button
+                  size="sm"
+                  disabled={isSaving}
+                  onClick={submitAsDraft}
+                  className="bg-violet-600 hover:bg-violet-700 text-white"
+                >
+                  Submit as Draft
+                </Button>
+              ) : (
+                <Button
+                  size="sm"
+                  disabled={!allPassed || isSaving}
+                  onClick={submitForReview}
+                  className={cn(
+                    allPassed && !isSaving
+                      ? "bg-blue-600 hover:bg-blue-700 text-white"
+                      : "bg-input text-muted-foreground cursor-not-allowed"
+                  )}
+                >
+                  Submit for Review
+                </Button>
+              )}
             </div>
           )}
         </div>

--- a/frontend/src/lib/api/agentApi.ts
+++ b/frontend/src/lib/api/agentApi.ts
@@ -287,6 +287,11 @@ export const AgentAPI = {
     await api.delete(`/api/agent/data/reports/${fileId}/`);
   },
 
+  promoteDecision: async (decisionId: number) => {
+    const response = await api.post(`/api/agent/decisions/${decisionId}/promote/`);
+    return response.data;
+  },
+
   fetchDecisionStats: async () => {
     const response = await api.get('/api/agent/decisions/stats/');
     return response.data;


### PR DESCRIPTION
## Summary
- AI-created decisions now start as pre-drafts, only visible in the agent panel
- Users review and promote to real drafts via Submit as Draft button
- Pre-drafts excluded from main decision list, stats, and commit flow

## Files Changed
- backend/decision/models.py — added is_pre_draft field
- backend/decision/migrations/0003_decision_is_pre_draft.py — new migration
- backend/agent/services.py, executors.py — set is_pre_draft=True on AI creation
- backend/agent/views.py, urls.py — added promote endpoint, updated stats/recent views
- backend/decision/views.py — filtered pre-drafts from main list, guarded commit
- frontend/src/lib/api/agentApi.ts — added promoteDecision API
- frontend/src/components/agent/decision/DecisionEditor.tsx — split list, Submit as Draft UI
- frontend/src/components/agent/chat/AgentChatPage.tsx — updated navigate label

## Test Plan
- [x] pytest -v all passing (35 tests)
- [x] npm run build no errors
- [x] Manual test via localhost:80