### PR TITLE
BGF-37 / SMP-496 / Chat-07: calendar fix, org token refresh, share task to chat              

### DIFF
--- a/backend/authentication/serializers.py
+++ b/backend/authentication/serializers.py
@@ -127,4 +127,8 @@ class ProfileUpdateSerializer(serializers.ModelSerializer):
                     print(f"Error deleting old avatar: {e}")
         
         return super().update(instance, validated_data)
+
+
+class OrganizationTokenRefreshSerializer(serializers.Serializer):
+    organization_access_token = serializers.CharField()
         

--- a/backend/authentication/services.py
+++ b/backend/authentication/services.py
@@ -1,0 +1,16 @@
+from django.core.exceptions import ValidationError
+from stripe_meta.permissions import generate_organization_access_token
+
+
+def refresh_organization_access_token(user):
+    """
+    Generate a fresh organization access token for the authenticated user.
+    """
+    if not user.organization:
+        raise ValidationError("User does not belong to an organization.")
+
+    token = generate_organization_access_token(user)
+    if not token:
+        raise ValidationError("Unable to generate organization token.")
+
+    return token

--- a/backend/authentication/tests/test_org_token_refresh.py
+++ b/backend/authentication/tests/test_org_token_refresh.py
@@ -1,0 +1,33 @@
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_refresh_org_token_success(authenticated_client):
+    response = authenticated_client.post('/auth/organization-token/refresh/')
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data.get('organization_access_token')
+
+
+@pytest.mark.django_db
+def test_refresh_org_token_requires_org():
+    client = APIClient()
+    user = User.objects.create_user(
+        username="noorguser",
+        email="noorg@example.com",
+        password="TestPassword123!",
+        is_verified=True,
+        is_active=True,
+    )
+    client.force_authenticate(user=user)
+
+    response = client.post('/auth/organization-token/refresh/')
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data.get('error')

--- a/backend/authentication/urls.py
+++ b/backend/authentication/urls.py
@@ -9,6 +9,7 @@ from .views import (
     GoogleOAuthStartView, 
     GoogleOAuthCallbackView, 
     GoogleSetPasswordView,
+    OrganizationTokenRefreshView,
     MeView, 
     UserTeamsView
 )
@@ -17,6 +18,7 @@ urlpatterns = [
     path('register/', RegisterView.as_view(), name='register'),
     path('verify/', VerifyEmailView.as_view(), name='verify'),
     path('login/', LoginView.as_view(), name='login'),
+    path('organization-token/refresh/', OrganizationTokenRefreshView.as_view(), name='organization-token-refresh'),
     path('me/', MeView.as_view(), name='me'),
     path('me/teams/', UserTeamsView.as_view(), name='user-teams'),
     

--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -11,7 +11,8 @@ from django.contrib.auth import authenticate
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
 from rest_framework_simplejwt.tokens import RefreshToken
-from .serializers import UserProfileSerializer
+from .serializers import UserProfileSerializer, OrganizationTokenRefreshSerializer
+from .services import refresh_organization_access_token
 from core.models import Team, Organization, Role
 from access_control.models import UserRole
 from stripe_meta.permissions import generate_organization_access_token
@@ -213,6 +214,21 @@ class LoginView(APIView):
             response_data['organization_access_token'] = custom_access_token
         
         return Response(response_data, status=status.HTTP_200_OK)
+
+
+class OrganizationTokenRefreshView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        try:
+            new_token = refresh_organization_access_token(request.user)
+        except ValidationError as exc:
+            return Response({"error": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
+        serializer = OrganizationTokenRefreshSerializer(
+            {"organization_access_token": new_token}
+        )
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 class SsoRedirectView(APIView):
     """

--- a/backend/core/tests/test_projects.py
+++ b/backend/core/tests/test_projects.py
@@ -7,7 +7,9 @@ Tests for:
 import pytest
 from django.urls import reverse
 from rest_framework import status
+from calendars.models import Calendar
 from core.models import Project, ProjectMember
+from core.utils.project_calendars import ensure_project_calendar
 
 
 @pytest.mark.django_db
@@ -171,6 +173,18 @@ class TestProjectViewSet:
         assert response.data['name'] == project.name
         assert 'is_active' in response.data
         assert 'member_count' in response.data
+
+    def test_delete_project_soft_deletes_calendar(self, authenticated_client, project):
+        """Deleting a project should soft-delete its calendar."""
+        calendar = ensure_project_calendar(project)
+        assert calendar.is_deleted is False
+
+        url = reverse('project-detail', kwargs={'pk': project.id})
+        response = authenticated_client.delete(url)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        calendar.refresh_from_db()
+        assert calendar.is_deleted is True
 
     def test_get_project_requires_membership(self, authenticated_client, user, organization):
         """Getting project details requires membership"""

--- a/backend/core/utils/project_calendars.py
+++ b/backend/core/utils/project_calendars.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Optional
+from django.utils import timezone
 
 
 PROJECT_ROLE_TO_CALENDAR_PERMISSION = {
@@ -45,6 +46,16 @@ def ensure_project_calendar(project):
     if changed_fields:
         calendar.save(update_fields=changed_fields + ["updated_at"])
     return calendar
+
+
+def soft_delete_project_calendars(project) -> None:
+    from calendars.models import Calendar
+
+    now = timezone.now()
+    Calendar.objects.filter(project=project, is_deleted=False).update(
+        is_deleted=True,
+        updated_at=now,
+    )
 
 
 def sync_project_member_calendar_access(project, user, role: str | None, include_subscription: bool = True):

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -36,6 +36,7 @@ from core.utils.invitations import accept_invitation, create_project_invitation,
 from core.utils.kpi_suggestions import get_kpi_suggestions
 from core.utils.project_calendars import (
     ensure_project_calendar,
+    soft_delete_project_calendars,
 )
 
 logger = logging.getLogger(__name__)
@@ -308,6 +309,12 @@ class ProjectViewSet(viewsets.ModelViewSet):
         ensure_project_calendar(project)
 
         return project
+
+    def perform_destroy(self, instance):
+        """Delete project and soft-delete related calendars."""
+        with transaction.atomic():
+            soft_delete_project_calendars(instance)
+            instance.delete()
 
     @action(detail=True, methods=['post'])
     def set_active(self, request, pk=None):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,10 +94,10 @@ services:
       # Increase OAuth token clock skew tolerance for time sync issues
       - OAUTHLIB_RELAX_TOKEN_SCOPE=1
     volumes:
-      # Mount host timezone and localtime to sync time with host (Linux/Mac)
+      # Mount host localtime to sync time with host (Linux/Mac)
+      # Note: /etc/timezone does not exist on macOS; TZ=UTC is set via environment instead
       # Note: On Windows with Docker Desktop, time is automatically synced
       - /etc/localtime:/etc/localtime:ro
-      - /etc/timezone:/etc/timezone:ro
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,10 +94,10 @@ services:
       # Increase OAuth token clock skew tolerance for time sync issues
       - OAUTHLIB_RELAX_TOKEN_SCOPE=1
     volumes:
-      # Mount host localtime to sync time with host (Linux/Mac)
-      # Note: /etc/timezone does not exist on macOS; TZ=UTC is set via environment instead
+      # Mount host timezone and localtime to sync time with host (Linux/Mac)
       # Note: On Windows with Docker Desktop, time is automatically synced
       - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:

--- a/frontend/src/components/chat/MessageItem.tsx
+++ b/frontend/src/components/chat/MessageItem.tsx
@@ -6,6 +6,7 @@ import type { MessageItemProps } from '@/types/chat';
 import MessageStatus from './MessageStatus';
 import AttachmentDisplay from './AttachmentDisplay';
 import LinkPreview from './LinkPreview';
+import TaskSharePreview from './TaskSharePreview';
 import { extractUrls } from '@/lib/api/linkPreviewApi';
 
 const AGENT_BOT_EMAIL = 'agent-bot@system.local';
@@ -46,6 +47,18 @@ export default function MessageItem({
   } catch (error) {
     console.warn('Error extracting URLs:', error);
   }
+
+  const extractTaskIds = (content: string) => {
+    const matches = [...content.matchAll(/\/tasks\/(\d+)/g)];
+    return matches
+      .map((match) => Number(match[1]))
+      .filter((taskId) => !Number.isNaN(taskId));
+  };
+
+  const taskIds = extractTaskIds(messageContent);
+  const taskPreviewId = taskIds[0];
+  const showTaskPreview = Boolean(taskPreviewId);
+  const showLinkPreview = hasUrls && !showTaskPreview;
 
   const handleToggleSelect = () => {
     if (!isSelectMode || !onToggleSelect) return;
@@ -90,8 +103,13 @@ export default function MessageItem({
                   </div>
                 )}
                 
+                {/* Task Share Preview */}
+                {showTaskPreview && taskPreviewId ? (
+                  <TaskSharePreview taskId={taskPreviewId} className="mt-2" />
+                ) : null}
+
                 {/* Link Previews */}
-                {hasUrls && (
+                {showLinkPreview && (
                   <LinkPreview content={messageContent} />
                 )}
                 
@@ -168,8 +186,13 @@ export default function MessageItem({
                 </div>
               )}
 
+              {/* Task Share Preview */}
+              {showTaskPreview && taskPreviewId ? (
+                <TaskSharePreview taskId={taskPreviewId} className="mt-2" />
+              ) : null}
+
               {/* Link Previews */}
-              {hasUrls && (
+              {showLinkPreview && (
                 <LinkPreview content={messageContent} />
               )}
 

--- a/frontend/src/components/chat/TaskSharePreview.tsx
+++ b/frontend/src/components/chat/TaskSharePreview.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { ClipboardList } from 'lucide-react';
+import { TaskAPI } from '@/lib/api/taskApi';
+import type { TaskData } from '@/types/task';
+
+interface TaskSharePreviewProps {
+  taskId: number;
+  className?: string;
+}
+
+const statusTone: Record<string, string> = {
+  DRAFT: 'bg-slate-100 text-slate-600',
+  SUBMITTED: 'bg-blue-100 text-blue-700',
+  UNDER_REVIEW: 'bg-amber-100 text-amber-700',
+  APPROVED: 'bg-emerald-100 text-emerald-700',
+  REJECTED: 'bg-rose-100 text-rose-700',
+  LOCKED: 'bg-purple-100 text-purple-700',
+  CANCELLED: 'bg-gray-100 text-gray-600',
+};
+
+const formatDate = (value?: string | null) => {
+  if (!value) return 'No due date';
+  try {
+    return new Date(value).toLocaleDateString();
+  } catch {
+    return value;
+  }
+};
+
+export default function TaskSharePreview({ taskId, className = '' }: TaskSharePreviewProps) {
+  const [task, setTask] = useState<TaskData | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const fetchTask = async () => {
+      try {
+        setLoading(true);
+        const response = await TaskAPI.getTask(taskId);
+        if (mounted) {
+          setTask(response.data as TaskData);
+        }
+      } catch (error) {
+        if (mounted) {
+          setTask(null);
+        }
+        console.error('Error loading shared task preview:', error);
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchTask();
+
+    return () => {
+      mounted = false;
+    };
+  }, [taskId]);
+
+  const displayStatus = task?.status || 'DRAFT';
+  const statusClass = statusTone[displayStatus] || 'bg-slate-100 text-slate-600';
+  const ownerLabel = useMemo(() => {
+    if (!task?.owner) return 'Unassigned';
+    return task.owner.username || task.owner.email || 'Unassigned';
+  }, [task?.owner]);
+
+  if (loading) {
+    return (
+      <div className={`rounded-lg border border-slate-200 bg-white p-3 ${className}`}>
+        <div className="animate-pulse space-y-2">
+          <div className="h-3 w-24 rounded bg-slate-200"></div>
+          <div className="h-4 w-full rounded bg-slate-200"></div>
+          <div className="h-3 w-32 rounded bg-slate-200"></div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!task) {
+    return null;
+  }
+
+  return (
+    <Link
+      href={`/tasks/${task.id}`}
+      className={`block rounded-lg border border-slate-200 bg-white p-3 shadow-sm transition hover:border-indigo-400 ${className}`}
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex h-9 w-9 items-center justify-center rounded-md bg-indigo-50 text-indigo-600">
+          <ClipboardList className="h-4 w-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${statusClass}`}>
+              {displayStatus.replace('_', ' ')}
+            </span>
+            <span className="text-xs text-slate-400">Task #{task.id}</span>
+          </div>
+          <p className="mt-1 truncate text-sm font-semibold text-slate-900">
+            {task.summary || 'Untitled task'}
+          </p>
+          <div className="mt-2 grid gap-1 text-xs text-slate-500">
+            <span>Owner: {ownerLabel}</span>
+            <span>Due: {formatDate(task.due_date)}</span>
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/frontend/src/components/tasks/ShareTaskDialog.tsx
+++ b/frontend/src/components/tasks/ShareTaskDialog.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import type { Chat } from '@/types/chat';
+import ParticipantSelector from '@/components/chat/ParticipantSelector';
+
+interface ShareTaskDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  projectId: string;
+  availableChats: Chat[];
+  currentUserId: number;
+  isSharing?: boolean;
+  onSubmit: (targetChatIds: number[], targetUserIds: number[]) => Promise<void> | void;
+}
+
+const getChatDisplayName = (chat: Chat, currentUserId: number): string => {
+  if (chat.type === 'group') {
+    return chat.name || `Group chat #${chat.id}`;
+  }
+
+  const otherParticipant = chat.participants.find(
+    (participant) => participant.user.id !== currentUserId
+  );
+  return otherParticipant?.user.username || otherParticipant?.user.email || 'Private chat';
+};
+
+export default function ShareTaskDialog({
+  isOpen,
+  onClose,
+  projectId,
+  availableChats,
+  currentUserId,
+  isSharing = false,
+  onSubmit,
+}: ShareTaskDialogProps) {
+  const [selectedChatIds, setSelectedChatIds] = useState<number[]>([]);
+  const [selectedUserIds, setSelectedUserIds] = useState<number[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  useEffect(() => {
+    if (!isOpen) {
+      setSelectedChatIds([]);
+      setSelectedUserIds([]);
+      setSearchQuery('');
+    }
+  }, [isOpen]);
+
+  const filteredChats = useMemo(() => {
+    if (!searchQuery.trim()) return availableChats;
+    const query = searchQuery.toLowerCase();
+    return availableChats.filter((chat) =>
+      getChatDisplayName(chat, currentUserId).toLowerCase().includes(query)
+    );
+  }, [availableChats, currentUserId, searchQuery]);
+
+  const toggleChat = (chatId: number) => {
+    setSelectedChatIds((prev) =>
+      prev.includes(chatId) ? prev.filter((id) => id !== chatId) : [...prev, chatId]
+    );
+  };
+
+  const handleSubmit = async () => {
+    if (isSharing) return;
+    await onSubmit(selectedChatIds, selectedUserIds);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-2xl" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>Share Task</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <p className="text-sm text-gray-500">
+            Choose chats or users to share this task with.
+          </p>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-gray-700">Target chats</span>
+                <span className="text-xs text-gray-400">
+                  {selectedChatIds.length} selected
+                </span>
+              </div>
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search chats..."
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              />
+              <div className="max-h-64 overflow-y-auto rounded-lg border border-gray-200">
+                {filteredChats.length === 0 ? (
+                  <div className="py-8 text-center text-sm text-gray-500">
+                    No chats found.
+                  </div>
+                ) : (
+                  <div className="divide-y divide-gray-100">
+                    {filteredChats.map((chat) => {
+                      const displayName = getChatDisplayName(chat, currentUserId);
+                      return (
+                        <label
+                          key={chat.id}
+                          className="flex cursor-pointer items-center gap-3 px-3 py-2 hover:bg-gray-50"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={selectedChatIds.includes(chat.id)}
+                            onChange={() => toggleChat(chat.id)}
+                            className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                          />
+                          <div className="min-w-0 flex-1">
+                            <p className="truncate text-sm font-medium text-gray-900">
+                              {displayName}
+                            </p>
+                            <p className="truncate text-xs text-gray-500">
+                              {chat.type === 'group' ? 'Group chat' : 'Private chat'}
+                            </p>
+                          </div>
+                        </label>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-gray-700">Target users</span>
+                <span className="text-xs text-gray-400">
+                  {selectedUserIds.length} selected
+                </span>
+              </div>
+              <ParticipantSelector
+                projectId={projectId}
+                selectedIds={selectedUserIds}
+                onSelect={setSelectedUserIds}
+                currentUserId={currentUserId}
+              />
+            </div>
+          </div>
+
+          <div className="text-xs text-gray-500">
+            Targets: {selectedChatIds.length} chats, {selectedUserIds.length} users
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            disabled={isSharing}
+            className="rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={isSharing || (selectedChatIds.length === 0 && selectedUserIds.length === 0)}
+            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isSharing ? 'Sharing...' : 'Share'}
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/tasks/TaskDetail.tsx
+++ b/frontend/src/components/tasks/TaskDetail.tsx
@@ -40,7 +40,7 @@ import {
   ScalingPlan,
 } from "@/lib/api/optimizationScalingApi";
 import { ExperimentAPI, Experiment } from "@/lib/api/experimentApi";
-import { ChevronDown, Trash2 } from "lucide-react";
+import { ChevronDown, Share2, Trash2 } from "lucide-react";
 import { OptimizationAPI, Optimization } from "@/lib/api/optimizationApi";
 import { ClientCommunicationAPI } from "@/lib/api/clientCommunicationApi";
 import type { ClientCommunicationPayload } from "@/lib/api/clientCommunicationApi";
@@ -60,6 +60,9 @@ import {
   JiraBoardDueTone,
 } from "@/components/jira-ticket/JiraBoard";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
+import { useChatData } from "@/hooks/useChatData";
+import { createChat, findPrivateChat, sendMessage } from "@/lib/api/chatApi";
+import ShareTaskDialog from "./ShareTaskDialog";
 
 interface TaskDetailProps {
   task: TaskData;
@@ -149,6 +152,8 @@ export default function TaskDetail({
   const { startReview: startBudgetReview, makeDecision: makeBudgetDecision } =
     useBudgetData();
   const projectId = task.project?.id ?? task.project_id;
+  const currentUserId = currentUser?.id !== undefined ? Number(currentUser.id) : null;
+  const { chats } = useChatData({ projectId, autoFetch: Boolean(projectId) });
 
   const [summaryDraft, setSummaryDraft] = useState(task.summary || "");
   const [descriptionDraft, setDescriptionDraft] = useState(
@@ -167,6 +172,8 @@ export default function TaskDetail({
   const [savingOwner, setSavingOwner] = useState(false);
   const [savingSummary, setSavingSummary] = useState(false);
   const [savingDescription, setSavingDescription] = useState(false);
+  const [shareDialogOpen, setShareDialogOpen] = useState(false);
+  const [sharingTask, setSharingTask] = useState(false);
   const {
     textareaRef: descriptionTextareaRef,
     resizeTextarea: resizeDescriptionTextarea,
@@ -774,6 +781,71 @@ export default function TaskDetail({
     setDueDateInput(task.due_date ?? "");
     setEditingStartDate(false);
     setEditingDueDate(false);
+  };
+
+  const buildTaskShareContent = () => {
+    const origin =
+      typeof window !== "undefined" && window.location?.origin
+        ? window.location.origin
+        : "";
+    const taskUrl = `${origin}/tasks/${task.id}`;
+    const title = task.summary || `Task #${task.id}`;
+    return `Task shared: ${title}\n${taskUrl}`;
+  };
+
+  const handleShareTask = async (
+    targetChatIds: number[],
+    targetUserIds: number[],
+  ) => {
+    if (!task?.id || !projectId || !currentUserId) {
+      toast.error("Unable to share task right now.");
+      return;
+    }
+    if (targetChatIds.length === 0 && targetUserIds.length === 0) {
+      toast.error("Select at least one chat or user.");
+      return;
+    }
+
+    setSharingTask(true);
+    try {
+      const messageContent = buildTaskShareContent();
+      const resolvedChatIds: number[] = [...targetChatIds];
+      const numericProjectId = Number(projectId);
+
+      for (const userId of targetUserIds) {
+        const existingChat = await findPrivateChat(numericProjectId, userId);
+        if (existingChat) {
+          resolvedChatIds.push(existingChat.id);
+          continue;
+        }
+
+        const newChat = await createChat({
+          type: "private",
+          project_id: numericProjectId,
+          participant_ids: [userId],
+        });
+        resolvedChatIds.push(newChat.id);
+      }
+
+      const uniqueChatIds = Array.from(new Set(resolvedChatIds));
+      await Promise.all(
+        uniqueChatIds.map((chatId) =>
+          sendMessage({ chat_id: chatId, content: messageContent }),
+        ),
+      );
+
+      toast.success("Task shared successfully.");
+      setShareDialogOpen(false);
+    } catch (error: any) {
+      const message =
+        error?.response?.data?.detail ||
+        error?.response?.data?.message ||
+        error?.message ||
+        "Failed to share task.";
+      toast.error(message);
+    } finally {
+      setSharingTask(false);
+    }
   };
 
   useEffect(() => {
@@ -2339,6 +2411,26 @@ export default function TaskDetail({
 
         {/* Right section */}
         <div className="space-y-4 lg:sticky lg:top-24 self-start">
+          {/* Share Task */}
+          {task?.id && projectId ? (
+            <div className="rounded-lg border border-slate-200 bg-white p-3">
+              <button
+                type="button"
+                onClick={() => setShareDialogOpen(true)}
+                disabled={!currentUserId}
+                className="w-full inline-flex items-center justify-center gap-2 rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-indigo-300"
+              >
+                <Share2 className="h-4 w-4" />
+                Share to Chat
+              </button>
+              {!currentUserId ? (
+                <p className="mt-2 text-xs text-gray-400">
+                  Sign in to share this task.
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+
           {/* Task Basic Info */}
           <Accordion
             type="multiple"
@@ -2632,6 +2724,17 @@ export default function TaskDetail({
           ) : null}
         </div>
       </div>
+      {task?.id && projectId && currentUserId ? (
+        <ShareTaskDialog
+          isOpen={shareDialogOpen}
+          onClose={() => setShareDialogOpen(false)}
+          projectId={String(projectId)}
+          availableChats={chats}
+          currentUserId={currentUserId}
+          isSharing={sharingTask}
+          onSubmit={handleShareTask}
+        />
+      ) : null}
       <ConfirmDialog
         isOpen={showDeleteConfirm}
         title="Delete task"

--- a/frontend/src/hooks/usePlan.ts
+++ b/frontend/src/hooks/usePlan.ts
@@ -44,6 +44,27 @@ export default function usePlan(): UsePlanReturn {
       const response = await api.get('/api/stripe/plans/');
       setPlans(response.data.results || []);
     } catch (error: any) {
+      const status = error?.response?.status;
+
+      if (status === 403) {
+        const { refreshOrganizationAccessToken } = useAuthStore.getState();
+        const refreshResult = await refreshOrganizationAccessToken();
+
+        if (refreshResult.success) {
+          try {
+            const retryResponse = await api.get('/api/stripe/plans/');
+            setPlans(retryResponse.data.results || []);
+            return;
+          } catch (retryError: any) {
+            console.error('Error fetching plans after refresh:', retryError);
+          }
+        }
+
+        setError('Session expired. Please sign in again to view plans.');
+        setPlans([]);
+        return;
+      }
+
       console.error('Error fetching plans:', error);
       let errorMessage = 'Failed to fetch plans';
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -138,6 +138,11 @@ export const authAPI = {
     return response.data;
   },
 
+  refreshOrganizationToken: async (): Promise<{ organization_access_token: string }> => {
+    const response = await api.post('/auth/organization-token/refresh/');
+    return response.data;
+  },
+
   // Profile update endpoint (handles both JSON and FormData for avatar uploads)
   updateProfile: async (profileData: { username?: string; first_name?: string; last_name?: string } | FormData): Promise<User> => {
     const config = profileData instanceof FormData 

--- a/frontend/src/lib/authStore.ts
+++ b/frontend/src/lib/authStore.ts
@@ -37,6 +37,7 @@ interface AuthState {
   logout: () => Promise<void>;
   getCurrentUser: () => Promise<{ success: boolean; error?: string }>;
   getUserTeams: () => Promise<{ success: boolean; error?: string }>;
+  refreshOrganizationAccessToken: () => Promise<{ success: boolean; error?: string }>;
   
   // Initialize auth state on app startup
   initializeAuth: () => Promise<void>;
@@ -207,6 +208,23 @@ export const useAuthStore = create<AuthState>()(
         } catch (error: any) {
           console.error('Failed to fetch user teams:', error);
           return { success: false, error: 'Failed to get user teams' };
+        }
+      },
+
+      // Refresh organization access token
+      refreshOrganizationAccessToken: async () => {
+        try {
+          const response = await authAPI.refreshOrganizationToken();
+          const token = response.organization_access_token || null;
+          set({ organizationAccessToken: token });
+          return { success: true };
+        } catch (error: any) {
+          const message =
+            error?.response?.data?.error ||
+            error?.response?.data?.detail ||
+            error?.message ||
+            'Failed to refresh organization token';
+          return { success: false, error: message };
         }
       },
 


### PR DESCRIPTION
## Summary                                                                 
                                                            
  - **BGF-37**: The calendar is synchronized with soft delete when deleting items, and the calendar page no longer displays deleted items
  - **SMP-496**: Add POST /auth/organization-token/refresh/ endpoint, 403 in front
Automatically refresh token and try again                                                
  - **Chat-07**: Added Share to Chat on the task details page Button, task link in chat rendered as rich text card         