### PR TITLE
UI-fix3: Fix dead links on landing page

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -45,7 +45,7 @@ export default function Page() {
   const displayRole = user?.roles?.[0] || 'Member';
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white">
+    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white scroll-smooth">
       <HeaderSection
         isAuthenticated={isAuthenticated}
         displayName={displayName}

--- a/frontend/src/components/home/FooterSection.tsx
+++ b/frontend/src/components/home/FooterSection.tsx
@@ -32,9 +32,9 @@ export default function FooterSection() {
               <div>
                 <h4 className="font-normal text-gray-900 mb-4">Product</h4>
                 <ul className="space-y-2">
-                  <li><a href="#" className="text-gray-600 hover:text-gray-900">Features</a></li>
-                  <li><a href="#" className="text-gray-600 hover:text-gray-900">How it works</a></li>
-                  <li><a href="#" className="text-gray-600 hover:text-gray-900">Pricing</a></li>
+                  <li><a href="#features" className="text-gray-600 hover:text-gray-900">Features</a></li>
+                  <li><a href="#how-it-works" className="text-gray-600 hover:text-gray-900">How it works</a></li>
+                  <li><a href="#solutions" className="text-gray-600 hover:text-gray-900">Solutions</a></li>
                 </ul>
               </div>
 
@@ -42,9 +42,9 @@ export default function FooterSection() {
               <div>
                 <h4 className="font-normal text-gray-900 mb-4">Resources</h4>
                 <ul className="space-y-2">
-                  <li><a href="#" className="text-gray-600 hover:text-gray-900">Blog</a></li>
-                  <li><a href="#" className="text-gray-600 hover:text-gray-900">Case Studies</a></li>
-                  <li><a href="#" className="text-gray-600 hover:text-gray-900">Guides</a></li>
+                  <li><span className="text-gray-600">Blog</span></li>
+                  <li><span className="text-gray-600">Case Studies</span></li>
+                  <li><span className="text-gray-600">Guides</span></li>
                 </ul>
               </div>
 
@@ -52,9 +52,9 @@ export default function FooterSection() {
               <div>
                 <h4 className="font-normal text-gray-900 mb-4">Company</h4>
                 <ul className="space-y-2">
-                  <li><a href="#" className="text-gray-600 hover:text-gray-900">About</a></li>
-                  <li><a href="#" className="text-gray-600 hover:text-gray-900">Contact us</a></li>
-                  <li><a href="#" className="text-gray-600 hover:text-gray-900">Careers</a></li>
+                  <li><span className="text-gray-600">About</span></li>
+                  <li><span className="text-gray-600">Contact us</span></li>
+                  <li><span className="text-gray-600">Careers</span></li>
                 </ul>
               </div>
 
@@ -62,8 +62,8 @@ export default function FooterSection() {
               <div>
                 <h4 className="font-normal text-gray-900 mb-4">Legal</h4>
                 <ul className="space-y-2">
-                  <li><a href="#" className="text-gray-600 hover:text-gray-900">Privacy Policy</a></li>
-                  <li><a href="#" className="text-gray-600 hover:text-gray-900">Terms of Service</a></li>
+                  <li><span className="text-gray-600">Privacy Policy</span></li>
+                  <li><span className="text-gray-600">Terms of Service</span></li>
                 </ul>
               </div>
             </div>
@@ -99,9 +99,9 @@ export default function FooterSection() {
             <div>
               <h4 className="font-semibold text-gray-900 mb-3 text-sm">Product</h4>
               <ul className="space-y-2">
-                <li><a href="#" className="text-gray-600 hover:text-gray-900 text-sm">Features</a></li>
-                <li><a href="#" className="text-gray-600 hover:text-gray-900 text-sm">How it works</a></li>
-                <li><a href="#" className="text-gray-600 hover:text-gray-900 text-sm">Pricing</a></li>
+                <li><a href="#features" className="text-gray-600 hover:text-gray-900 text-sm">Features</a></li>
+                <li><a href="#how-it-works" className="text-gray-600 hover:text-gray-900 text-sm">How it works</a></li>
+                <li><a href="#solutions" className="text-gray-600 hover:text-gray-900 text-sm">Solutions</a></li>
               </ul>
             </div>
 
@@ -109,9 +109,9 @@ export default function FooterSection() {
             <div>
               <h4 className="font-semibold text-gray-900 mb-3 text-sm">Resources</h4>
               <ul className="space-y-2">
-                <li><a href="#" className="text-gray-600 hover:text-gray-900 text-sm">Blog</a></li>
-                <li><a href="#" className="text-gray-600 hover:text-gray-900 text-sm">Case Studies</a></li>
-                <li><a href="#" className="text-gray-600 hover:text-gray-900 text-sm">Guides</a></li>
+                <li><span className="text-gray-600 text-sm">Blog</span></li>
+                <li><span className="text-gray-600 text-sm">Case Studies</span></li>
+                <li><span className="text-gray-600 text-sm">Guides</span></li>
               </ul>
             </div>
 
@@ -119,9 +119,9 @@ export default function FooterSection() {
             <div>
               <h4 className="font-semibold text-gray-900 mb-3 text-sm">Company</h4>
               <ul className="space-y-2">
-                <li><a href="#" className="text-gray-600 hover:text-gray-900 text-sm">About</a></li>
-                <li><a href="#" className="text-gray-600 hover:text-gray-900 text-sm">Contact us</a></li>
-                <li><a href="#" className="text-gray-600 hover:text-gray-900 text-sm">Careers</a></li>
+                <li><span className="text-gray-600 text-sm">About</span></li>
+                <li><span className="text-gray-600 text-sm">Contact us</span></li>
+                <li><span className="text-gray-600 text-sm">Careers</span></li>
               </ul>
             </div>
 
@@ -129,8 +129,8 @@ export default function FooterSection() {
             <div>
               <h4 className="font-semibold text-gray-900 mb-3 text-sm">Legal</h4>
               <ul className="space-y-2">
-                <li><a href="#" className="text-gray-600 hover:text-gray-900 text-sm">Privacy Policy</a></li>
-                <li><a href="#" className="text-gray-600 hover:text-gray-900 text-sm">Terms of Service</a></li>
+                <li><span className="text-gray-600 text-sm">Privacy Policy</span></li>
+                <li><span className="text-gray-600 text-sm">Terms of Service</span></li>
               </ul>
             </div>
           </div>

--- a/frontend/src/components/home/HeaderSection.tsx
+++ b/frontend/src/components/home/HeaderSection.tsx
@@ -41,10 +41,10 @@ export default function HeaderSection({
               </h1>
             </div>
             <nav className="hidden lg:flex gap-6">
-              <a href="#" className="text-gray-700 hover:text-gray-900">Features</a>
-              <a href="#" className="text-gray-700 hover:text-gray-900">Solutions</a>
-              <a href="#" className="text-gray-700 hover:text-gray-900">Pricing</a>
-              <a href="#" className="text-gray-700 hover:text-gray-900">Resource</a>
+              <a href="#features" className="text-gray-700 hover:text-gray-900">Features</a>
+              <a href="#solutions" className="text-gray-700 hover:text-gray-900">Solutions</a>
+              <a href="#how-it-works" className="text-gray-700 hover:text-gray-900">Pricing</a>
+              <a href="#testimonials" className="text-gray-700 hover:text-gray-900">Resources</a>
             </nav>
           </div>
           <div className="flex items-center gap-3 ">

--- a/frontend/src/components/home/HowItWorksSection.tsx
+++ b/frontend/src/components/home/HowItWorksSection.tsx
@@ -9,7 +9,7 @@ export default function HowItWorksSection({ onGetStartedClick }: HowItWorksSecti
   return (
     <>
       {/* How it works Section -Desktop */}
-      <section className="hidden md:block py-20 px-6 bg-white">
+      <section id="how-it-works" className="hidden md:block py-20 px-6 bg-white">
         <div className="max-w-7xl mx-auto">
           <div className="text-center mb-16">
             <h2 className="text-4xl md:text-5xl font-bold text-gray-900 mb-4">

--- a/frontend/src/components/home/InsightfulAnalyticsSection.tsx
+++ b/frontend/src/components/home/InsightfulAnalyticsSection.tsx
@@ -49,7 +49,7 @@ export default function InsightfulAnalyticsSection({ onRedirectToLogin }: Insigh
                 <div className="bg-gray-50 rounded-lg p-3">
                   <div className="flex items-center justify-between mb-1.5">
                     <h5 className="text-sm font-bold text-gray-900">Top Media Buyers</h5>
-                    <a href="#" className="text-xs text-blue-600 hover:text-blue-700">Learn</a>
+                    <span className="text-xs text-blue-600">Learn</span>
                   </div>
                   <div className="space-y-1.5">
                     <div className="flex items-center gap-2">
@@ -232,7 +232,7 @@ export default function InsightfulAnalyticsSection({ onRedirectToLogin }: Insigh
                   <div className="bg-gray-50 rounded p-1">
                     <div className="flex items-center justify-between">
                       <h5 className="text-[7px] font-semibold text-gray-900">Top Media Buyers</h5>
-                      <a href="#" className="text-[6px] text-blue-600">Learn</a>
+                      <span className="text-[6px] text-blue-600">Learn</span>
                     </div>
                     <div className="space-y-0.5">
                       <div className="flex items-center gap-1">

--- a/frontend/src/components/home/SmartWorkflowSection.tsx
+++ b/frontend/src/components/home/SmartWorkflowSection.tsx
@@ -18,7 +18,7 @@ export default function SmartWorkflowSection({ onRedirectToLogin }: SmartWorkflo
   return (
     <>
       {/* Smart Workflow Section - Desktop */}
-      <section className="hidden md:block py-20 px-6 bg-white">
+      <section id="solutions" className="hidden md:block py-20 px-6 bg-white">
         <div className="max-w-7xl mx-auto relative">
           <div className="flex flex-col lg:flex-row gap-4 items-center justify-center relative">
             {/* Left Card - Workflow Application */}
@@ -67,30 +67,30 @@ export default function SmartWorkflowSection({ onRedirectToLogin }: SmartWorkflo
                 {/* Sidebar */}
                 <div className="w-40 bg-white border-r border-gray-200 p-1.5">
                   <nav className="space-y-0.5 mb-3">
-                    <a href="#" className="flex items-center gap-2 px-2 py-1.5 bg-blue-50 text-blue-700 rounded-lg font-medium">
-                      <div className="w-1 h-3 bg-blue-600 rounded-full"></div>
+                    <span className="flex items-center gap-2 px-2 py-1.5 bg-blue-50 text-blue-700 rounded-lg font-medium">
+                      <span className="w-1 h-3 bg-blue-600 rounded-full"></span>
                       <span className="text-xs">Dashboard</span>
-                    </a>
-                    <a href="#" className="flex items-center gap-2 px-2 py-1.5 text-gray-600 hover:bg-gray-50 rounded-lg">
+                    </span>
+                    <span className="flex items-center gap-2 px-2 py-1.5 text-gray-600 rounded-lg">
                       <span className="text-xs">Tasks</span>
                       <span className="ml-auto px-1.5 py-0.5 bg-blue-100 text-blue-700 text-[10px] font-semibold rounded-full">16</span>
-                    </a>
+                    </span>
                   </nav>
 
                   <div className="space-y-0.5 mb-2">
                     <div className="text-[10px] font-semibold text-gray-400 uppercase mb-0.5 px-2">MAIN</div>
-                    <a href="#" className="flex items-center gap-2 px-2 py-1.5 text-gray-600 hover:bg-gray-50 rounded-lg text-xs">Reports</a>
-                    <a href="#" className="flex items-center gap-2 px-2 py-1.5 text-gray-600 hover:bg-gray-50 rounded-lg text-xs">Teams</a>
-                    <a href="#" className="flex items-center gap-2 px-2 py-1.5 text-gray-600 hover:bg-gray-50 rounded-lg text-xs">Settings</a>
+                    <span className="flex items-center gap-2 px-2 py-1.5 text-gray-600 rounded-lg text-xs">Reports</span>
+                    <span className="flex items-center gap-2 px-2 py-1.5 text-gray-600 rounded-lg text-xs">Teams</span>
+                    <span className="flex items-center gap-2 px-2 py-1.5 text-gray-600 rounded-lg text-xs">Settings</span>
                   </div>
 
                   <div className="space-y-0.5">
                     <div className="text-[10px] font-semibold text-gray-400 uppercase mb-1 px-2">RECOMMEND</div>
-                    <a href="#" className="flex items-center gap-2 px-2 py-1.5 text-gray-600 hover:bg-gray-50 rounded-lg text-xs">
+                    <span className="flex items-center gap-2 px-2 py-1.5 text-gray-600 rounded-lg text-xs">
                       Team
                       <ChevronRight className="w-3 h-3 ml-auto" />
-                    </a>
-                    <a href="#" className="flex items-center gap-2 px-2 py-1.5 text-gray-600 hover:bg-gray-50 rounded-lg text-xs">Clients</a>
+                    </span>
+                    <span className="flex items-center gap-2 px-2 py-1.5 text-gray-600 rounded-lg text-xs">Clients</span>
                   </div>
 
                   <div className="mt-auto pt-2 border-t border-gray-200">

--- a/frontend/src/components/home/TestimonialsSection.tsx
+++ b/frontend/src/components/home/TestimonialsSection.tsx
@@ -9,7 +9,7 @@ export default function TestimonialsSection({ onRedirectToLogin, onGetStartedCli
   return (
     <>
       {/* Testimonials Section -Desktop */}
-      <section className="hidden md:block py-20 px-6 bg-blue-50 rounded-t-3xl">
+      <section id="testimonials" className="hidden md:block py-20 px-6 bg-blue-50 rounded-t-3xl">
         <div className="max-w-7xl mx-auto">
           <div className="text-center mb-16">
             <h2 className="text-4xl md:text-5xl font-bold text-gray-900 mb-4">

--- a/frontend/src/components/home/UnifiedNotificationsSection.tsx
+++ b/frontend/src/components/home/UnifiedNotificationsSection.tsx
@@ -40,9 +40,9 @@ export default function UnifiedNotificationsSection({ onRedirectToLogin }: Unifi
               {/* Header */}
               <div className="flex items-center justify-between mb-3 pt-2">
                 <h4 className="text-lg font-bold text-gray-900">Notification Center</h4>
-                <a href="#" className="text-sm text-blue-600 hover:text-blue-700 font-medium">
+                <span className="text-sm text-blue-600 font-medium">
                   Unsubscribe
-                </a>
+                </span>
               </div>
 
               {/* Enable custom alerts toggle */}
@@ -165,7 +165,7 @@ export default function UnifiedNotificationsSection({ onRedirectToLogin }: Unifi
                 {/* Header */}
                 <div className="bg-white border-b border-gray-200 px-2 py-1 flex items-center justify-between">
                   <h4 className="text-[8px] font-bold text-gray-900">Notification Center</h4>
-                  <a href="#" className="text-[6px] text-blue-600 font-medium">Unsubscribe</a>
+                  <span className="text-[6px] text-blue-600 font-medium">Unsubscribe</span>
                 </div>
 
                 {/* Content */}

--- a/frontend/src/components/home/WhyMarketingSimplifiedSection.tsx
+++ b/frontend/src/components/home/WhyMarketingSimplifiedSection.tsx
@@ -4,7 +4,7 @@ export default function WhyMarketingSimplifiedSection() {
   return (
     <>
       {/* Why Marketing Simplified Section */}
-      <section className="hidden md:block py-20 px-6 bg-white">
+      <section id="features" className="hidden md:block py-20 px-6 bg-white">
         <div className="max-w-4xl mx-auto">
           <h2 className="text-4xl md:text-5xl font-bold text-center text-gray-900 mb-4">
             Why Marketing Simplified?


### PR DESCRIPTION
## Summary
- Replace all 37 dead `href="#"` links on the landing page
- Header/Footer nav links now scroll to corresponding section IDs (`#features`, `#solutions`, `#how-it-works`, `#testimonials`)
- Mockup links in demo sections (SmartWorkflow sidebar, Notifications, Analytics) converted from `<a>` to `<span>` to prevent misleading clicks
- Added `scroll-smooth` behavior to landing page container

## Files changed (9)
- `page.tsx` — add scroll-smooth
- `HeaderSection.tsx` — nav links → scroll anchors
- `FooterSection.tsx` — Product → scroll anchors, Resources/Company/Legal → non-clickable spans
- `SmartWorkflowSection.tsx` — mockup sidebar links → spans
- `UnifiedNotificationsSection.tsx` — Unsubscribe mockup → span
- `InsightfulAnalyticsSection.tsx` — Learn mockup → span
- `WhyMarketingSimplifiedSection.tsx` / `HowItWorksSection.tsx` / `TestimonialsSection.tsx` — add section IDs

## Test plan
- [ ] Open localhost:80 landing page
- [ ] Click header nav (Features/Solutions/Pricing/Resources) → smooth scroll to sections
- [ ] Click footer Product links → smooth scroll to sections
- [ ] Verify footer Resources/Company/Legal are non-clickable text
- [ ] Verify mockup demo sections have no clickable links
- [ ] Mobile view: same behavior