### PR TITLE
SMP-527 feat(chat): show project members in DM sidebar for quick mess…

### DIFF
--- a/frontend/src/__tests__/components/HomeSidebar.test.tsx
+++ b/frontend/src/__tests__/components/HomeSidebar.test.tsx
@@ -1,0 +1,227 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import HomeSidebar from '@/components/messages/LeftSidebar/HomeSidebar';
+import type { Chat, ChatParticipant } from '@/types/chat';
+import type { ProjectMemberData } from '@/lib/api/projectApi';
+
+// ── Mocks ──────────────────────────────────────────────────
+
+jest.mock('@/lib/authStore', () => ({
+  useAuthStore: (selector: any) =>
+    selector({ user: { id: 100, email: 'me@test.com', username: 'me' } }),
+}));
+
+jest.mock('@/lib/api/chatApi', () => ({
+  listStarredChats: jest.fn().mockResolvedValue([]),
+  starChat: jest.fn(),
+  unstarChat: jest.fn(),
+  reorderStarredChats: jest.fn(),
+}));
+
+jest.mock('@/components/messages/LeftSidebar/FilesSidebarView', () => {
+  return function MockFilesSidebarView() {
+    return <div data-testid="files-view" />;
+  };
+});
+
+jest.mock('@/components/messages/LeftSidebar/ActivitySidebarView', () => {
+  return function MockActivitySidebarView() {
+    return <div data-testid="activity-view" />;
+  };
+});
+
+// ── Test helpers ───────────────────────────────────────────
+
+const makeParticipant = (userId: number, username: string): ChatParticipant => ({
+  id: userId,
+  user: { id: userId, email: `${username}@test.com`, username },
+  chat_id: 0,
+  joined_at: '2026-01-01T00:00:00Z',
+});
+
+const makePrivateChat = (
+  id: number,
+  otherUserId: number,
+  otherUsername: string
+): Chat => ({
+  id,
+  project_id: 3,
+  type: 'private',
+  name: null,
+  participants: [
+    makeParticipant(100, 'me'),
+    makeParticipant(otherUserId, otherUsername),
+  ],
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+});
+
+const makeGroupChat = (id: number, name: string): Chat => ({
+  id,
+  project_id: 3,
+  type: 'group',
+  name,
+  participants: [makeParticipant(100, 'me')],
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+});
+
+const makeMember = (
+  id: number,
+  userId: number,
+  name: string
+): ProjectMemberData => ({
+  id,
+  user: { id: userId, username: name.toLowerCase(), email: `${name.toLowerCase()}@test.com`, name },
+  project: { id: 3, name: 'Test' },
+  role: 'member',
+  is_active: true,
+});
+
+const defaultProps = {
+  view: 'home' as const,
+  selectedProjectId: 3,
+  chats: [] as Chat[],
+  currentChatId: null,
+  onSelectChat: jest.fn(),
+  onCreateChat: jest.fn(),
+  onCreateChannel: jest.fn(),
+  isLoading: false,
+  emptyState: <div>Empty</div>,
+  roleByUserId: {},
+  projectMembers: [] as ProjectMemberData[],
+  isLoadingMembers: false,
+  onStartDM: jest.fn(),
+};
+
+// ── Tests ──────────────────────────────────────────────────
+
+describe('HomeSidebar — Project members integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // AC: When a project is selected, the DM panel shows project members
+  test('shows "Project members" section when project is selected', async () => {
+    const members = [makeMember(1, 101, 'Alice'), makeMember(2, 102, 'Bob')];
+    render(<HomeSidebar {...defaultProps} projectMembers={members} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Project members')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  // AC: When no project is selected (global view), behaviour is unchanged
+  test('hides "Project members" section when no project selected', () => {
+    const members = [makeMember(1, 101, 'Alice')];
+    render(
+      <HomeSidebar
+        {...defaultProps}
+        selectedProjectId={null}
+        projectMembers={members}
+      />
+    );
+
+    expect(screen.queryByText('Project members')).not.toBeInTheDocument();
+  });
+
+  // AC: Members the user has already DM'd appear under "Direct messages", not in members section
+  test('deduplicates: members with existing DMs appear only in DM list', async () => {
+    const dmChat = makePrivateChat(10, 101, 'alice');
+    const members = [makeMember(1, 101, 'Alice'), makeMember(2, 102, 'Bob')];
+
+    render(
+      <HomeSidebar
+        {...defaultProps}
+        chats={[dmChat]}
+        projectMembers={members}
+      />
+    );
+
+    await waitFor(() => {
+      // Alice should appear in DM section (as a chat row), not in project members
+      const memberRows = screen.getAllByTestId('project-member-dm-row');
+      const memberNames = memberRows.map((r) => r.textContent);
+      expect(memberNames.some((n) => n?.includes('Alice'))).toBe(false);
+      expect(memberNames.some((n) => n?.includes('Bob'))).toBe(true);
+    });
+
+    // Alice's DM thread is shown in the DM section
+    const chatRows = screen.getAllByTestId('messages-chat-row');
+    expect(chatRows.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // AC: "No direct messages" empty state is replaced by member list when in project context
+  test('shows member list instead of only "No direct messages" when project has members', async () => {
+    const members = [makeMember(1, 101, 'Alice')];
+    render(<HomeSidebar {...defaultProps} projectMembers={members} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No direct messages')).toBeInTheDocument();
+      expect(screen.getByText('Project members')).toBeInTheDocument();
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+    });
+  });
+
+  // AC: "No other members yet" when only the current user
+  test('shows "No other members yet" when project has no other members', async () => {
+    const members = [makeMember(4, 100, 'Me')]; // current user only
+    render(<HomeSidebar {...defaultProps} projectMembers={members} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No other members yet')).toBeInTheDocument();
+    });
+  });
+
+  // AC: Clicking a member calls onStartDM
+  test('clicking a project member triggers onStartDM with the user id', async () => {
+    const onStartDM = jest.fn();
+    const members = [makeMember(1, 101, 'Alice')];
+    render(
+      <HomeSidebar {...defaultProps} projectMembers={members} onStartDM={onStartDM} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Alice'));
+    expect(onStartDM).toHaveBeenCalledWith(101);
+  });
+
+  // AC: Section visible in DMs nav view as well
+  test('shows Project members in DMs view', async () => {
+    const members = [makeMember(1, 101, 'Alice')];
+    render(<HomeSidebar {...defaultProps} view="dms" projectMembers={members} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Project members')).toBeInTheDocument();
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+    });
+  });
+
+  // AC: Section NOT visible in files/activity views
+  test('hides Project members in activity view', () => {
+    const members = [makeMember(1, 101, 'Alice')];
+    render(<HomeSidebar {...defaultProps} view="activity" projectMembers={members} />);
+    expect(screen.queryByText('Project members')).not.toBeInTheDocument();
+  });
+
+  test('hides Project members in files view', () => {
+    const members = [makeMember(1, 101, 'Alice')];
+    render(<HomeSidebar {...defaultProps} view="files" projectMembers={members} />);
+    expect(screen.queryByText('Project members')).not.toBeInTheDocument();
+  });
+
+  // AC: Loading state
+  test('shows skeleton loader while members are loading', () => {
+    render(<HomeSidebar {...defaultProps} isLoadingMembers={true} />);
+
+    expect(screen.getByText('Project members')).toBeInTheDocument();
+    const skeletons = document.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/__tests__/components/ProjectMembersSection.test.tsx
+++ b/frontend/src/__tests__/components/ProjectMembersSection.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ProjectMembersSection from '@/components/messages/LeftSidebar/ProjectMembersSection';
+import type { ProjectMemberData } from '@/lib/api/projectApi';
+
+const makeMember = (
+  id: number,
+  userId: number,
+  name: string,
+  email: string
+): ProjectMemberData => ({
+  id,
+  user: { id: userId, username: name.toLowerCase().replace(' ', '.'), email, name },
+  project: { id: 3, name: 'Test Project' },
+  role: 'member',
+  is_active: true,
+});
+
+const alice = makeMember(1, 101, 'Alice Wang', 'alice@test.com');
+const bob = makeMember(2, 102, 'Bob Chen', 'bob@test.com');
+const carol = makeMember(3, 103, 'Carol Li', 'carol@test.com');
+const currentUser = makeMember(4, 100, 'Current User', 'me@test.com');
+
+describe('ProjectMembersSection', () => {
+  const defaultProps = {
+    members: [alice, bob, carol, currentUser],
+    isLoading: false,
+    currentUserId: 100,
+    dmUserIds: new Set<number>(),
+    onStartDM: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // AC: Members sorted alphabetically
+  test('renders members sorted alphabetically, excluding current user', () => {
+    render(<ProjectMembersSection {...defaultProps} />);
+
+    const rows = screen.getAllByTestId('project-member-dm-row');
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toHaveTextContent('Alice Wang');
+    expect(rows[1]).toHaveTextContent('Bob Chen');
+    expect(rows[2]).toHaveTextContent('Carol Li');
+  });
+
+  // AC: Current user excluded
+  test('does not show current user in the list', () => {
+    render(<ProjectMembersSection {...defaultProps} />);
+    expect(screen.queryByText('Current User')).not.toBeInTheDocument();
+  });
+
+  // AC: Members with existing DMs are deduplicated out
+  test('excludes members who already have DM threads (deduplication)', () => {
+    const dmUserIds = new Set([101]); // Alice already has a DM
+    render(<ProjectMembersSection {...defaultProps} dmUserIds={dmUserIds} />);
+
+    expect(screen.queryByText('Alice Wang')).not.toBeInTheDocument();
+    expect(screen.getByText('Bob Chen')).toBeInTheDocument();
+    expect(screen.getByText('Carol Li')).toBeInTheDocument();
+  });
+
+  // AC: Clicking member starts a DM
+  test('calls onStartDM with correct userId when clicking a member', () => {
+    const onStartDM = jest.fn();
+    render(<ProjectMembersSection {...defaultProps} onStartDM={onStartDM} />);
+
+    fireEvent.click(screen.getByText('Bob Chen'));
+    expect(onStartDM).toHaveBeenCalledWith(102);
+    expect(onStartDM).toHaveBeenCalledTimes(1);
+  });
+
+  // AC: Loading state shows skeleton
+  test('shows skeleton loader while loading', () => {
+    render(<ProjectMembersSection {...defaultProps} isLoading={true} />);
+
+    const skeletons = document.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBe(3);
+    expect(screen.queryByTestId('project-member-dm-row')).not.toBeInTheDocument();
+  });
+
+  // AC: "No other members yet" state
+  test('shows empty message when only the current user is in the project', () => {
+    render(
+      <ProjectMembersSection
+        {...defaultProps}
+        members={[currentUser]}
+      />
+    );
+
+    expect(screen.getByText('No other members yet')).toBeInTheDocument();
+    expect(screen.queryByTestId('project-member-dm-row')).not.toBeInTheDocument();
+  });
+
+  // AC: "No other members yet" when all others have existing DMs
+  test('shows empty message when all non-self members are deduplicated', () => {
+    const dmUserIds = new Set([101, 102, 103]);
+    render(<ProjectMembersSection {...defaultProps} dmUserIds={dmUserIds} />);
+
+    expect(screen.getByText('No other members yet')).toBeInTheDocument();
+  });
+
+  test('renders avatar initial for each member', () => {
+    render(<ProjectMembersSection {...defaultProps} />);
+
+    const rows = screen.getAllByTestId('project-member-dm-row');
+    // First member "Alice Wang" → initial "A"
+    expect(rows[0].querySelector('.rounded-full')).toHaveTextContent('A');
+    expect(rows[1].querySelector('.rounded-full')).toHaveTextContent('B');
+    expect(rows[2].querySelector('.rounded-full')).toHaveTextContent('C');
+  });
+});

--- a/frontend/src/__tests__/hooks/useProjectMembers.test.tsx
+++ b/frontend/src/__tests__/hooks/useProjectMembers.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useProjectMembers } from '@/hooks/useProjectMembers';
+import { ProjectAPI } from '@/lib/api/projectApi';
+
+jest.mock('@/lib/api/projectApi');
+
+const mockProjectAPI = ProjectAPI as jest.Mocked<typeof ProjectAPI>;
+
+const makeMember = (id: number, name: string, email: string) => ({
+  id,
+  user: { id: id + 100, username: name.toLowerCase(), email, name },
+  project: { id: 3, name: 'Testing Project' },
+  role: 'member',
+  is_active: true,
+});
+
+// Harness to render the hook's return values into the DOM for inspection
+function Harness({ projectId }: { projectId: number | null | undefined }) {
+  const { members, isLoading, error } = useProjectMembers(projectId);
+  return (
+    <div>
+      <span data-testid="loading">{String(isLoading)}</span>
+      <span data-testid="error">{error ?? ''}</span>
+      <span data-testid="count">{members.length}</span>
+      {members.map((m) => (
+        <span key={m.id} data-testid="member">
+          {m.user.name}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+describe('useProjectMembers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('does not fetch when projectId is null', async () => {
+    render(<Harness projectId={null} />);
+    expect(mockProjectAPI.getAllProjectMembers).not.toHaveBeenCalled();
+    expect(screen.getByTestId('count').textContent).toBe('0');
+  });
+
+  test('does not fetch when projectId is undefined', async () => {
+    render(<Harness projectId={undefined} />);
+    expect(mockProjectAPI.getAllProjectMembers).not.toHaveBeenCalled();
+  });
+
+  test('does not fetch when projectId is 0 or negative', async () => {
+    render(<Harness projectId={0} />);
+    expect(mockProjectAPI.getAllProjectMembers).not.toHaveBeenCalled();
+
+    render(<Harness projectId={-1} />);
+    expect(mockProjectAPI.getAllProjectMembers).not.toHaveBeenCalled();
+  });
+
+  test('fetches members for a valid projectId', async () => {
+    const members = [
+      makeMember(1, 'Alice', 'alice@test.com'),
+      makeMember(2, 'Bob', 'bob@test.com'),
+    ];
+    mockProjectAPI.getAllProjectMembers.mockResolvedValue(members);
+
+    render(<Harness projectId={3} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('count').textContent).toBe('2');
+    });
+
+    expect(mockProjectAPI.getAllProjectMembers).toHaveBeenCalledWith(3);
+    expect(screen.getByTestId('error').textContent).toBe('');
+  });
+
+  test('clears members and sets error on API failure', async () => {
+    mockProjectAPI.getAllProjectMembers.mockRejectedValue(new Error('Network error'));
+
+    render(<Harness projectId={3} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error').textContent).toBe('Network error');
+    });
+
+    expect(screen.getByTestId('count').textContent).toBe('0');
+  });
+
+  test('re-fetches when projectId changes', async () => {
+    const membersA = [makeMember(1, 'Alice', 'alice@test.com')];
+    const membersB = [makeMember(2, 'Bob', 'bob@test.com'), makeMember(3, 'Carol', 'carol@test.com')];
+
+    mockProjectAPI.getAllProjectMembers
+      .mockResolvedValueOnce(membersA)
+      .mockResolvedValueOnce(membersB);
+
+    const { rerender } = render(<Harness projectId={3} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('count').textContent).toBe('1');
+    });
+
+    rerender(<Harness projectId={5} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('count').textContent).toBe('2');
+    });
+
+    expect(mockProjectAPI.getAllProjectMembers).toHaveBeenCalledTimes(2);
+    expect(mockProjectAPI.getAllProjectMembers).toHaveBeenNthCalledWith(1, 3);
+    expect(mockProjectAPI.getAllProjectMembers).toHaveBeenNthCalledWith(2, 5);
+  });
+
+  test('clears members when projectId becomes null', async () => {
+    const members = [makeMember(1, 'Alice', 'alice@test.com')];
+    mockProjectAPI.getAllProjectMembers.mockResolvedValue(members);
+
+    const { rerender } = render(<Harness projectId={3} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('count').textContent).toBe('1');
+    });
+
+    rerender(<Harness projectId={null} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('count').textContent).toBe('0');
+    });
+  });
+});

--- a/frontend/src/components/messages/LeftSidebar/HomeSidebar.tsx
+++ b/frontend/src/components/messages/LeftSidebar/HomeSidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState, type DragEvent } from 'react';
-import { Hash, MessagesSquare, Plus, Star, Users } from 'lucide-react';
+import { Hash, MessagesSquare, Plus, Star, User, Users } from 'lucide-react';
 import type { Chat } from '@/types/chat';
 import { useAuthStore } from '@/lib/authStore';
 import {
@@ -14,6 +14,8 @@ import toast from 'react-hot-toast';
 import type { MessagesNavView } from './NavRail';
 import FilesSidebarView from './FilesSidebarView';
 import ActivitySidebarView from './ActivitySidebarView';
+import ProjectMembersSection from './ProjectMembersSection';
+import type { ProjectMemberData } from '@/lib/api/projectApi';
 
 function normalizeChat(c: Chat): Chat {
   const raw = c.project_id ?? (c as { project?: number }).project;
@@ -32,6 +34,9 @@ interface HomeSidebarProps {
   isLoading: boolean;
   emptyState: React.ReactNode;
   roleByUserId?: Record<number, string>;
+  projectMembers: ProjectMemberData[];
+  isLoadingMembers: boolean;
+  onStartDM: (userId: number) => void;
 }
 
 function Section({
@@ -75,6 +80,9 @@ export default function HomeSidebar({
   isLoading,
   emptyState,
   roleByUserId,
+  projectMembers,
+  isLoadingMembers,
+  onStartDM,
 }: HomeSidebarProps) {
   const currentUserId = useAuthStore((s) => (s.user?.id ? Number(s.user.id) : null));
   const [isCollapsed, setIsCollapsed] = useState(false);
@@ -91,6 +99,19 @@ export default function HomeSidebar({
     }
     return { groupChats: group, privateChats: priv };
   }, [chats]);
+
+  // User IDs that already have a DM thread — used to deduplicate the project members list
+  const dmUserIds = useMemo(() => {
+    const ids = new Set<number>();
+    for (const chat of privateChats) {
+      for (const p of chat.participants ?? []) {
+        if (p.user?.id && p.user.id !== currentUserId) {
+          ids.add(p.user.id);
+        }
+      }
+    }
+    return ids;
+  }, [privateChats, currentUserId]);
 
   const getPrivateChatDisplayName = useCallback(
     (chat: Chat) => {
@@ -261,7 +282,7 @@ export default function HomeSidebar({
     const showHome = view === 'home';
     const showDmsOnly = view === 'dms';
 
-    if (showDmsOnly && privateChats.length === 0) {
+    if (showDmsOnly && privateChats.length === 0 && !selectedProjectId) {
       return <div className="p-4 text-sm text-gray-500">No direct messages</div>;
     }
 
@@ -493,6 +514,21 @@ export default function HomeSidebar({
                 ))}
               </div>
             )}
+          </Section>
+        )}
+
+        {(showHome || showDmsOnly) && selectedProjectId && (
+          <Section
+            title="Project members"
+            icon={<User className="w-3.5 h-3.5" />}
+          >
+            <ProjectMembersSection
+              members={projectMembers}
+              isLoading={isLoadingMembers}
+              currentUserId={currentUserId}
+              dmUserIds={dmUserIds}
+              onStartDM={onStartDM}
+            />
           </Section>
         )}
       </div>

--- a/frontend/src/components/messages/LeftSidebar/ProjectMembersSection.tsx
+++ b/frontend/src/components/messages/LeftSidebar/ProjectMembersSection.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useMemo } from 'react';
+import { User, UserPlus } from 'lucide-react';
+import type { ProjectMemberData } from '@/lib/api/projectApi';
+
+interface ProjectMembersSectionProps {
+  members: ProjectMemberData[];
+  isLoading: boolean;
+  currentUserId: number | null;
+  /**
+   * Set of user IDs that already have a DM thread open.
+   * These members will be excluded from the list.
+   */
+  dmUserIds: Set<number>;
+  onStartDM: (userId: number) => void;
+}
+
+export default function ProjectMembersSection({
+  members,
+  isLoading,
+  currentUserId,
+  dmUserIds,
+  onStartDM,
+}: ProjectMembersSectionProps) {
+  // Filter out self and members who already have DM threads, then sort alphabetically
+  const visibleMembers = useMemo(() => {
+    return members
+      .filter((m) => {
+        const uid = m.user?.id;
+        if (typeof uid !== 'number') return false;
+        // Exclude current user
+        if (uid === currentUserId) return false;
+        // Exclude members who already have a DM thread
+        if (dmUserIds.has(uid)) return false;
+        return true;
+      })
+      .sort((a, b) => {
+        const nameA = (a.user?.name || a.user?.username || a.user?.email || '').toLowerCase();
+        const nameB = (b.user?.name || b.user?.username || b.user?.email || '').toLowerCase();
+        return nameA.localeCompare(nameB);
+      });
+  }, [members, currentUserId, dmUserIds]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2 px-3 py-2">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="flex items-center gap-2 animate-pulse">
+            <div className="w-7 h-7 rounded-full bg-gray-200" />
+            <div className="h-3 w-24 bg-gray-200 rounded" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (visibleMembers.length === 0) {
+    return (
+      <div className="px-3 py-2 text-xs text-gray-500">
+        No other members yet
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-0.5 mx-1">
+      {visibleMembers.map((member) => {
+        const displayName =
+          member.user?.name || member.user?.username || member.user?.email || 'Unknown';
+        return (
+          <button
+            key={member.id}
+            type="button"
+            onClick={() => onStartDM(member.user.id)}
+            className="w-full px-3 py-1.5 flex items-center gap-2 text-sm text-gray-700 hover:bg-gray-100 text-left rounded-md group/member"
+            title={`Message ${displayName}`}
+            data-testid="project-member-dm-row"
+            data-user-id={String(member.user.id)}
+          >
+            <div className="w-6 h-6 rounded-full bg-blue-100 text-blue-600 flex items-center justify-center flex-shrink-0 text-xs font-medium">
+              {displayName.charAt(0).toUpperCase()}
+            </div>
+            <span className="flex-1 min-w-0 truncate">{displayName}</span>
+            <UserPlus className="w-4 h-4 text-gray-400 opacity-0 group-hover/member:opacity-100 transition-opacity" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/messages/MessagePageContent.tsx
+++ b/frontend/src/components/messages/MessagePageContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { MessageSquare, Plus, Search } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuthStore } from '@/lib/authStore';
@@ -8,6 +8,7 @@ import { useChatStore } from '@/lib/chatStore';
 import { useChatData } from '@/hooks/useChatData';
 import { useChatSocket } from '@/hooks/useChatSocket';
 import { useProjectMemberRoles } from '@/hooks/useProjectMemberRoles';
+import { useProjectMembers } from '@/hooks/useProjectMembers';
 import ProjectSelector from './ProjectSelector';
 import ChatWindow from '@/components/chat/ChatWindow';
 import CreateChatDialog from '@/components/chat/CreateChatDialog';
@@ -30,12 +31,16 @@ export default function MessagePageContent() {
   const setCurrentChat = useChatStore(state => state.setCurrentChat);
   const chatsByProject = useChatStore(state => state.chatsByProject);
   // Get chats for the selected project only (independent from widget)
-  const chats = selectedProjectId ? (chatsByProject[selectedProjectId] || []) : [];
+  const chats = useMemo(
+    () => (selectedProjectId ? (chatsByProject[selectedProjectId] || []) : []),
+    [chatsByProject, selectedProjectId]
+  );
 
   const { roleByUserId } = useProjectMemberRoles(selectedProjectId);
+  const { members: projectMembers, isLoading: isLoadingMembers } = useProjectMembers(selectedProjectId);
   
   // Fetch chats for selected project
-  const { fetchChats, isLoading } = useChatData({
+  const { fetchChats, createNewChat, isLoading } = useChatData({
     projectId: selectedProjectId || undefined,
     autoFetch: false,
   });
@@ -191,6 +196,35 @@ export default function MessagePageContent() {
     fetchChats();
   };
 
+  const handleStartDM = useCallback(async (targetUserId: number) => {
+    if (!selectedProjectId) return;
+
+    // Check if a DM thread already exists with this user
+    const existingChat = chats.find(
+      (c) =>
+        c.type === 'private' &&
+        c.participants?.some((p) => p.user.id === targetUserId)
+    );
+
+    if (existingChat) {
+      setCurrentChat(existingChat.id);
+      replaceMessagesQuery({ projectId: selectedProjectId, chatId: existingChat.id, messageId: null });
+      return;
+    }
+
+    try {
+      const newChat = await createNewChat({
+        type: 'private',
+        project_id: selectedProjectId,
+        participant_ids: [targetUserId],
+      });
+      setCurrentChat(newChat.id);
+      replaceMessagesQuery({ projectId: selectedProjectId, chatId: newChat.id, messageId: null });
+    } catch {
+      // createNewChat already shows a toast on error
+    }
+  }, [selectedProjectId, chats, createNewChat, setCurrentChat, replaceMessagesQuery]);
+
   return (
     <div className="h-full flex flex-col bg-gray-50">
       {/* Header */}
@@ -237,6 +271,9 @@ export default function MessagePageContent() {
         onCreateChannel={handleCreateChannel}
         roleByUserId={roleByUserId}
         isLoadingChats={isLoading}
+        projectMembers={projectMembers}
+        isLoadingMembers={isLoadingMembers}
+        onStartDM={handleStartDM}
         chatListEmptyState={
           !selectedProjectId ? (
             <div className="flex items-center justify-center p-6 text-center">

--- a/frontend/src/components/messages/SlackMessagesLayout.tsx
+++ b/frontend/src/components/messages/SlackMessagesLayout.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import type { Chat } from '@/types/chat';
+import type { ProjectMemberData } from '@/lib/api/projectApi';
 import ProjectRail from '@/components/messages/LeftSidebar/ProjectRail';
 import NavRail, { type MessagesNavView } from '@/components/messages/LeftSidebar/NavRail';
 import HomeSidebar from '@/components/messages/LeftSidebar/HomeSidebar';
@@ -20,6 +21,10 @@ interface SlackMessagesLayoutProps {
   chatListEmptyState: React.ReactNode;
   roleByUserId?: Record<number, string>;
 
+  projectMembers: ProjectMemberData[];
+  isLoadingMembers: boolean;
+  onStartDM: (userId: number) => void;
+
   chatPanel: React.ReactNode;
 }
 
@@ -34,6 +39,9 @@ export default function SlackMessagesLayout({
   isLoadingChats,
   chatListEmptyState,
   roleByUserId,
+  projectMembers,
+  isLoadingMembers,
+  onStartDM,
   chatPanel,
 }: SlackMessagesLayoutProps) {
   const isMobileChatOpen = Boolean(currentChatId);
@@ -70,6 +78,9 @@ export default function SlackMessagesLayout({
             isLoading={isLoadingChats}
             emptyState={chatListEmptyState}
             roleByUserId={roleByUserId}
+            projectMembers={projectMembers}
+            isLoadingMembers={isLoadingMembers}
+            onStartDM={onStartDM}
           />
         </div>
 

--- a/frontend/src/hooks/useProjectMembers.ts
+++ b/frontend/src/hooks/useProjectMembers.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ProjectAPI, type ProjectMemberData } from '@/lib/api/projectApi';
+
+interface UseProjectMembersResult {
+  members: ProjectMemberData[];
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useProjectMembers(projectId: number | null | undefined): UseProjectMembersResult {
+  const [members, setMembers] = useState<ProjectMemberData[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const latestProjectIdRef = useRef<number | null>(null);
+
+  const fetchMembers = useCallback(async () => {
+    if (typeof projectId !== 'number' || projectId <= 0) {
+      setMembers([]);
+      return;
+    }
+
+    latestProjectIdRef.current = projectId;
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const result = await ProjectAPI.getAllProjectMembers(projectId);
+      // Only apply if this is still the latest request
+      if (latestProjectIdRef.current === projectId) {
+        setMembers(result);
+      }
+    } catch (err: any) {
+      if (latestProjectIdRef.current === projectId) {
+        setError(err?.message || 'Failed to load members');
+        setMembers([]);
+      }
+    } finally {
+      if (latestProjectIdRef.current === projectId) {
+        setIsLoading(false);
+      }
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    fetchMembers();
+  }, [fetchMembers]);
+
+  return { members, isLoading, error, refetch: fetchMembers };
+}


### PR DESCRIPTION
 Display project members in the Chat/DM left sidebar so users can start a direct message with any teammate in one click — no need to manually create a chat first.
>> 
>> ## Changes
>> 
>> ### New files
>> - **\`ProjectMembersSection.tsx\`** — Standalone component rendering the *Project members* list with avatar initials, alphabetical sorting, loading skeletons, and empty state.
>> - **\`useProjectMembers.ts\`** — Hook that fetches project members via \`ProjectAPI.getAllProjectMembers\`, with race-condition protection (\`latestProjectIdRef\`) and auto-cleanup when the project changes.
>> 
>> ### Modified files
>> - **\`HomeSidebar.tsx\`** — Added a *Project members* collapsible section (visible in *home* and *dms* views when a project is selected). Computes \`dmUserIds\` to deduplicate members who already have an open DM thread.
>> - **\`MessagePageContent.tsx\`** — Wired up \`useProjectMembers\` hook and \`handleStartDM\` callback that either navigates to an existing private chat or creates a new one.
>> - **\`SlackMessagesLayout.tsx\`** — Passes \`projectMembers\`, \`isLoadingMembers\`, and \`onStartDM\` props through to \`HomeSidebar\`.
>>
>> ### Tests (3 new test files, 467 lines)
>> - \`HomeSidebar.test.tsx\` — Integration tests: section visibility per view, deduplication, loading skeleton, empty states.
>> - \`ProjectMembersSection.test.tsx\` — Unit tests: alphabetical sort, current-user exclusion, DM dedup, click handler, avatar initials, loading & empty states.
>> - \`useProjectMembers.test.tsx\` — Hook tests: null/undefined/invalid project IDs, successful fetch, error handling, re-fetch on project change, cleanup.
>>
>> ## Key behaviors
>> - Members who already have a DM thread are excluded from the *Project members* list (shown under *Direct messages* instead).
>> - Current user is always excluded from the members list.
>> - Clicking a member either opens the existing DM or creates a new private chat.
>> - Section hidden when no project is selected or in *files*/*activity* views.
>> - Loading state shows 3 skeleton rows with \`animate-pulse\`.
>>
>> ## Files changed
>> | File | Change |
>> |------|--------|
>> | \`frontend/src/components/messages/LeftSidebar/ProjectMembersSection.tsx\` | **Added** |
>> | \`frontend/src/hooks/useProjectMembers.ts\` | **Added** |
>> | \`frontend/src/components/messages/LeftSidebar/HomeSidebar.tsx\` | Modified |
>> | \`frontend/src/components/messages/MessagePageContent.tsx\` | Modified |
>> | \`frontend/src/components/messages/SlackMessagesLayout.tsx\` | Modified |
>> | \`frontend/src/__tests__/components/HomeSidebar.test.tsx\` | **Added** |
>> | \`frontend/src/__tests__/components/ProjectMembersSection.test.tsx\` | **Added** |
>> | \`frontend/src/__tests__/hooks/useProjectMembers.test.tsx\` | **Added** |
>>
>> **+699 / -5**
>> "