### PR TITLE
Add Playwright tests for calendar and stabilize event dialog

### DIFF
--- a/frontend/e2e/auth.setup.ts
+++ b/frontend/e2e/auth.setup.ts
@@ -4,6 +4,7 @@ import { test as setup, expect } from '@playwright/test';
 
 const AUTH_DIR = path.join(__dirname, '.auth');
 const AUTH_FILE = path.join(AUTH_DIR, 'user.json');
+const POST_LOGIN_ROUTE_PATTERN = /^\/(tasks|campaigns)(\/|$)/i;
 
 const TEST_EMAIL = process.env.DEV_USER_EMAIL || 'devuser@example.com';
 const TEST_PASSWORD = process.env.DEV_USER_PASSWORD || 'password123!';
@@ -15,9 +16,20 @@ setup('authenticate', async ({ page }) => {
   await page.getByPlaceholder('Enter your password').fill(TEST_PASSWORD);
   await page.locator('form').getByRole('button', { name: 'Sign in', exact: true }).click();
 
-  await page.waitForURL(/\/campaigns/, { timeout: 15_000 });
+  // Accept either protected landing route used after sign-in.
+  await page.waitForURL(
+    (url) => POST_LOGIN_ROUTE_PATTERN.test(url.pathname) && !/\/login(\?|$)/i.test(url.pathname),
+    { timeout: 15_000 },
+  );
 
   await expect(page.getByText('Preparing your workspace')).not.toBeVisible({ timeout: 30_000 });
+
+  const currentUrl = new URL(page.url());
+  if (!POST_LOGIN_ROUTE_PATTERN.test(currentUrl.pathname)) {
+    throw new Error(
+      `Authentication setup expected a protected landing route after sign-in, but reached ${page.url()}.`,
+    );
+  }
 
   fs.mkdirSync(AUTH_DIR, { recursive: true });
   await page.context().storageState({ path: AUTH_FILE });

--- a/frontend/e2e/calendar/calendar-helpers.ts
+++ b/frontend/e2e/calendar/calendar-helpers.ts
@@ -1,0 +1,433 @@
+import fs from 'fs';
+import path from 'path';
+import { type Locator, type Page, expect } from '@playwright/test';
+import { waitForLayoutMain } from '../navigation/navigation-helpers';
+
+type CalendarViewName = 'Day' | 'Week' | 'Month';
+
+type CalendarDTO = {
+  id: string;
+  name: string;
+};
+
+type EventDTO = {
+  id: string;
+  title: string;
+};
+
+type EnsureCalendarResult = {
+  calendarId: string;
+  createdCalendarId: string | null;
+};
+
+const AUTH_STORAGE_KEY = 'auth-storage';
+const AUTH_FILE = path.resolve(__dirname, '../.auth/user.json');
+
+function calendarViewTrigger(page: Page): Locator {
+  return page.getByRole('button', { name: 'Calendar view' });
+}
+
+function calendarViewOption(page: Page, view: CalendarViewName): Locator {
+  return page
+    .getByRole('listbox')
+    .getByRole('option', { name: new RegExp(`^${view}(?:\\s|$)`) })
+    .first();
+}
+
+function calendarViewRoot(page: Page, view: CalendarViewName): Locator {
+  if (view === 'Day') {
+    return page.locator('[data-testid="calendar-day-view"]');
+  }
+  if (view === 'Week') {
+    return page.locator('[data-testid="calendar-week-view"]');
+  }
+  return page.locator('[data-testid="calendar-month-view"]');
+}
+
+function parseAuthToken(raw: string | null | undefined): string | null {
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed?.state?.token ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function readAuthTokenFromStorageState(): string | null {
+  try {
+    const raw = fs.readFileSync(AUTH_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    const authEntry = parsed?.origins
+      ?.flatMap((origin: { localStorage?: Array<{ name: string; value: string }> }) =>
+        origin.localStorage ?? [],
+      )
+      .find((entry: { name: string; value: string }) => entry.name === AUTH_STORAGE_KEY);
+
+    return parseAuthToken(authEntry?.value);
+  } catch {
+    return null;
+  }
+}
+
+async function getAuthToken(page: Page): Promise<string | null> {
+  if (page.isClosed()) {
+    return readAuthTokenFromStorageState();
+  }
+
+  try {
+    return await page.evaluate((storageKey) => {
+      const raw = localStorage.getItem(storageKey);
+      return raw;
+    }, AUTH_STORAGE_KEY).then(parseAuthToken);
+  } catch {
+    return readAuthTokenFromStorageState();
+  }
+}
+
+function getBaseUrl(page: Page): string {
+  try {
+    return new URL(page.url()).origin;
+  } catch {
+    return (process.env.BASE_URL || 'http://localhost').replace(/\/$/, '');
+  }
+}
+
+async function getAuthenticatedApiContext(page: Page) {
+  const token = await getAuthToken(page);
+  if (!token) {
+    throw new Error('No auth token found in localStorage.');
+  }
+
+  return {
+    baseUrl: getBaseUrl(page),
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  };
+}
+
+/**
+ * Wait for the calendar shell and default week view to finish rendering before
+ * interacting with toolbar controls or calendar slots.
+ */
+export async function waitForCalendarPageReady(page: Page) {
+  await waitForLayoutMain(page);
+  await expect(page.locator('main')).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByRole('button', { name: 'Today' })).toBeVisible({
+    timeout: 20_000,
+  });
+  await expect(
+    page.getByRole('button', { name: 'Previous period' }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: 'Next period' }),
+  ).toBeVisible();
+  await expect(calendarViewTrigger(page)).toBeVisible();
+  await expect(page.locator('[data-testid="calendar-header-title"]')).toBeVisible();
+  await expect(calendarViewRoot(page, 'Week')).toBeVisible({ timeout: 20_000 });
+}
+
+/**
+ * Navigate directly to /calendar and wait for the page shell to become stable.
+ * Use this when a test does not care how the user reached the calendar route.
+ */
+export async function ensureOnCalendarPage(page: Page) {
+  await page.goto('/calendar');
+  await waitForCalendarPageReady(page);
+}
+
+/** Calendar toolbar title element that shows the current visible date range. */
+export function getCalendarTitleLocator(page: Page) {
+  return page.locator('[data-testid="calendar-header-title"]').first();
+}
+
+/** Read and normalize the visible calendar header title text. */
+export async function getCalendarTitle(page: Page) {
+  return (await getCalendarTitleLocator(page).innerText()).trim();
+}
+
+/**
+ * Wait until the calendar header title changes after toolbar navigation.
+ * This gives us a stable signal that the visible date range has updated.
+ */
+export async function waitForCalendarTitleToChange(
+  page: Page,
+  previousTitle: string,
+) {
+  await expect
+    .poll(async () => await getCalendarTitle(page), { timeout: 10_000 })
+    .not.toBe(previousTitle);
+}
+
+/**
+ * Open the calendar view picker and wait for the listbox options to render.
+ * The trigger itself stays labeled "Calendar view" across view changes.
+ */
+export async function openCalendarViewSwitcher(page: Page) {
+  const trigger = calendarViewTrigger(page);
+  await expect(trigger).toBeVisible();
+  await trigger.click();
+  await expect(page.getByRole('listbox')).toBeVisible({ timeout: 10_000 });
+}
+
+/**
+ * Switch between Day / Week / Month views and assert both the target view root
+ * and the trigger text update to the selected view.
+ */
+export async function switchCalendarView(page: Page, view: CalendarViewName) {
+  await openCalendarViewSwitcher(page);
+  const listbox = page.getByRole('listbox');
+  const option = calendarViewOption(page, view);
+
+  await expect(option).toBeVisible({ timeout: 10_000 });
+  await option.click();
+  await expect(listbox).not.toBeVisible({ timeout: 10_000 });
+  await expect(calendarViewTrigger(page)).toContainText(view);
+  await expect(calendarViewRoot(page, view)).toBeVisible({ timeout: 10_000 });
+}
+
+/**
+ * Move to Day view, click a visible hour slot, and return the create-event
+ * dialog once it is open.
+ */
+export async function openCreateEventDialogFromDaySlot(
+  page: Page,
+  hour = 9,
+) {
+  await switchCalendarView(page, 'Day');
+  const slot = page.locator('[data-testid="calendar-day-slot"]').nth(hour);
+  await expect(slot).toBeVisible();
+  await slot.click();
+
+  const dialog = page.getByRole('dialog', { name: 'Create event' });
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
+  return dialog;
+}
+
+/** Find the first rendered calendar event card whose visible text includes `title`. */
+export function getCalendarEventCardByTitle(page: Page, title: string) {
+  return page
+    .locator('[data-testid="calendar-event-card"]')
+    .filter({ hasText: title })
+    .first();
+}
+
+/**
+ * Create an event from a visible day slot and wait for both the POST response
+ * and dialog dismissal so the test does not depend on optimistic UI timing.
+ */
+export async function createEventFromDaySlot(
+  page: Page,
+  title: string,
+  hour = 9,
+  calendarId?: string,
+): Promise<string | null> {
+  const dialog = await openCreateEventDialogFromDaySlot(page, hour);
+  const calendarSelect = dialog.getByRole('combobox');
+  await expect(calendarSelect).toBeVisible({ timeout: 10_000 });
+
+  // Wait for the calendar field to initialize before filling the form.
+  await expect
+    .poll(
+      async () =>
+        await calendarSelect.evaluate(
+          (element) => (element as HTMLSelectElement).value,
+        ),
+      { timeout: 10_000 },
+    )
+    .not.toBe('');
+
+  if (calendarId) {
+    await expect(calendarSelect.locator(`option[value="${calendarId}"]`)).toHaveCount(1, {
+      timeout: 10_000,
+    });
+    await calendarSelect.selectOption(calendarId);
+    await expect(calendarSelect).toHaveValue(calendarId);
+  }
+
+  const titleInput = dialog.getByPlaceholder('Add title');
+  await titleInput.fill(title);
+  await expect(titleInput).toHaveValue(title);
+
+  const isCreateEventRequest = (url: string, method: string) => {
+    const pathname = new URL(url).pathname;
+    return pathname === '/api/v1/events/' && method === 'POST';
+  };
+
+  const saveButton = dialog.getByRole('button', { name: 'Save' });
+  const responsePromise = page.waitForResponse(
+    (candidate) =>
+      isCreateEventRequest(candidate.url(), candidate.request().method()),
+    { timeout: 15_000 },
+  );
+
+  await saveButton.click();
+
+  const response = await responsePromise;
+
+  let eventId: string | null = null;
+  if (response.ok()) {
+    const body = await response.json();
+    eventId = body?.id ?? null;
+  }
+
+  await expect(dialog).not.toBeVisible({ timeout: 10_000 });
+  await expect(getCalendarEventCardByTitle(page, title)).toBeVisible({
+    timeout: 15_000,
+  });
+
+  return eventId;
+}
+
+/**
+ * List calendars the authenticated user can access.
+ * Used by setup helpers so tests can adapt to the environment's seed data.
+ */
+export async function listAccessibleCalendars(page: Page): Promise<CalendarDTO[]> {
+  const { baseUrl, headers } = await getAuthenticatedApiContext(page);
+  const response = await page.request.get(`${baseUrl}/api/v1/calendars/`, {
+    headers,
+  });
+
+  if (!response.ok()) {
+    throw new Error(`Failed to list calendars (${response.status()}).`);
+  }
+
+  return (await response.json()) as CalendarDTO[];
+}
+
+/**
+ * Create a temporary calendar through the API for tests that need a writable
+ * calendar but cannot assume one already exists.
+ */
+export async function createCalendarViaApi(
+  page: Page,
+  name: string,
+): Promise<CalendarDTO> {
+  const { baseUrl, headers } = await getAuthenticatedApiContext(page);
+  const response = await page.request.post(`${baseUrl}/api/v1/calendars/`, {
+    headers,
+    data: {
+      name,
+      color: '#1E88E5',
+      visibility: 'private',
+      timezone: 'UTC',
+      is_primary: false,
+    },
+  });
+
+  if (!response.ok()) {
+    throw new Error(`Failed to create calendar (${response.status()}).`);
+  }
+
+  return (await response.json()) as CalendarDTO;
+}
+
+/** Best-effort calendar cleanup helper for calendars created during a test. */
+export async function deleteCalendarById(page: Page, calendarId: string) {
+  try {
+    const { baseUrl, headers } = await getAuthenticatedApiContext(page);
+    const response = await page.request.delete(`${baseUrl}/api/v1/calendars/${calendarId}/`, {
+      headers,
+    });
+
+    if (!response.ok() && response.status() !== 404) {
+      console.warn(`Failed to delete calendar ${calendarId} (${response.status()}).`);
+    }
+  } catch (error) {
+    console.warn(`Calendar cleanup skipped for ${calendarId}.`, error);
+  }
+}
+
+/**
+ * Return an existing writable calendar when possible, otherwise create a
+ * temporary one so event-creation tests remain deterministic.
+ */
+export async function ensureCalendarAvailable(
+  page: Page,
+): Promise<EnsureCalendarResult> {
+  const calendars = await listAccessibleCalendars(page);
+  if (calendars.length > 0) {
+    return {
+      calendarId: calendars[0].id,
+      createdCalendarId: null,
+    };
+  }
+
+  const createdCalendar = await createCalendarViaApi(
+    page,
+    `E2E Calendar ${Date.now()}`,
+  );
+
+  await page.reload();
+  await waitForCalendarPageReady(page);
+
+  return {
+    calendarId: createdCalendar.id,
+    createdCalendarId: createdCalendar.id,
+  };
+}
+
+/**
+ * Seed a regular event through the API so "open existing event" tests can stay
+ * focused on calendar rendering and dialog behavior.
+ */
+export async function createEventViaApi(
+  page: Page,
+  calendarId: string,
+  title: string,
+): Promise<EventDTO> {
+  const { baseUrl, headers } = await getAuthenticatedApiContext(page);
+  const eventWindow = await page.evaluate(() => {
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+    const start = new Date();
+    start.setHours(11, 0, 0, 0);
+    const end = new Date(start);
+    end.setHours(12, 0, 0, 0);
+
+    return {
+      timezone,
+      startDatetime: start.toISOString(),
+      endDatetime: end.toISOString(),
+    };
+  });
+
+  const response = await page.request.post(`${baseUrl}/api/v1/events/`, {
+    headers,
+    data: {
+      calendar_id: calendarId,
+      title,
+      description: 'Created by Playwright E2E',
+      start_datetime: eventWindow.startDatetime,
+      end_datetime: eventWindow.endDatetime,
+      timezone: eventWindow.timezone,
+      is_all_day: false,
+    },
+  });
+
+  if (!response.ok()) {
+    throw new Error(`Failed to create event (${response.status()}).`);
+  }
+
+  return (await response.json()) as EventDTO;
+}
+
+/** Best-effort event cleanup helper for events created or seeded during a test. */
+export async function deleteEventById(page: Page, eventId: string) {
+  try {
+    const { baseUrl, headers } = await getAuthenticatedApiContext(page);
+    const response = await page.request.delete(`${baseUrl}/api/v1/events/${eventId}/`, {
+      headers,
+    });
+
+    if (!response.ok() && response.status() !== 404) {
+      console.warn(`Failed to delete event ${eventId} (${response.status()}).`);
+    }
+  } catch (error) {
+    console.warn(`Event cleanup skipped for ${eventId}.`, error);
+  }
+}

--- a/frontend/e2e/calendar/calendar.spec.ts
+++ b/frontend/e2e/calendar/calendar.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect } from '@playwright/test';
+import {
+  createEventFromDaySlot,
+  createEventViaApi,
+  deleteCalendarById,
+  deleteEventById,
+  ensureCalendarAvailable,
+  ensureOnCalendarPage,
+  getCalendarEventCardByTitle,
+  getCalendarTitle,
+  switchCalendarView,
+  waitForCalendarTitleToChange,
+} from './calendar-helpers';
+
+/**
+ * Calendar page coverage for load, toolbar navigation, view switching,
+ * event creation, and opening an existing event.
+ */
+test.describe('Calendar page', () => {
+  // These tests share one authenticated account and create temporary calendar
+  // data, so serial mode avoids cross-test interference.
+  test.describe.configure({ mode: 'serial', timeout: 90_000 });
+
+  test('logged-in user opens calendar and sees toolbar plus default week grid', async ({
+    page,
+  }) => {
+    await ensureOnCalendarPage(page);
+
+    await expect(page.getByRole('button', { name: 'Today' })).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Previous period' }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Next period' }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Calendar view' }),
+    ).toContainText('Week');
+    await expect(page.locator('[data-testid="calendar-header-title"]')).toBeVisible();
+    await expect(page.locator('[data-testid="calendar-week-view"]')).toBeVisible();
+    await expect(page.locator('[data-testid="calendar-week-slot"]')).toHaveCount(24 * 7);
+  });
+
+  test('calendar navigation updates the header title for previous next and today', async ({
+    page,
+  }) => {
+    await ensureOnCalendarPage(page);
+
+    // The header title is the clearest user-visible signal that the active
+    // date range changed after toolbar navigation.
+    const initialTitle = await getCalendarTitle(page);
+
+    // 1) Move forward and confirm the visible range changes
+    await page.getByRole('button', { name: 'Next period' }).click();
+    await waitForCalendarTitleToChange(page, initialTitle);
+    const nextTitle = await getCalendarTitle(page);
+    expect(nextTitle).not.toBe(initialTitle);
+
+    // 2) Move back to the original range
+    await page.getByRole('button', { name: 'Previous period' }).click();
+    await expect
+      .poll(async () => await getCalendarTitle(page), { timeout: 10_000 })
+      .toBe(initialTitle);
+
+    // 3) Move away again, then use Today to return to the current range
+    await page.getByRole('button', { name: 'Previous period' }).click();
+    await waitForCalendarTitleToChange(page, initialTitle);
+
+    await page.getByRole('button', { name: 'Today' }).click();
+    await expect
+      .poll(async () => await getCalendarTitle(page), { timeout: 10_000 })
+      .toBe(initialTitle);
+  });
+
+  test('user can switch between day week and month views', async ({ page }) => {
+    await ensureOnCalendarPage(page);
+
+    // 1) Day view
+    await switchCalendarView(page, 'Day');
+    await expect(page.locator('[data-testid="calendar-day-view"]')).toBeVisible();
+    await expect(page.locator('[data-testid="calendar-day-slot"]')).toHaveCount(24);
+
+    // 2) Month view
+    await switchCalendarView(page, 'Month');
+    await expect(page.locator('[data-testid="calendar-month-view"]')).toBeVisible();
+
+    // 3) Week view
+    await switchCalendarView(page, 'Week');
+    await expect(page.locator('[data-testid="calendar-week-view"]')).toBeVisible();
+    await expect(page.locator('[data-testid="calendar-week-slot"]')).toHaveCount(24 * 7);
+  });
+
+  test('user can create an event from a day time slot', async ({ page }) => {
+    await ensureOnCalendarPage(page);
+
+    let createdCalendarId: string | null = null;
+    let eventId: string | null = null;
+
+    try {
+      // Ensure the account has a writable calendar before opening the create flow.
+      const ensuredCalendar = await ensureCalendarAvailable(page);
+      createdCalendarId = ensuredCalendar.createdCalendarId;
+
+      // Create through the UI from a visible day slot.
+      const title = `E2E Calendar Event ${Date.now()}`;
+      eventId = await createEventFromDaySlot(
+        page,
+        title,
+        9,
+        ensuredCalendar.calendarId,
+      );
+
+      // The new event should render on the grid and the create dialog should close.
+      await expect(getCalendarEventCardByTitle(page, title)).toBeVisible();
+      await expect(
+        page.getByRole('dialog', { name: 'Create event' }),
+      ).not.toBeVisible();
+    } finally {
+      // Cleanup runs in finally so temporary data does not leak on failures.
+      if (eventId) {
+        await deleteEventById(page, eventId);
+      }
+      if (createdCalendarId) {
+        await deleteCalendarById(page, createdCalendarId);
+      }
+    }
+  });
+
+  test('user can open an existing event from the calendar', async ({ page }) => {
+    await ensureOnCalendarPage(page);
+
+    let createdCalendarId: string | null = null;
+    let eventId: string | null = null;
+
+    try {
+      // Ensure the account has a calendar, then seed an event by API so this
+      // test stays focused on opening the existing event from the grid.
+      const ensuredCalendar = await ensureCalendarAvailable(page);
+      createdCalendarId = ensuredCalendar.createdCalendarId;
+
+      const title = `E2E Existing Event ${Date.now()}`;
+      const event = await createEventViaApi(page, ensuredCalendar.calendarId, title);
+      eventId = event.id;
+
+      // Reload so the seeded event is fetched through the normal page load flow.
+      await page.reload();
+      await ensureOnCalendarPage(page);
+      await switchCalendarView(page, 'Day');
+
+      // Open the existing event and assert the detail/edit actions are present.
+      const eventCard = getCalendarEventCardByTitle(page, title);
+      await expect(eventCard).toBeVisible({ timeout: 15_000 });
+      await eventCard.click();
+
+      const dialog = page.getByRole('dialog', { name: 'View event' });
+      await expect(dialog).toBeVisible({ timeout: 10_000 });
+      await expect(dialog).toContainText(title);
+      await expect(
+        dialog.getByRole('button', { name: 'Edit event' }),
+      ).toBeVisible();
+      await expect(
+        dialog.getByRole('button', { name: 'Delete event' }),
+      ).toBeVisible();
+    } finally {
+      // Cleanup runs in finally so seeded data does not affect later tests.
+      if (eventId) {
+        await deleteEventById(page, eventId);
+      }
+      if (createdCalendarId) {
+        await deleteCalendarById(page, createdCalendarId);
+      }
+    }
+  });
+});

--- a/frontend/src/components/calendar/CalendarToolbar.tsx
+++ b/frontend/src/components/calendar/CalendarToolbar.tsx
@@ -55,7 +55,13 @@ export function CalendarToolbar({
           </button>
         </div>
         <div className="flex items-center gap-2">
-          <span className="text-lg font-semibold text-gray-900">{headerTitle}</span>
+          <span
+            // Stable hook for E2E assertions without coupling tests to layout styles.
+            data-testid="calendar-header-title"
+            className="text-lg font-semibold text-gray-900"
+          >
+            {headerTitle}
+          </span>
         </div>
       </div>
 

--- a/frontend/src/components/calendar/CalendarToolbar.tsx
+++ b/frontend/src/components/calendar/CalendarToolbar.tsx
@@ -56,7 +56,6 @@ export function CalendarToolbar({
         </div>
         <div className="flex items-center gap-2">
           <span
-            // Stable hook for E2E assertions without coupling tests to layout styles.
             data-testid="calendar-header-title"
             className="text-lg font-semibold text-gray-900"
           >

--- a/frontend/src/components/calendar/CalendarViews.tsx
+++ b/frontend/src/components/calendar/CalendarViews.tsx
@@ -15,6 +15,16 @@ import type { CalendarDTO, EventDTO, CalendarViewType } from "@/lib/api/calendar
 import type { EventPanelPosition } from "@/components/calendar/types";
 import { computePanelPosition } from "@/components/calendar/utils";
 
+const WEEKDAY_LABELS = [
+  { key: "mon", label: "M" },
+  { key: "tue", label: "T" },
+  { key: "wed", label: "W" },
+  { key: "thu", label: "T" },
+  { key: "fri", label: "F" },
+  { key: "sat", label: "S" },
+  { key: "sun", label: "S" },
+] as const;
+
 export type WeekViewProps = {
   currentDate: Date;
   events: EventDTO[];
@@ -145,7 +155,6 @@ export function WeekView({
   return (
     <div
       className="flex h-full flex-col rounded-3xl bg-white shadow-sm"
-      // Expose stable E2E hooks for the active view without relying on utility classes.
       data-testid="calendar-week-view"
       aria-label="Week calendar view"
     >
@@ -201,7 +210,6 @@ export function WeekView({
                   <button
                     key={hour}
                     type="button"
-                    // Slot hooks let E2E tests create events from a predictable target.
                     data-testid="calendar-week-slot"
                     aria-label={`Create event on ${format(
                       slotStart,
@@ -237,7 +245,6 @@ export function WeekView({
                   <button
                     key={event.id + event.start_datetime}
                     type="button"
-                    // Event cards need a durable selector because their layout can shift with time.
                     data-testid="calendar-event-card"
                     aria-label={`Open event ${event.title || "(No title)"}`}
                     onClick={(e) => {
@@ -397,7 +404,6 @@ export function DayView({
   return (
     <div
       className="flex flex-col rounded-xl bg-white"
-      // Match the week view hooks so tests can assert the active calendar mode consistently.
       data-testid="calendar-day-view"
       aria-label="Day calendar view"
     >
@@ -436,7 +442,6 @@ export function DayView({
               <button
                 key={hour}
                 type="button"
-                // Day slots are used by E2E tests to open the create-event dialog.
                 data-testid="calendar-day-slot"
                 aria-label={`Create event on ${format(
                   slotStart,
@@ -469,7 +474,6 @@ export function DayView({
               <button
                 key={event.id + event.start_datetime}
                 type="button"
-                // Reuse the same selector as week view so event-open tests stay view-agnostic.
                 data-testid="calendar-event-card"
                 aria-label={`Open event ${event.title || "(No title)"}`}
                 onClick={(e) => {
@@ -582,7 +586,6 @@ export function MonthView({
     return result;
   }, [days, events]);
 
-  const weekdayLabels = ["M", "T", "W", "T", "F", "S", "S"];
   const today = new Date();
 
   return (
@@ -597,9 +600,9 @@ export function MonthView({
       </div>
       <div className="grid flex-1 grid-rows-[auto_1fr]">
         <div className="grid grid-cols-7 bg-white text-[11px] font-medium text-gray-500">
-          {weekdayLabels.map((label) => (
-            <div key={label} className="flex items-center justify-center py-1">
-              {label}
+          {WEEKDAY_LABELS.map((item) => (
+            <div key={item.key} className="flex items-center justify-center py-1">
+              {item.label}
             </div>
           ))}
         </div>
@@ -787,7 +790,6 @@ export function YearView({ currentDate, onDaySelect }: YearViewProps) {
           const startMonth = startOfMonth(monthDate);
           const gridStart = startOfWeek(startMonth, { weekStartsOn: 1 });
           const days = Array.from({ length: 42 }, (_, index) => addDays(gridStart, index));
-          const weekdayLabels = ["M", "T", "W", "T", "F", "S", "S"];
 
           return (
             <div key={monthDate.toISOString()} className="rounded bg-white p-2">
@@ -795,9 +797,9 @@ export function YearView({ currentDate, onDaySelect }: YearViewProps) {
                 {format(monthDate, "MMMM")}
               </div>
               <div className="grid grid-cols-7 place-items-center gap-0.5 text-[10px] text-gray-400">
-                {weekdayLabels.map((label) => (
-                  <div key={label} className="flex h-4 items-center justify-center">
-                    {label}
+                {WEEKDAY_LABELS.map((item) => (
+                  <div key={item.key} className="flex h-4 items-center justify-center">
+                    {item.label}
                   </div>
                 ))}
                 {days.map((day) => {
@@ -842,7 +844,6 @@ export function MiniMonthCalendar({ currentDate, onDateChange }: MiniMonthCalend
     () => Array.from({ length: 42 }, (_, index) => addDays(gridStart, index)),
     [gridStart],
   );
-  const weekdayLabels = ["M", "T", "W", "T", "F", "S", "S"];
   const today = new Date();
 
   return (
@@ -851,9 +852,9 @@ export function MiniMonthCalendar({ currentDate, onDateChange }: MiniMonthCalend
         <span>{format(currentDate, "MMMM yyyy")}</span>
       </div>
       <div className="grid grid-cols-7 gap-1 text-[11px] text-gray-500">
-        {weekdayLabels.map((label) => (
-          <div key={label} className="flex h-5 items-center justify-center">
-            {label}
+        {WEEKDAY_LABELS.map((item) => (
+          <div key={item.key} className="flex h-5 items-center justify-center">
+            {item.label}
           </div>
         ))}
         {days.map((day) => {

--- a/frontend/src/components/calendar/CalendarViews.tsx
+++ b/frontend/src/components/calendar/CalendarViews.tsx
@@ -143,7 +143,12 @@ export function WeekView({
   };
 
   return (
-    <div className="flex h-full flex-col rounded-3xl bg-white shadow-sm">
+    <div
+      className="flex h-full flex-col rounded-3xl bg-white shadow-sm"
+      // Expose stable E2E hooks for the active view without relying on utility classes.
+      data-testid="calendar-week-view"
+      aria-label="Week calendar view"
+    >
       <div className="relative z-0 grid grid-cols-[60px_repeat(7,minmax(0,1fr))] bg-white text-xs font-medium text-gray-500">
         <div className="relative px-2 py-2 text-gray-400 before:absolute before:bottom-0 before:right-0 before:block before:h-px before:w-3 before:bg-gray-100 before:content-[''] after:absolute after:bottom-0 after:right-0 after:block after:h-4 after:w-px after:bg-gray-100 after:content-['']" />
         {days.map((day) => (
@@ -196,6 +201,12 @@ export function WeekView({
                   <button
                     key={hour}
                     type="button"
+                    // Slot hooks let E2E tests create events from a predictable target.
+                    data-testid="calendar-week-slot"
+                    aria-label={`Create event on ${format(
+                      slotStart,
+                      "EEEE, MMMM d 'at' h:mm a",
+                    )}`}
                     className="h-12 w-full border-b border-gray-100 bg-white text-left hover:bg-blue-50 flex flex-col"
                     onClick={(e) => {
                       const rect = e.currentTarget.getBoundingClientRect();
@@ -226,6 +237,9 @@ export function WeekView({
                   <button
                     key={event.id + event.start_datetime}
                     type="button"
+                    // Event cards need a durable selector because their layout can shift with time.
+                    data-testid="calendar-event-card"
+                    aria-label={`Open event ${event.title || "(No title)"}`}
                     onClick={(e) => {
                       if (suppressClick) {
                         e.preventDefault();
@@ -381,7 +395,12 @@ export function DayView({
   };
 
   return (
-    <div className="flex flex-col rounded-xl bg-white">
+    <div
+      className="flex flex-col rounded-xl bg-white"
+      // Match the week view hooks so tests can assert the active calendar mode consistently.
+      data-testid="calendar-day-view"
+      aria-label="Day calendar view"
+    >
       <div className="relative z-0 grid grid-cols-[60px_minmax(0,1fr)] bg-white text-xs font-medium text-gray-500">
         <div className="relative px-2 py-2 text-gray-400 before:absolute before:bottom-0 before:right-0 before:block before:h-px before:w-3 before:bg-gray-100 before:content-[''] after:absolute after:bottom-0 after:right-0 after:block after:h-2 after:w-px after:bg-gray-100 after:content-['']" />
         <div className="flex flex-col px-2 py-2 border-b">
@@ -417,6 +436,12 @@ export function DayView({
               <button
                 key={hour}
                 type="button"
+                // Day slots are used by E2E tests to open the create-event dialog.
+                data-testid="calendar-day-slot"
+                aria-label={`Create event on ${format(
+                  slotStart,
+                  "EEEE, MMMM d 'at' h:mm a",
+                )}`}
                 className="h-12 w-full border-b border-gray-100 bg-white text-left hover:bg-blue-50"
                 onClick={(e) => {
                   const rect = e.currentTarget.getBoundingClientRect();
@@ -444,6 +469,9 @@ export function DayView({
               <button
                 key={event.id + event.start_datetime}
                 type="button"
+                // Reuse the same selector as week view so event-open tests stay view-agnostic.
+                data-testid="calendar-event-card"
+                aria-label={`Open event ${event.title || "(No title)"}`}
                 onClick={(e) => {
                   if (suppressClick) {
                     e.preventDefault();
@@ -558,7 +586,11 @@ export function MonthView({
   const today = new Date();
 
   return (
-    <div className="flex h-full flex-col rounded-xl bg-white">
+    <div
+      className="flex h-full flex-col rounded-xl bg-white"
+      data-testid="calendar-month-view"
+      aria-label="Month calendar view"
+    >
       <div className="flex items-center justify-between px-4 py-2 text-sm font-semibold text-gray-700">
         {isLoading && <span className="text-xs text-gray-400">Loading…</span>}
         {error && <span className="text-xs text-red-500">Failed to load events.</span>}

--- a/frontend/src/components/calendar/EventPanelDialog.tsx
+++ b/frontend/src/components/calendar/EventPanelDialog.tsx
@@ -66,14 +66,44 @@ export function EventPanelDialog({
   const [calendarId, setCalendarId] = React.useState<string>(
     resolveDefaultCalendarId(event?.calendar_id),
   );
+  const formSeedRef = React.useRef<string | null>(null);
+  const formSeedKey = [
+    mode,
+    event?.id ?? "create",
+    start?.toISOString() ?? "",
+    end?.toISOString() ?? "",
+  ].join("|");
 
   React.useEffect(() => {
-    setTitle(event?.title ?? "");
-    setDescription(event?.description ?? "");
-    setCalendarId(resolveDefaultCalendarId(event?.calendar_id));
-    setLocalStart(start);
-    setLocalEnd(end);
-  }, [event, mode, resolveDefaultCalendarId, start, end]);
+    const defaultCalendarId = resolveDefaultCalendarId(event?.calendar_id);
+
+    // Reset only when the dialog target changes; preserve user input during
+    // late calendar hydration.
+    if (formSeedRef.current !== formSeedKey) {
+      formSeedRef.current = formSeedKey;
+      setTitle(event?.title ?? "");
+      setDescription(event?.description ?? "");
+      setCalendarId(defaultCalendarId);
+      setLocalStart(start);
+      setLocalEnd(end);
+      return;
+    }
+
+    setCalendarId((currentCalendarId) => {
+      if (currentCalendarId && calendars.some((cal) => cal.id === currentCalendarId)) {
+        return currentCalendarId;
+      }
+      return defaultCalendarId;
+    });
+  }, [
+    calendars,
+    end,
+    event,
+    formSeedKey,
+    mode,
+    resolveDefaultCalendarId,
+    start,
+  ]);
 
   if (!open || !localStart || !localEnd || !position) {
     return null;
@@ -99,6 +129,9 @@ export function EventPanelDialog({
       <>
         {backdrop}
         <div
+          role="dialog"
+          aria-label="View event"
+          data-testid="calendar-event-dialog"
           className="fixed z-50 w-[360px] rounded-3xl border bg-[#f0f4f9] shadow-xl animate-in slide-in-from-bottom-8 fade-in duration-300"
           style={{ top: position.top, left: position.left }}
           onClick={(e) => e.stopPropagation()}
@@ -251,6 +284,9 @@ export function EventPanelDialog({
     <>
       {backdrop}
       <div
+        role="dialog"
+        aria-label={mode === "edit" ? "Edit event" : "Create event"}
+        data-testid="calendar-event-dialog"
         className="fixed z-50 w-[420px] rounded-3xl border bg-[#f0f4f9] shadow-xl animate-in slide-in-from-bottom-8 fade-in duration-300"
         style={{ top: position.top, left: position.left }}
         onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
This PR adds Playwright end-to-end coverage for the Calendar flow, fulfilling the requirements for MD-130.

### What's Implemented
**1. Calendar E2E Coverage**

- **Page Load:** Added a test to verify that an authenticated user can open the Calendar page and see the default week view.

- **Navigation and Views:** Added tests for toolbar navigation and switching between Day, Week, and Month views.

**2. Event Flow Coverage**

- **Create Event:** Added E2E coverage for creating an event from a day time slot.

- **Open Event:** Added E2E coverage for opening an existing event from the calendar grid.

**3. Test Stability Improvements**

- **Stable Hooks:** Added durable selectors for calendar views, header title, event cards, and dialogs.

- **Auth Setup:** Updated Playwright auth setup to accept the app’s current post-login landing routes.

- **Dialog Fix:** Prevented late calendar hydration from resetting form input during event creation.

