### PR TITLE
TaskBugFix1: fix 400 error on task resubmit after rejection

### DIFF
--- a/frontend/src/app/tasks/page.js
+++ b/frontend/src/app/tasks/page.js
@@ -1536,14 +1536,20 @@ function TasksPageContent() {
       const existingTask = { id: draftEditingTaskId };
       setContentType(config?.contentType || "");
 
-      const createdObject = await createTaskTypeObject(taskData.type, existingTask);
+      // Check if type-specific object already exists (e.g. resubmit after rejection).
+      // The backend rejects duplicate creation, so skip create + link when object_id is set.
+      const taskResp = await TaskAPI.getTask(draftEditingTaskId);
+      const hasLinkedObject = taskResp?.data?.object_id;
 
-      if (createdObject && config?.contentType) {
-        await TaskAPI.linkTask(
-          existingTask.id,
-          config.contentType,
-          createdObject.id.toString(),
-        );
+      if (!hasLinkedObject) {
+        const createdObject = await createTaskTypeObject(taskData.type, existingTask);
+        if (createdObject && config?.contentType) {
+          await TaskAPI.linkTask(
+            existingTask.id,
+            config.contentType,
+            createdObject.id.toString(),
+          );
+        }
       }
 
       await TaskAPI.submitTask(draftEditingTaskId);


### PR DESCRIPTION
## Summary
- When a task is rejected and revised back to Draft, clicking Submit again caused a 400 error because the frontend tried to create a duplicate type object (Report/ScalingPlan)
- Added a check in handleSubmitDraft to skip object creation when object_id already exists

## Changes
- frontend/src/app/tasks/page.js: check object_id via getTask() before calling createTaskTypeObject()

## Test Plan
- [x] Reject a Report task → Revise → Resubmit (no 400 error)
- [x] Reject a Scaling task → Revise → Resubmit (no 400 error)
- [x] Fresh draft submit still works normally (regression test)