### PR TITLE
fix(devops): stop topic-init from burning CPU in restart loop

### DIFF
--- a/devops/topic-init/entrypoint-dev
+++ b/devops/topic-init/entrypoint-dev
@@ -11,4 +11,4 @@ cd /usr/local/bin/ && python3 create-topics.py
 
 echo "Done."
 
-exec /etc/confluent/docker/run
+exit 0

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -312,7 +312,7 @@ services:
       context: ./devops/topic-init
       dockerfile: Dockerfile.dev
     container_name: topic-init
-    restart: always
+    restart: on-failure:3
     entrypoint: ["/bin/bash", "/usr/local/bin/entrypoint-dev"]
     depends_on:
       kafka:


### PR DESCRIPTION
## Problem

`topic-init` was pegging a full CPU core continuously on dev machines.

Observed on a fresh Docker Desktop restart:
- `docker stats` showed **119% CPU** on `topic-init` while all other containers were idle
- `RestartCount: 74`
- `docker logs topic-init | grep -c '^Creating topics'` returned **6130** — the init had re-run 6130 times over ~5 days, averaging one cycle every ~70 seconds
- Each cycle spun up a fresh Kafka AdminClient and walked metadata for all 42 topics, adding load to the broker too

## Root cause

Two issues compounding:

**1. `devops/topic-init/entrypoint-dev` ended with `exec /etc/confluent/docker/run`.** The image is built on `confluentinc/cp-kafka:7.6.0`, so after creating topics the script chained into the base image's broker startup, which immediately fails because this container isn't a broker:

\`\`\`
Running in Zookeeper mode...
KAFKA_ZOOKEEPER_CONNECT is required.
Command [/usr/local/bin/dub ensure KAFKA_ZOOKEEPER_CONNECT] FAILED !
\`\`\`

So the container always exited non-zero a few seconds after topics were created.

**2. \`docker-compose.dev.yml\` set \`restart: always\` on this one-shot init job.** Compose kept resurrecting it after every failure. The init is idempotent (topics exist → \"skipping...\"), so the loop was silent — just burning CPU and spamming logs forever.

## Fix

- \`entrypoint-dev\`: replace \`exec /etc/confluent/docker/run\` with \`exit 0\`. The script is a one-shot init, not a broker.
- \`docker-compose.dev.yml\`: \`restart: always\` → \`restart: on-failure:3\`. Successful exits now stay \`Exited (0)\`. Transient failures (e.g. Kafka briefly unready) can still retry a few times but can no longer loop forever.

## Verification

\`\`\`
docker compose -f docker-compose.dev.yml up -d --build topic-init
# ~15s later:
docker ps -a --filter name=topic-init --format '{{.Status}}'
# Exited (0) 2 seconds ago
\`\`\`

\`kafka-1\` returns to idle, host CPU and fan noise back to normal.