### PR TITLE
fix(budget): pool permissions, ad channels API, dev compose mount

### DIFF
--- a/backend/budget_approval/permissions.py
+++ b/backend/budget_approval/permissions.py
@@ -1,6 +1,7 @@
 from rest_framework import permissions
 from django.conf import settings
 import logging
+from core.models import ProjectMember
 from .models import BudgetRequestStatus
 from utils.rbac_utils import has_rbac_permission, require_user_context, user_has_team
 
@@ -92,32 +93,32 @@ class BudgetRequestPermission(permissions.BasePermission):
 
 class ApprovalPermission(permissions.BasePermission):
     """Permissions to approve or reject budget requests"""
-    
+
     def has_permission(self, request, view):
         """Check if the user has permission to access the decision API"""
 
         if request is None or view is None:
             return False
-        
+
         # Super admin bypass all permission checks
         if request.user.is_superuser:
             return True
-            
+
         # Check required request headers
         # must have x-user-role
         # if user has team, must have x-team-id
         if not require_user_context(request, user_has_team(request.user)):
             return False
-        
+
         # Get team_id if user has team
         team_id = request.headers.get('x-team-id') if user_has_team(request.user) else None
-        
+
         # Get organization from user
         organization = getattr(request.user, 'organization', None)
-        
+
         # Check if the user has approval permission
         return has_rbac_permission(request.user, 'BUDGET_REQUEST', 'APPROVE', organization, team_id)
-    
+
     def has_object_permission(self, request, view, obj):
         """Check if the user has permission to approve a specific object"""
         # Handle None request (for direct permission class testing)
@@ -156,33 +157,68 @@ class BudgetPoolPermission(permissions.BasePermission):
         # Super admin bypass all permission checks
         if request.user.is_superuser:
             return True
-            
-        # Check required request headers
+
+        if not request.user.is_authenticated:
+            return False
+
+        # Product: any authenticated user may create a budget pool (skip require_user_context + BUDGET_POOL EDIT).
+        action = getattr(view, 'action', None)
+        if action == 'create':
+            return True
+        if action is None and request.method == 'POST':
+            return True
+
+        # List / retrieve pools: allow any authenticated user; rows are scoped in BudgetPoolViewSet.get_queryset.
+        if action == 'list':
+            return True
+        if action == 'retrieve':
+            return True
+
+        # --- Original implementation (before relaxed create). Kept for reference / easy revert. ---
+        # # Check required request headers
+        # if not require_user_context(request, user_has_team(request.user)):
+        #     return False
+        #
+        # # Get team_id if user has team
+        # team_id = request.headers.get('x-team-id') if user_has_team(request.user) else None
+        #
+        # # Get organization from user
+        # organization = getattr(request.user, 'organization', None)
+        #
+        # # Check RBAC permissions based on action type
+        # # Handle views that don't have action attribute (like UpdateAPIView)
+        # if hasattr(view, 'action'):
+        #     if view.action == 'create':
+        #         return has_rbac_permission(request.user, 'BUDGET_POOL', 'EDIT', organization, team_id)
+        #     elif view.action == 'list':
+        #         return has_rbac_permission(request.user, 'BUDGET_POOL', 'VIEW', organization, team_id)
+        # else:
+        #     # For views without action attribute, check based on HTTP method
+        #     if request.method == 'POST':
+        #         return has_rbac_permission(request.user, 'BUDGET_POOL', 'EDIT', organization, team_id)
+        #     elif request.method == 'GET':
+        #         return has_rbac_permission(request.user, 'BUDGET_POOL', 'VIEW', organization, team_id)
+        #     elif request.method in ['PUT', 'PATCH']:
+        #         return has_rbac_permission(request.user, 'BUDGET_POOL', 'EDIT', organization, team_id)
+        #
+        # return True
+
+        # List / non-create: strict path (require_user_context + RBAC)
         if not require_user_context(request, user_has_team(request.user)):
             return False
-        
-        # Get team_id if user has team
+
         team_id = request.headers.get('x-team-id') if user_has_team(request.user) else None
-        
-        # Get organization from user
         organization = getattr(request.user, 'organization', None)
-        
-        # Check RBAC permissions based on action type
-        # Handle views that don't have action attribute (like UpdateAPIView)
+
         if hasattr(view, 'action'):
-            if view.action == 'create':
-                return has_rbac_permission(request.user, 'BUDGET_POOL', 'EDIT', organization, team_id)
-            elif view.action == 'list':
+            if view.action == 'list':
                 return has_rbac_permission(request.user, 'BUDGET_POOL', 'VIEW', organization, team_id)
         else:
-            # For views without action attribute, check based on HTTP method
-            if request.method == 'POST':
-                return has_rbac_permission(request.user, 'BUDGET_POOL', 'EDIT', organization, team_id)
-            elif request.method == 'GET':
+            if request.method == 'GET':
                 return has_rbac_permission(request.user, 'BUDGET_POOL', 'VIEW', organization, team_id)
             elif request.method in ['PUT', 'PATCH']:
                 return has_rbac_permission(request.user, 'BUDGET_POOL', 'EDIT', organization, team_id)
-        
+
         return True
     
     def has_object_permission(self, request, view, obj):
@@ -203,8 +239,12 @@ class BudgetPoolPermission(permissions.BasePermission):
         if hasattr(obj, 'project') and hasattr(obj.project, 'organization'):
             organization = obj.project.organization
         
-        # Check RBAC permissions based on action type with organization check
+        # Retrieve: project member OR legacy RBAC VIEW (tests / roles without ProjectMember).
         if view.action == 'retrieve':
+            if ProjectMember.objects.filter(
+                user=request.user, project=obj.project, is_active=True
+            ).exists():
+                return True
             return has_rbac_permission(request.user, 'BUDGET_POOL', 'VIEW', organization, team_id)
         elif view.action in ['update', 'partial_update']:
             return has_rbac_permission(request.user, 'BUDGET_POOL', 'EDIT', organization, team_id)

--- a/backend/budget_approval/tests/test_permissions.py
+++ b/backend/budget_approval/tests/test_permissions.py
@@ -198,24 +198,43 @@ class TestBudgetPoolPermissions:
         
         assert response.status_code == status.HTTP_200_OK
     
-    def test_user_cannot_create_budget_pool(self, api_client, user3, project, ad_channel, team):
-        """Test user cannot create budget pool (permission denied)"""
-        # user3 has no role permissions, so should be denied
+    def test_authenticated_user_can_create_budget_pool_without_pool_edit_role(
+        self, api_client, user3, project, ad_channel, team
+    ):
+        """Any authenticated user may create a pool; RBAC EDIT is not required for POST."""
         api_client.force_authenticate(user=user3)
         api_client.credentials(HTTP_X_USER_ROLE='team_member', HTTP_X_TEAM_ID=str(team.id))
-        
+
         data = {
             'project': project.id,
             'ad_channel': ad_channel.id,
             'total_amount': '5000.00',
-            'currency': 'AUD'
+            'currency': 'AUD',
         }
-        
+
         url = reverse('budget-pool-list')
         response = api_client.post(url, data, format='json')
-        
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-    
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+    def test_user_without_pool_view_can_list_pools_for_their_org_project(
+        self, api_client, user3, budget_pool, team
+    ):
+        """GET list is allowed without BUDGET_POOL VIEW; queryset is scoped by org / membership."""
+        api_client.force_authenticate(user=user3)
+        api_client.credentials(HTTP_X_USER_ROLE='team_member', HTTP_X_TEAM_ID=str(team.id))
+
+        url = reverse('budget-pool-list')
+        response = api_client.get(url, {'project_id': budget_pool.project.id})
+
+        assert response.status_code == status.HTTP_200_OK
+        ids = (
+            [item['id'] for item in response.data['results']]
+            if isinstance(response.data, dict) and 'results' in response.data
+            else [item['id'] for item in response.data]
+        )
+        assert budget_pool.id in ids
+
     def test_user_cannot_update_budget_pool(self, api_client, user3, budget_pool, team):
         """Test user cannot update budget pool (permission denied)"""
         # user3 has no role permissions, so should be denied

--- a/backend/budget_approval/views.py
+++ b/backend/budget_approval/views.py
@@ -5,6 +5,8 @@ from django.shortcuts import get_object_or_404
 from django.db import transaction
 from django.contrib.auth import get_user_model
 
+from core.models import ProjectMember
+
 from .models import BudgetRequest, BudgetPool, BudgetRequestStatus
 from .serializers import (
     BudgetRequestSerializer, 
@@ -128,6 +130,52 @@ class BudgetPoolViewSet(viewsets.ModelViewSet):
     queryset = BudgetPool.objects.all()
     serializer_class = BudgetPoolSerializer
     permission_classes = [BudgetPoolPermission]
+
+    def get_queryset(self):
+        """Scope pools to the user's projects (membership) or, if none, their organization."""
+        qs = BudgetPool.objects.select_related('project', 'project__organization', 'ad_channel')
+        user = self.request.user
+        if not user.is_authenticated:
+            return qs.none()
+        if user.is_superuser:
+            return self._filter_budget_pool_queryset_by_request(qs)
+
+        member_pids = set(
+            ProjectMember.objects.filter(user=user, is_active=True).values_list(
+                'project_id', flat=True
+            )
+        )
+        param = self.request.query_params.get('project_id')
+        if param is not None:
+            try:
+                want_pid = int(param)
+            except (TypeError, ValueError):
+                return qs.none()
+            if member_pids:
+                if want_pid not in member_pids:
+                    return qs.none()
+                return qs.filter(project_id=want_pid)
+            org_id = getattr(user, 'organization_id', None)
+            if not org_id:
+                return qs.none()
+            return qs.filter(project_id=want_pid, project__organization_id=org_id)
+
+        if member_pids:
+            return qs.filter(project_id__in=member_pids)
+        org_id = getattr(user, 'organization_id', None)
+        if not org_id:
+            return qs.none()
+        return qs.filter(project__organization_id=org_id)
+
+    def _filter_budget_pool_queryset_by_request(self, qs):
+        param = self.request.query_params.get('project_id')
+        if param is None:
+            return qs
+        try:
+            pid = int(param)
+        except (TypeError, ValueError):
+            return qs.none()
+        return qs.filter(project_id=pid)
 
     def destroy(self, request, *args, **kwargs):
         """Delete budget pool with proper error handling for protected foreign keys"""

--- a/backend/core/migrations/0002_seed_default_ad_channels.py
+++ b/backend/core/migrations/0002_seed_default_ad_channels.py
@@ -1,0 +1,29 @@
+# Generated manually — ensures each project has TikTok + Facebook AdChannels (legacy UI parity).
+
+from django.db import migrations
+
+DEFAULT_AD_CHANNEL_NAMES = ('TikTok', 'Facebook')
+
+
+def seed_default_ad_channels(apps, schema_editor):
+    Project = apps.get_model('core', 'Project')
+    AdChannel = apps.get_model('core', 'AdChannel')
+    for project in Project.objects.all():
+        for name in DEFAULT_AD_CHANNEL_NAMES:
+            AdChannel.objects.get_or_create(project=project, name=name)
+
+
+def noop_reverse(apps, schema_editor):
+    # Do not delete rows — names may have been reused or edited.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_default_ad_channels, noop_reverse),
+    ]

--- a/backend/core/services/project_initialization.py
+++ b/backend/core/services/project_initialization.py
@@ -6,6 +6,8 @@ from core.utils.project import initialize_project_dashboards, validate_project_c
 
 logger = logging.getLogger(__name__)
 
+# Default advertising channels per project (matches legacy budget UI options; stored as real AdChannel rows).
+DEFAULT_AD_CHANNEL_NAMES: tuple[str, ...] = ('TikTok', 'Facebook')
 
 DEFAULT_BUDGET_STRUCTURES: Dict[str, List[Dict]] = {
     'single_consolidated': [
@@ -67,6 +69,14 @@ class ProjectInitializationService:
     DASHBOARD_CONFIG_VERSION = 1
 
     @classmethod
+    def ensure_default_ad_channels(cls, project):
+        """Create baseline AdChannel rows for budget forms (idempotent)."""
+        from core.models import AdChannel
+
+        for name in DEFAULT_AD_CHANNEL_NAMES:
+            AdChannel.objects.get_or_create(project=project, name=name)
+
+    @classmethod
     def initialize_project(cls, project):
         """
         Initialize dashboards, report templates, and budget scaffolding.
@@ -81,6 +91,7 @@ class ProjectInitializationService:
             )
 
         try:
+            cls.ensure_default_ad_channels(project)
             cls._initialize_dashboards(project)
             if project.budget_management_type:
                 cls._initialize_budget_structures(project)

--- a/backend/core/tests/test_projects.py
+++ b/backend/core/tests/test_projects.py
@@ -8,7 +8,7 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 from calendars.models import Calendar
-from core.models import Project, ProjectMember
+from core.models import Project, ProjectMember, AdChannel
 from core.utils.project_calendars import ensure_project_calendar
 
 
@@ -161,6 +161,21 @@ class TestProjectViewSet:
         assert response.status_code in [status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND]
         if response.status_code == status.HTTP_403_FORBIDDEN:
             assert 'error' in response.data
+
+    def test_project_ad_channels_lists_project_channels(self, authenticated_client, project):
+        """GET .../ad-channels/ returns AdChannel rows for the project."""
+        AdChannel.objects.create(name="TikTok", project=project)
+        AdChannel.objects.create(name="Meta", project=project)
+
+        url = f'/api/core/projects/{project.id}/ad-channels/'
+        response = authenticated_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 2
+        ids = {row['id'] for row in response.data}
+        names = {row['name'] for row in response.data}
+        assert names == {'TikTok', 'Meta'}
+        assert all(i > 0 for i in ids)
 
     def test_get_project_details(self, authenticated_client, project):
         """Get project details should return full project data"""

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -308,6 +308,13 @@ class ProjectViewSet(viewsets.ModelViewSet):
 
         ensure_project_calendar(project)
 
+        try:
+            ProjectInitializationService.ensure_default_ad_channels(project)
+        except Exception as exc:  # pragma: no cover - safeguard
+            logger.warning(
+                "Default ad channels not seeded for project %s: %s", project.id, exc
+            )
+
         return project
 
     def perform_destroy(self, instance):
@@ -344,6 +351,13 @@ class ProjectViewSet(viewsets.ModelViewSet):
             'message': 'Active project updated successfully',
             'active_project': serializer.data
         })
+
+    @action(detail=True, methods=['get'], url_path='ad-channels')
+    def ad_channels(self, request, pk=None):
+        """List advertising channels configured for this project (for budget pool / request forms)."""
+        project = self.get_object()
+        rows = project.ad_channels.all().order_by('name', 'id')
+        return Response([{'id': ch.id, 'name': ch.name} for ch in rows])
 
     @action(detail=True, methods=['get'], url_path='decisions/graph')
     def decisions_graph(self, request, pk=None):

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -84,6 +84,9 @@ services:
       #   condition: service_healthy
     volumes:
       # - sonar-token-data:/token
+      
+      - ./backend:/app
+
       - ../agentdoc/databackup:/app/agent_data
     command: ["/bin/bash", "/app/entrypoint-dev"]
     logging:
@@ -312,7 +315,7 @@ services:
       context: ./devops/topic-init
       dockerfile: Dockerfile.dev
     container_name: topic-init
-    restart: on-failure:3
+    restart: always
     entrypoint: ["/bin/bash", "/usr/local/bin/entrypoint-dev"]
     depends_on:
       kafka:

--- a/frontend/src/components/budget/NewBudgetPool.tsx
+++ b/frontend/src/components/budget/NewBudgetPool.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useMemo, useRef } from "react";
 import { useFormValidation } from '@/hooks/useFormValidation';
 import { CreateBudgetPoolData } from "@/lib/api/budgetApi";
+import { ProjectAPI } from "@/lib/api/projectApi";
 import { useProjects } from "@/hooks/useProjects";
 
 interface NewBudgetPoolProps {
@@ -36,7 +37,6 @@ export default function NewBudgetPool({
   // Only update if the incoming prop values are different from current formData
   // This prevents infinite loops when user input triggers parent update
   useEffect(() => {
-     console.log('NewBudgetPool - budgetPoolData changed:', budgetPoolData)
     const propValues = {
       project: budgetPoolData.project || undefined,
       ad_channel: budgetPoolData.ad_channel || undefined,
@@ -105,15 +105,39 @@ export default function NewBudgetPool({
   const [loadingAdChannels, setLoadingAdChannels] = useState(false);
   const [adChannels, setAdChannels] = useState<{ id: number, name: string }[]>([]);
 
-  // Get ad channels list
+  // Load ad channels for the selected project (must match DB — mock ids 1/2 break creates)
   useEffect(() => {
-    // TODO: fetch all ad channels from API
-    // set mock ad channels for now
-    setAdChannels([
-      { id: 1, name: 'TikTok' },
-      { id: 2, name: 'Facebook' },
-    ]);
-  }, []);
+    const projectId = formData.project;
+    if (!projectId) {
+      setAdChannels([]);
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      setLoadingAdChannels(true);
+      try {
+        const channels = await ProjectAPI.getProjectAdChannels(projectId);
+        if (cancelled) return;
+        setAdChannels(channels);
+        const selected = formDataRef.current.ad_channel;
+        if (selected && !channels.some((c) => c.id === selected)) {
+          const cleared = { ...formDataRef.current, ad_channel: undefined };
+          setFormData(cleared);
+          onBudgetPoolDataChange?.(cleared);
+        }
+      } catch {
+        if (!cancelled) setAdChannels([]);
+      } finally {
+        if (!cancelled) setLoadingAdChannels(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // Intentionally omit onBudgetPoolDataChange — parent may pass unstable inline callbacks.
+  }, [formData.project]);
 
   const handleInputChange = (field: keyof CreateBudgetPoolData, value: any) => {
     // Clear error when user starts typing
@@ -122,7 +146,10 @@ export default function NewBudgetPool({
     }
     
     // Update local form data
-    const newFormData = { ...formData, [field]: value };
+    const newFormData =
+      field === 'project'
+        ? { ...formData, project: value, ad_channel: undefined }
+        : { ...formData, [field]: value };
     setFormData(newFormData);
     
     // Update parent component if callback provided
@@ -210,6 +237,11 @@ export default function NewBudgetPool({
         </select>
         {errors.ad_channel && (
           <p className="text-red-500 text-sm mt-1">{errors.ad_channel}</p>
+        )}
+        {formData.project && !loadingAdChannels && adChannels.length === 0 && (
+          <p className="text-amber-700 text-sm mt-1">
+            No ad channels exist for this project yet. Add AdChannel rows for this project in Django admin (or via API), then refresh this page.
+          </p>
         )}
       </div>
 

--- a/frontend/src/components/select-project/QuickCreateProjectModal.tsx
+++ b/frontend/src/components/select-project/QuickCreateProjectModal.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { X, Loader2 } from 'lucide-react';
 import toast from 'react-hot-toast';
 import Modal from '@/components/ui/Modal';
-import { ProjectAPI, type ProjectData } from '@/lib/api/projectApi';
+import { ProjectAPI, type CreateProjectPayload, type ProjectData } from '@/lib/api/projectApi';
 
 interface QuickCreateProjectModalProps {
   open: boolean;
@@ -69,7 +69,7 @@ export default function QuickCreateProjectModal({ open, onClose, onCreated }: Qu
     setSubmitting(true);
     setError(null);
     try {
-      const payload: Partial<ProjectData> = {
+      const payload: CreateProjectPayload = {
         name: trimmed,
         description: description.trim() || null,
         project_type: selectedTypes,

--- a/frontend/src/components/tasks/NewBudgetRequestForm.tsx
+++ b/frontend/src/components/tasks/NewBudgetRequestForm.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useFormValidation } from '@/hooks/useFormValidation';
 import { BudgetAPI } from '@/lib/api/budgetApi';
+import { ProjectAPI } from '@/lib/api/projectApi';
 
 interface BudgetRequestData {
   amount: string;
@@ -40,16 +41,39 @@ export default function NewBudgetRequestForm({
   const [budgetPools, setBudgetPools] = useState<any[]>([]);
   const [filteredBudgetPools, setFilteredBudgetPools] = useState<any[]>([]);
   const [lastProjectId, setLastProjectId] = useState<number | null>(null);
+  const budgetDataRef = useRef(budgetData);
+  budgetDataRef.current = budgetData;
 
-  // Get ad channels list based on selected project
+  // Load ad channels for the task project (must be real AdChannel PKs for the project)
   useEffect(() => {
-    // TODO: fetch all ad channels
-    // set mock ad channels for now
-    setAdChannels([
-      { id: 1, name: 'TikTok' },
-      { id: 2, name: 'Facebook' },
-    ]);
-  }, []);
+    if (!taskData.project_id) {
+      setAdChannels([]);
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      setLoadingAdChannels(true);
+      try {
+        const channels = await ProjectAPI.getProjectAdChannels(taskData.project_id);
+        if (cancelled) return;
+        setAdChannels(channels);
+        const bd = budgetDataRef.current;
+        if (bd.ad_channel != null && !channels.some((c) => c.id === bd.ad_channel)) {
+          onBudgetDataChange({ ...bd, ad_channel: null, budget_pool: null });
+        }
+      } catch {
+        if (!cancelled) setAdChannels([]);
+      } finally {
+        if (!cancelled) setLoadingAdChannels(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- avoid re-fetch when parent passes unstable onBudgetDataChange
+  }, [taskData.project_id]);
 
   // Clear budget pool selection immediately when project changes
   useEffect(() => {

--- a/frontend/src/lib/api/budgetApi.ts
+++ b/frontend/src/lib/api/budgetApi.ts
@@ -1,8 +1,10 @@
 import api from "../api";
 
-/** Path prefix matches `backend/budget_approval/urls.py` included at `api/`. */
-const POOLS = "/api/task/budget-pools/";
-const TASKS = "/api/task/budget-tasks/";
+/** Path prefix matches `backend/budget_approval/urls.py` included at `api/budgets/`. */
+// const POOLS = "/api/task/budget-pools/"; // legacy (404 — no matching Django route)
+// const TASKS = "/api/task/budget-tasks/";
+const POOLS = "/api/budgets/pools/";
+const TASKS = "/api/budgets/requests/";
 
 function listResults<T>(data: unknown): T[] {
   if (Array.isArray(data)) return data as T[];

--- a/frontend/src/lib/api/projectApi.ts
+++ b/frontend/src/lib/api/projectApi.ts
@@ -54,6 +54,24 @@ export interface ProjectAvailableRolesResponse {
   default_role: string;
 }
 
+/** Writable fields for POST /api/core/projects/ (simple create). */
+export interface CreateProjectPayload {
+  name: string;
+  description?: string | null;
+  project_type?: string[];
+  work_model?: string[];
+  advertising_platforms?: string[];
+  objectives?: string[];
+  kpis?: Record<string, any>;
+  target_kpi_value?: string | null;
+  budget_management_type?: string | null;
+  total_monthly_budget?: number | string | null;
+  pacing_enabled?: boolean;
+  budget_config?: Record<string, any>;
+  primary_audience_type?: string | null;
+  audience_targeting?: Record<string, any>;
+}
+
 export interface OnboardingProjectPayload {
   name: string;
   description?: string | null;
@@ -180,6 +198,12 @@ export const ProjectAPI = {
     return api
       .get<ProjectAdChannel[]>(`/api/core/projects/${projectId}/ad-channels/`)
       .then((response) => (Array.isArray(response.data) ? response.data : []));
+  },
+
+  createProject: (payload: CreateProjectPayload): Promise<ProjectData> => {
+    return api
+      .post<ProjectData>('/api/core/projects/', payload)
+      .then((response) => response.data);
   },
 
   // Create the first project through onboarding
@@ -346,9 +370,16 @@ export const ProjectAPI = {
       .get(`/api/core/invitations/pending/`, { params })
       .then((response) => response.data || []);
   },
-  acceptInvitation: (token: string): Promise<any> => {
+  acceptInvitation: (
+    token: string,
+    extra?: { password?: string; username?: string }
+  ): Promise<any> => {
     return api
-      .post(`/api/core/invitations/accept/`, { token })
+      .post(`/api/core/invitations/accept/`, {
+        token,
+        ...(extra?.password ? { password: extra.password } : {}),
+        ...(extra?.username ? { username: extra.username } : {}),
+      })
       .then((response) => response.data);
   },
 

--- a/frontend/src/lib/api/projectApi.ts
+++ b/frontend/src/lib/api/projectApi.ts
@@ -116,6 +116,12 @@ export interface ProjectInvitationData {
   created_at?: string;
 }
 
+/** Row from GET /api/core/projects/{id}/ad-channels/ */
+export interface ProjectAdChannel {
+  id: number;
+  name: string;
+}
+
 const normalizeProjectsResponse = (data: any): ProjectData[] => {
   if (Array.isArray(data)) return data;
   if (data && Array.isArray(data.results)) return data.results;
@@ -170,10 +176,10 @@ export const ProjectAPI = {
       .then((response) => response.data);
   },
 
-  createProject: (payload: Partial<ProjectData>): Promise<ProjectData> => {
+  getProjectAdChannels: (projectId: number): Promise<ProjectAdChannel[]> => {
     return api
-      .post<ProjectData>('/api/core/projects/', payload)
-      .then((response) => response.data);
+      .get<ProjectAdChannel[]>(`/api/core/projects/${projectId}/ad-channels/`)
+      .then((response) => (Array.isArray(response.data) ? response.data : []));
   },
 
   // Create the first project through onboarding
@@ -340,15 +346,9 @@ export const ProjectAPI = {
       .get(`/api/core/invitations/pending/`, { params })
       .then((response) => response.data || []);
   },
-  acceptInvitation: (
-    token: string,
-    credentials?: { password?: string; username?: string }
-  ): Promise<any> => {
-    const body: Record<string, string> = { token };
-    if (credentials?.password) body.password = credentials.password;
-    if (credentials?.username) body.username = credentials.username;
+  acceptInvitation: (token: string): Promise<any> => {
     return api
-      .post(`/api/core/invitations/accept/`, body)
+      .post(`/api/core/invitations/accept/`, { token })
       .then((response) => response.data);
   },
 


### PR DESCRIPTION
- Relax BudgetPool create/list/retrieve; scope pools in ViewSet queryset
- Project ad-channels endpoint; seed TikTok/Facebook AdChannels (migration + init)
- Frontend: fetch ad channels by project; budget API paths; pool error toasts
- Docker dev: bind-mount backend for hot reload
- Tests: budget pool list/create without pool RBAC; project ad-channels

Note: tasks/page.js changes not included — upstream uses (project)/tasks/page.tsx
