### PR TITLE
fix(auth): stabilize Safari password input height

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -565,9 +565,15 @@ input[type="password"]::-ms-clear {
 }
 /* Some WebKit credential decorations */
 input[type="password"]::-webkit-credentials-auto-fill-button,
-input[type="password"]::-webkit-textfield-decoration-container {
-  display: none !important;
+input[type="password"]::-webkit-contacts-auto-fill-button {
+  opacity: 0 !important;
+  pointer-events: none !important;
 }
+
+/*
+  Safari/WebKit: do NOT hide `::-webkit-textfield-decoration-container`.
+  Hiding it can collapse the input's internal layout and shrink the clickable area.
+*/
 
 
 /* Liquid glass card */

--- a/frontend/src/components/form/FormInput.js
+++ b/frontend/src/components/form/FormInput.js
@@ -34,7 +34,8 @@ export default function FormInput({
           onBlur={() => setFocused(false)}
           placeholder={placeholder}
           className={`
-            w-full px-3 py-2 border rounded-md shadow-sm transition-colors
+            w-full h-10 px-3 border rounded-md shadow-sm transition-colors leading-6
+            ${type === 'password' ? 'pr-10' : 'py-2'}
             ${error ? 'border-red-500 focus:border-red-500 focus:ring-red-500' : 
               focused ? 'border-[#3CCED7] focus:border-[#3CCED7] focus:ring-[#3CCED7]' : 
               'border-gray-300 focus:border-[#3CCED7] focus:ring-[#3CCED7]'}
@@ -46,7 +47,7 @@ export default function FormInput({
           <button
             type="button"
             onClick={() => setShowPassword(!showPassword)}
-            className="absolute right-3 top-2.5 text-gray-400 hover:text-gray-600"
+            className="absolute right-3 inset-y-0 my-auto h-10 flex items-center text-gray-400 hover:text-gray-600"
           >
             {showPassword ? (
               <EyeSlashIcon className="h-5 w-5" />


### PR DESCRIPTION
## Summary
- Fix Safari-specific password input collapsing/click-area issue on Sign In.
- Stop hiding WebKit textfield decoration container; hide only autofill button interactions.
- Set explicit input height/line-height and reserve space for the visibility icon.

## Test plan
- Open Sign In in Safari on macOS and verify password field height/click area is normal.
- Toggle password visibility icon and confirm layout remains stable.

Made with [Cursor](https://cursor.com)