### PR TITLE
feat(SMP-537): add task list row context menu

### DIFF
--- a/frontend/src/__tests__/components/tasks-v2/ListView.contextMenu.test.tsx
+++ b/frontend/src/__tests__/components/tasks-v2/ListView.contextMenu.test.tsx
@@ -1,0 +1,600 @@
+import React from 'react';
+import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ListView from '@/components/tasks-v2/ListView';
+import type { TaskData } from '@/types/task';
+import type { ProjectMemberData } from '@/lib/api/projectApi';
+import { ProjectAPI } from '@/lib/api/projectApi';
+import { TaskAPI } from '@/lib/api/taskApi';
+import toast from 'react-hot-toast';
+
+jest.mock('@/lib/api/projectApi', () => ({
+  __esModule: true,
+  ProjectAPI: {
+    getProjectMembers: jest.fn(),
+  },
+}));
+
+const getProjectMembersMock = ProjectAPI.getProjectMembers as jest.Mock;
+
+const mockPush = jest.fn();
+const mockRemoveTask = jest.fn();
+const mockUpdateTask = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('@/lib/taskStore', () => ({
+  useTaskStore: (
+    selector: (s: { removeTask: typeof mockRemoveTask; updateTask: typeof mockUpdateTask }) => unknown
+  ) => selector({ removeTask: mockRemoveTask, updateTask: mockUpdateTask }),
+}));
+
+jest.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/api/taskApi', () => ({
+  __esModule: true,
+  TaskAPI: {
+    deleteTask: jest.fn(),
+    updateTask: jest.fn(),
+    submitTask: jest.fn(),
+    startReview: jest.fn(),
+    makeApproval: jest.fn(),
+    cancelTask: jest.fn(),
+    lock: jest.fn(),
+    unlock: jest.fn(),
+    revise: jest.fn(),
+    getTask: jest.fn(),
+  },
+}));
+
+const deleteTaskMock = TaskAPI.deleteTask as jest.Mock;
+const updateTaskApiMock = TaskAPI.updateTask as jest.Mock;
+
+function resetWorkflowMocks() {
+  (TaskAPI.submitTask as jest.Mock).mockReset();
+  (TaskAPI.startReview as jest.Mock).mockReset();
+  (TaskAPI.makeApproval as jest.Mock).mockReset();
+  (TaskAPI.cancelTask as jest.Mock).mockReset();
+  (TaskAPI.lock as jest.Mock).mockReset();
+  (TaskAPI.unlock as jest.Mock).mockReset();
+  (TaskAPI.revise as jest.Mock).mockReset();
+  (TaskAPI.getTask as jest.Mock).mockReset();
+}
+
+const LABELS_TOOLTIP = 'Task labels are not supported yet';
+
+/** Flush ListView member-fetch effect after opening the row menu (tasks use project_id from makeTask). */
+async function settleListViewMenuFetch(opts?: { advanceTimers?: boolean }) {
+  await waitFor(
+    () => {
+      expect(getProjectMembersMock).toHaveBeenCalled();
+    },
+    opts?.advanceTimers ? { advanceTimers: true } : undefined
+  );
+  const ix = getProjectMembersMock.mock.calls.length - 1;
+  const pending = getProjectMembersMock.mock.results[ix]?.value as Promise<unknown> | undefined;
+  await act(async () => {
+    if (pending) await pending;
+    if (opts?.advanceTimers) {
+      await jest.runOnlyPendingTimersAsync();
+    } else {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    }
+  });
+}
+
+const makeTask = (overrides: Partial<TaskData> = {}): TaskData => ({
+  id: 42,
+  project_id: 1,
+  type: 'task',
+  summary: 'Hello task',
+  ...overrides,
+});
+
+const makeMember = (overrides: Partial<ProjectMemberData> = {}): ProjectMemberData => ({
+  id: 1,
+  user: { id: 201, username: 'alice', email: 'alice@test.com' },
+  project: { id: 1, name: 'Proj' },
+  role: 'member',
+  is_active: true,
+  ...overrides,
+});
+
+describe('ListView row context menu (Step 1)', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockRemoveTask.mockClear();
+    mockUpdateTask.mockClear();
+    deleteTaskMock.mockReset();
+    updateTaskApiMock.mockReset();
+    resetWorkflowMocks();
+    getProjectMembersMock.mockReset();
+    getProjectMembersMock.mockResolvedValue([]);
+    (toast.success as jest.Mock).mockClear();
+    (toast.error as jest.Mock).mockClear();
+    Object.assign(navigator, {
+      clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  async function openMenuOnFirstRow() {
+    render(
+      <ListView
+        tasks={[makeTask({ id: 7, summary: 'Row one' }), makeTask({ id: 8, summary: 'Other' })]}
+        loading={false}
+        error={null}
+      />
+    );
+    const row = screen.getByText('Row one').closest('tr');
+    expect(row).toBeTruthy();
+    fireEvent.contextMenu(row!, { clientX: 120, clientY: 160, bubbles: true });
+    await settleListViewMenuFetch();
+    const menus = screen.getAllByRole('menu');
+    const menu = menus[menus.length - 1];
+    return { row: row!, menu };
+  }
+
+  it('opens custom menu on right-click and lists actions', async () => {
+    const { menu } = await openMenuOnFirstRow();
+    expect(within(menu).getByRole('menuitem', { name: /open task/i })).toBeInTheDocument();
+    expect(within(menu).getByRole('menuitem', { name: /copy task link/i })).toBeInTheDocument();
+    expect(within(menu).getByRole('menuitem', { name: /^workflow$/i })).toBeInTheDocument();
+    expect(within(menu).getByRole('menuitem', { name: /^owner$/i })).toBeInTheDocument();
+    expect(within(menu).getByRole('menuitem', { name: /^approver$/i })).toBeInTheDocument();
+    expect(within(menu).getByRole('menuitem', { name: /^priority$/i })).toBeInTheDocument();
+    expect(within(menu).getByRole('menuitem', { name: /^due date$/i })).toBeInTheDocument();
+    const labelsItem = within(menu).getByRole('menuitem', { name: /^labels$/i });
+    expect(labelsItem).toBeDisabled();
+    expect(labelsItem).toHaveAttribute('title', LABELS_TOOLTIP);
+    expect(within(menu).getByRole('menuitem', { name: /delete task/i })).toBeInTheDocument();
+  });
+
+  it('Labels stub does not call TaskAPI.updateTask when clicked', async () => {
+    const { menu } = await openMenuOnFirstRow();
+    updateTaskApiMock.mockClear();
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^labels$/i }));
+    expect(updateTaskApiMock).not.toHaveBeenCalled();
+  });
+
+  it('closes menu on Escape', async () => {
+    await openMenuOnFirstRow();
+    expect(screen.getAllByRole('menu').length).toBeGreaterThan(0);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('closes menu on outside pointerdown', async () => {
+    await openMenuOnFirstRow();
+    expect(screen.getAllByRole('menu').length).toBeGreaterThan(0);
+    fireEvent.pointerDown(document.body, { bubbles: true });
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('Open task navigates and closes menu', async () => {
+    const { menu } = await openMenuOnFirstRow();
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /open task/i }));
+    expect(mockPush).toHaveBeenCalledWith('/tasks/7');
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('Copy task link writes URL and closes menu', async () => {
+    const { menu } = await openMenuOnFirstRow();
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /copy task link/i }));
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        expect.stringMatching(/\/tasks\/7$/)
+      );
+    });
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('Delete opens confirm dialog and removes task on confirm', async () => {
+    deleteTaskMock.mockResolvedValue(undefined);
+    const { menu } = await openMenuOnFirstRow();
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /delete task/i }));
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+
+    expect(screen.getByRole('heading', { name: /delete task/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(deleteTaskMock).toHaveBeenCalledWith(7);
+      expect(mockRemoveTask).toHaveBeenCalledWith(7);
+    });
+  });
+});
+
+describe('ListView row context menu (Step 2 PATCH)', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockRemoveTask.mockClear();
+    mockUpdateTask.mockClear();
+    deleteTaskMock.mockReset();
+    updateTaskApiMock.mockReset();
+    resetWorkflowMocks();
+    getProjectMembersMock.mockReset();
+    getProjectMembersMock.mockResolvedValue([]);
+    (toast.success as jest.Mock).mockClear();
+    (toast.error as jest.Mock).mockClear();
+    Object.assign(navigator, {
+      clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it('priority calls TaskAPI.updateTask with correct id and payload and updates store', async () => {
+    updateTaskApiMock.mockResolvedValue({
+      data: { id: 7, priority: 'HIGH', due_date: '2026-01-01' },
+    });
+    render(
+      <ListView
+        tasks={[makeTask({ id: 7, summary: 'Row one', priority: 'MEDIUM' })]}
+        loading={false}
+        error={null}
+      />
+    );
+    const row = screen.getByText('Row one').closest('tr')!;
+    fireEvent.contextMenu(row, { clientX: 120, clientY: 160, bubbles: true });
+    await settleListViewMenuFetch();
+    const menu = screen.getAllByRole('menu').pop()!;
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^priority$/i }));
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^high$/i }));
+
+    await waitFor(() => {
+      expect(updateTaskApiMock).toHaveBeenCalledWith(7, { priority: 'HIGH' });
+      expect(mockUpdateTask).toHaveBeenCalledWith(7, { priority: 'HIGH' });
+    });
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it('due date Today calls TaskAPI.updateTask with YYYY-MM-DD and updates store', async () => {
+    updateTaskApiMock.mockResolvedValue({
+      data: { id: 7, due_date: '2026-06-15' },
+    });
+    render(<ListView tasks={[makeTask({ id: 7, summary: 'Row one' })]} loading={false} error={null} />);
+    const row = screen.getByText('Row one').closest('tr')!;
+    fireEvent.contextMenu(row, { clientX: 120, clientY: 160, bubbles: true });
+    await settleListViewMenuFetch();
+
+    jest.useFakeTimers({ advanceTimers: true });
+    jest.setSystemTime(new Date('2026-06-15T14:00:00'));
+    const menu = screen.getAllByRole('menu').pop()!;
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^due date$/i }));
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^today$/i }));
+
+    await waitFor(
+      () => {
+        expect(updateTaskApiMock).toHaveBeenCalledWith(7, { due_date: '2026-06-15' });
+        expect(mockUpdateTask).toHaveBeenCalledWith(7, { due_date: '2026-06-15' });
+      },
+      { advanceTimers: true }
+    );
+    jest.useRealTimers();
+  });
+
+  it('clear due date sends null payload', async () => {
+    updateTaskApiMock.mockResolvedValue({
+      data: { id: 7, due_date: null },
+    });
+    render(
+      <ListView
+        tasks={[makeTask({ id: 7, summary: 'Row one', due_date: '2026-01-01' })]}
+        loading={false}
+        error={null}
+      />
+    );
+    const row = screen.getByText('Row one').closest('tr')!;
+    fireEvent.contextMenu(row, { clientX: 120, clientY: 160, bubbles: true });
+    await settleListViewMenuFetch();
+    const menu = screen.getAllByRole('menu').pop()!;
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^due date$/i }));
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /clear due date/i }));
+
+    await waitFor(() => {
+      expect(updateTaskApiMock).toHaveBeenCalledWith(7, { due_date: null });
+      expect(mockUpdateTask).toHaveBeenCalledWith(7, { due_date: undefined });
+    });
+  });
+
+  it('PATCH failure does not update store and shows error toast', async () => {
+    updateTaskApiMock.mockRejectedValue({ response: { data: { detail: 'Not allowed' } } });
+    render(<ListView tasks={[makeTask({ id: 7, summary: 'Row one' })]} loading={false} error={null} />);
+    const row = screen.getByText('Row one').closest('tr')!;
+    fireEvent.contextMenu(row, { clientX: 120, clientY: 160, bubbles: true });
+    await settleListViewMenuFetch();
+    const menu = screen.getAllByRole('menu').pop()!;
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^priority$/i }));
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^low$/i }));
+
+    await waitFor(() => {
+      expect(updateTaskApiMock).toHaveBeenCalled();
+      expect(mockUpdateTask).not.toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalledWith('Not allowed');
+    });
+  });
+});
+
+describe('ListView row context menu (Step 3 owner / approver)', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockRemoveTask.mockClear();
+    mockUpdateTask.mockClear();
+    deleteTaskMock.mockReset();
+    updateTaskApiMock.mockReset();
+    resetWorkflowMocks();
+    getProjectMembersMock.mockReset();
+    (toast.success as jest.Mock).mockClear();
+    (toast.error as jest.Mock).mockClear();
+    Object.assign(navigator, {
+      clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it('fetches project members once per project when opening menu on different rows', async () => {
+    const bob = makeMember({
+      id: 2,
+      user: { id: 202, username: 'bob', email: 'bob@test.com' },
+    });
+    getProjectMembersMock.mockResolvedValue([makeMember(), bob]);
+    render(
+      <ListView
+        tasks={[
+          makeTask({ id: 7, summary: 'Row one', project_id: 1 }),
+          makeTask({ id: 8, summary: 'Row two', project_id: 1 }),
+        ]}
+        loading={false}
+        error={null}
+      />
+    );
+
+    fireEvent.contextMenu(screen.getByText('Row one').closest('tr')!, {
+      clientX: 120,
+      clientY: 160,
+      bubbles: true,
+    });
+    await settleListViewMenuFetch();
+    expect(getProjectMembersMock).toHaveBeenCalledWith(1);
+    expect(getProjectMembersMock).toHaveBeenCalledTimes(1);
+    fireEvent.pointerDown(document.body, { bubbles: true });
+
+    await act(async () => {
+      fireEvent.contextMenu(screen.getByText('Row two').closest('tr')!, {
+        clientX: 120,
+        clientY: 160,
+        bubbles: true,
+      });
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    });
+    await waitFor(() => expect(screen.getAllByRole('menu').length).toBeGreaterThan(0));
+    expect(getProjectMembersMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('owner assigns member via PATCH and updates store from response', async () => {
+    getProjectMembersMock.mockResolvedValue([makeMember()]);
+    updateTaskApiMock.mockResolvedValue({
+      data: {
+        id: 7,
+        owner: { id: 201, username: 'alice', email: 'alice@test.com' },
+      },
+    });
+    render(<ListView tasks={[makeTask({ id: 7, summary: 'Row one', project_id: 1 })]} loading={false} error={null} />);
+    const row = screen.getByText('Row one').closest('tr')!;
+    fireEvent.contextMenu(row, { clientX: 120, clientY: 160, bubbles: true });
+    await settleListViewMenuFetch();
+    const menu = screen.getAllByRole('menu').pop()!;
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^owner$/i }));
+    await waitFor(() => expect(within(menu).getByRole('menuitem', { name: /^alice$/i })).toBeInTheDocument());
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^alice$/i }));
+
+    await waitFor(() => {
+      expect(updateTaskApiMock).toHaveBeenCalledWith(7, { owner_id: 201 });
+      expect(mockUpdateTask).toHaveBeenCalledWith(7, {
+        owner: { id: 201, username: 'alice', email: 'alice@test.com' },
+      });
+    });
+  });
+
+  it('owner unassigned sends null owner_id', async () => {
+    getProjectMembersMock.mockResolvedValue([makeMember()]);
+    updateTaskApiMock.mockResolvedValue({
+      data: { id: 7, owner: null as unknown as undefined },
+    });
+    render(<ListView tasks={[makeTask({ id: 7, summary: 'Row one', project_id: 1 })]} loading={false} error={null} />);
+    const row = screen.getByText('Row one').closest('tr')!;
+    fireEvent.contextMenu(row, { clientX: 120, clientY: 160, bubbles: true });
+    await settleListViewMenuFetch();
+    const menu = screen.getAllByRole('menu').pop()!;
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^owner$/i }));
+    await waitFor(() => within(menu).getByRole('menuitem', { name: /^unassigned$/i }));
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^unassigned$/i }));
+
+    await waitFor(() => {
+      expect(updateTaskApiMock).toHaveBeenCalledWith(7, { owner_id: null });
+    });
+  });
+
+  it('approver assigns member via PATCH and updates store', async () => {
+    getProjectMembersMock.mockResolvedValue([makeMember()]);
+    updateTaskApiMock.mockResolvedValue({
+      data: {
+        id: 7,
+        current_approver: { id: 201, username: 'alice', email: 'alice@test.com' },
+        current_approver_id: 201,
+      },
+    });
+    render(<ListView tasks={[makeTask({ id: 7, summary: 'Row one', project_id: 1 })]} loading={false} error={null} />);
+    const row = screen.getByText('Row one').closest('tr')!;
+    fireEvent.contextMenu(row, { clientX: 120, clientY: 160, bubbles: true });
+    await settleListViewMenuFetch();
+    const menu = screen.getAllByRole('menu').pop()!;
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^approver$/i }));
+    await waitFor(() =>
+      expect(within(menu).getByRole('menuitem', { name: /alice/i })).toBeInTheDocument()
+    );
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /alice/i }));
+
+    await waitFor(() => {
+      expect(updateTaskApiMock).toHaveBeenCalledWith(7, { current_approver_id: 201 });
+      expect(mockUpdateTask).toHaveBeenCalledWith(7, {
+        current_approver: { id: 201, username: 'alice', email: 'alice@test.com' },
+        current_approver_id: 201,
+      });
+    });
+  });
+
+  it('LOCKED task disables owner and approver menu rows', async () => {
+    getProjectMembersMock.mockResolvedValue([makeMember()]);
+    render(
+      <ListView
+        tasks={[makeTask({ id: 7, summary: 'Row one', project_id: 1, status: 'LOCKED' })]}
+        loading={false}
+        error={null}
+      />
+    );
+    const row = screen.getByText('Row one').closest('tr')!;
+    fireEvent.contextMenu(row, { clientX: 120, clientY: 160, bubbles: true });
+    await settleListViewMenuFetch();
+    const menu = screen.getAllByRole('menu').pop()!;
+    expect(within(menu).getByRole('menuitem', { name: /^owner$/i })).toBeDisabled();
+    expect(within(menu).getByRole('menuitem', { name: /^approver$/i })).toBeDisabled();
+  });
+});
+
+describe('ListView row context menu (Step 4 workflow)', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockRemoveTask.mockClear();
+    mockUpdateTask.mockClear();
+    deleteTaskMock.mockReset();
+    updateTaskApiMock.mockReset();
+    resetWorkflowMocks();
+    getProjectMembersMock.mockReset();
+    getProjectMembersMock.mockResolvedValue([]);
+    (toast.success as jest.Mock).mockClear();
+    (toast.error as jest.Mock).mockClear();
+    Object.assign(navigator, {
+      clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it('Workflow Submit calls submitTask and updates store', async () => {
+    (TaskAPI.submitTask as jest.Mock).mockResolvedValue({
+      data: { task: { id: 7, status: 'SUBMITTED', project_id: 1, type: 'task', summary: 'Row one' } },
+    });
+    render(
+      <ListView
+        tasks={[makeTask({ id: 7, summary: 'Row one', status: 'DRAFT' })]}
+        loading={false}
+        error={null}
+      />
+    );
+    const row = screen.getByText('Row one').closest('tr')!;
+    fireEvent.contextMenu(row, { clientX: 120, clientY: 160, bubbles: true });
+    await settleListViewMenuFetch();
+    const menu = screen.getAllByRole('menu').pop()!;
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^workflow$/i }));
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^submit$/i }));
+
+    await waitFor(() => {
+      expect(TaskAPI.submitTask).toHaveBeenCalledWith(7);
+      expect(mockUpdateTask).toHaveBeenCalledWith(7, expect.objectContaining({ status: 'SUBMITTED' }));
+    });
+  });
+
+  it('Workflow submit failure does not update store', async () => {
+    (TaskAPI.submitTask as jest.Mock).mockRejectedValue({
+      response: { data: { detail: 'Cannot submit' } },
+    });
+    render(
+      <ListView
+        tasks={[makeTask({ id: 7, summary: 'Row one', status: 'DRAFT' })]}
+        loading={false}
+        error={null}
+      />
+    );
+    const row = screen.getByText('Row one').closest('tr')!;
+    fireEvent.contextMenu(row, { clientX: 120, clientY: 160, bubbles: true });
+    await settleListViewMenuFetch();
+    const menu = screen.getAllByRole('menu').pop()!;
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^workflow$/i }));
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^submit$/i }));
+
+    await waitFor(() => {
+      expect(mockUpdateTask).not.toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalledWith('Cannot submit');
+    });
+  });
+
+  it('UNDER_REVIEW Approve calls makeApproval with approve action', async () => {
+    (TaskAPI.makeApproval as jest.Mock).mockResolvedValue({
+      data: {
+        task: { id: 7, status: 'APPROVED', project_id: 1, type: 'task', summary: 'Row one' },
+      },
+    });
+    render(
+      <ListView
+        tasks={[makeTask({ id: 7, summary: 'Row one', status: 'UNDER_REVIEW' })]}
+        loading={false}
+        error={null}
+      />
+    );
+    const row = screen.getByText('Row one').closest('tr')!;
+    fireEvent.contextMenu(row, { clientX: 120, clientY: 160, bubbles: true });
+    await settleListViewMenuFetch();
+    const menu = screen.getAllByRole('menu').pop()!;
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^workflow$/i }));
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^approve$/i }));
+
+    await waitFor(() => {
+      expect(TaskAPI.makeApproval).toHaveBeenCalledWith(7, { action: 'approve' });
+      expect(mockUpdateTask).toHaveBeenCalledWith(7, expect.objectContaining({ status: 'APPROVED' }));
+    });
+  });
+
+  it('LOCKED: patch rows disabled but Unlock works (TaskAPI.unlock + store)', async () => {
+    (TaskAPI.unlock as jest.Mock).mockResolvedValue({
+      data: { task: { id: 7, status: 'APPROVED', project_id: 1, type: 'task', summary: 'Row one' } },
+    });
+    render(
+      <ListView
+        tasks={[makeTask({ id: 7, summary: 'Row one', status: 'LOCKED', project_id: 1 })]}
+        loading={false}
+        error={null}
+      />
+    );
+    const row = screen.getByText('Row one').closest('tr')!;
+    fireEvent.contextMenu(row, { clientX: 120, clientY: 160, bubbles: true });
+    await settleListViewMenuFetch();
+    const menu = screen.getAllByRole('menu').pop()!;
+
+    expect(within(menu).getByRole('menuitem', { name: /^priority$/i })).toBeDisabled();
+    expect(within(menu).getByRole('menuitem', { name: /^due date$/i })).toBeDisabled();
+    expect(within(menu).getByRole('menuitem', { name: /^owner$/i })).toBeDisabled();
+    expect(within(menu).getByRole('menuitem', { name: /^approver$/i })).toBeDisabled();
+
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /^workflow$/i }));
+    const unlockItem = within(menu).getByRole('menuitem', { name: /^unlock$/i });
+    expect(unlockItem).not.toBeDisabled();
+    fireEvent.click(unlockItem);
+
+    await waitFor(() => {
+      expect(TaskAPI.unlock).toHaveBeenCalledWith(7);
+      expect(mockUpdateTask).toHaveBeenCalledWith(7, expect.objectContaining({ status: 'APPROVED' }));
+    });
+  });
+});

--- a/frontend/src/components/tasks-v2/ListView.tsx
+++ b/frontend/src/components/tasks-v2/ListView.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import { Search } from 'lucide-react';
 import type { TaskData } from '@/types/task';
+import { ProjectAPI, type ProjectMemberData } from '@/lib/api/projectApi';
 import {
   PRIORITY_META,
   STATUS_META,
@@ -11,6 +12,10 @@ import {
   formatDateShort,
 } from './TYPE_META';
 import { Skeleton } from '@/components/ui/skeleton';
+import TaskListRowContextMenu, {
+  type TaskListRowContextMenuState,
+} from '@/components/tasks-v2/TaskListRowContextMenu';
+import { useTaskStore } from '@/lib/taskStore';
 
 interface ListViewProps {
   tasks: TaskData[];
@@ -34,7 +39,99 @@ const TABLE_COLUMN_WIDTHS = {
 
 export default function ListView({ tasks, loading, error }: ListViewProps) {
   const router = useRouter();
+  const removeTask = useTaskStore((s) => s.removeTask);
+  const updateTask = useTaskStore((s) => s.updateTask);
   const [search, setSearch] = useState('');
+  const [rowMenu, setRowMenu] = useState<TaskListRowContextMenuState>(null);
+  const [menuMembers, setMenuMembers] = useState<ProjectMemberData[]>([]);
+  const [menuMembersLoading, setMenuMembersLoading] = useState(false);
+  const membersByProjectIdRef = useRef<Map<number, ProjectMemberData[]>>(new Map());
+  const pendingMemberFetchesRef = useRef<Map<number, Promise<ProjectMemberData[]>>>(new Map());
+
+  useEffect(() => {
+    if (!rowMenu) {
+      setMenuMembers([]);
+      setMenuMembersLoading(false);
+      return;
+    }
+    const pid = rowMenu.task.project_id ?? rowMenu.task.project?.id ?? null;
+    if (pid == null) {
+      setMenuMembers([]);
+      setMenuMembersLoading(false);
+      return;
+    }
+
+    const cached = membersByProjectIdRef.current.get(pid);
+    if (cached) {
+      setMenuMembers(cached);
+      setMenuMembersLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setMenuMembers([]);
+    setMenuMembersLoading(true);
+
+    const existing = pendingMemberFetchesRef.current.get(pid);
+    const promise =
+      existing ??
+      ProjectAPI.getProjectMembers(pid)
+        .then((rows) => {
+          membersByProjectIdRef.current.set(pid, rows);
+          pendingMemberFetchesRef.current.delete(pid);
+          return rows;
+        })
+        .catch(() => {
+          pendingMemberFetchesRef.current.delete(pid);
+          return [] as ProjectMemberData[];
+        });
+    if (!existing) {
+      pendingMemberFetchesRef.current.set(pid, promise);
+    }
+
+    void promise.then((rows) => {
+      if (!cancelled) {
+        setMenuMembers(rows);
+        setMenuMembersLoading(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [rowMenu]);
+
+  const openRowMenu = useCallback((e: MouseEvent, task: TaskData) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (task.id == null) return;
+    let x = e.clientX;
+    let y = e.clientY;
+    setRowMenu({ task, x, y });
+  }, []);
+
+  const closeRowMenu = useCallback(() => setRowMenu(null), []);
+
+  const handleOpenDetail = useCallback(
+    (taskId: number) => {
+      router.push(`/tasks/${taskId}`);
+    },
+    [router]
+  );
+
+  const handleTaskDeleted = useCallback(
+    (taskId: number) => {
+      removeTask(taskId);
+    },
+    [removeTask]
+  );
+
+  const handleTaskPatched = useCallback(
+    (taskId: number, data: Partial<TaskData>) => {
+      updateTask(taskId, data);
+    },
+    [updateTask]
+  );
 
   const visible = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -48,6 +145,15 @@ export default function ListView({ tasks, loading, error }: ListViewProps) {
 
   return (
     <div>
+      <TaskListRowContextMenu
+        state={rowMenu}
+        menuMembers={menuMembers}
+        menuMembersLoading={menuMembersLoading}
+        onRequestClose={closeRowMenu}
+        onOpenDetail={handleOpenDetail}
+        onTaskDeleted={handleTaskDeleted}
+        onTaskPatched={handleTaskPatched}
+      />
       <div className="mb-3 flex items-center gap-3">
         <div className="relative flex-1">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
@@ -137,6 +243,7 @@ export default function ListView({ tasks, loading, error }: ListViewProps) {
                     key={task.id}
                     className="cursor-pointer transition hover:bg-gray-50/80"
                     onClick={() => router.push(`/tasks/${task.id}`)}
+                    onContextMenu={(e) => openRowMenu(e, task)}
                   >
                     <td className={`${TABLE_COLUMN_WIDTHS.icon} px-4 py-3`}>
                       <span

--- a/frontend/src/components/tasks-v2/TaskListRowContextMenu.tsx
+++ b/frontend/src/components/tasks-v2/TaskListRowContextMenu.tsx
@@ -1,0 +1,513 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import toast from 'react-hot-toast';
+import {
+  Calendar,
+  ChevronRight,
+  ExternalLink,
+  GitBranch,
+  Link2,
+  Tag,
+  Trash2,
+  User,
+  UserCheck,
+} from 'lucide-react';
+import type { TaskData } from '@/types/task';
+import type { ProjectMemberData } from '@/lib/api/projectApi';
+import { TaskAPI } from '@/lib/api/taskApi';
+import ConfirmDialog from '@/components/common/ConfirmDialog';
+import { PRIORITY_META, PRIORITY_OPTIONS } from './TYPE_META';
+import { dueDateNextWeek, dueDateToday, dueDateTomorrow } from './taskDueDateQuickPick';
+import {
+  getMvpWorkflowMenuItems,
+  runWorkflowMvpAction,
+  type WorkflowMvpKind,
+} from './taskWorkflowMvp';
+
+const MENU_W = 220;
+const MENU_H_COLLAPSED = 440;
+const MENU_H_EXPANDED = 600;
+
+const LABELS_NOT_SUPPORTED_TITLE = 'Task labels are not supported yet';
+
+export type TaskListRowContextMenuState = {
+  task: TaskData;
+  x: number;
+  y: number;
+} | null;
+
+type ExpandedSection = null | 'workflow' | 'priority' | 'dueDate' | 'owner' | 'approver';
+
+function clampPosition(x: number, y: number, expanded: ExpandedSection) {
+  let nx = x;
+  let ny = y;
+  const pad = 8;
+  const menuH = expanded ? MENU_H_EXPANDED : MENU_H_COLLAPSED;
+  if (nx + MENU_W > window.innerWidth - pad) {
+    nx = window.innerWidth - MENU_W - pad;
+  }
+  if (ny + menuH > window.innerHeight - pad) {
+    ny = window.innerHeight - menuH - pad;
+  }
+  if (nx < pad) nx = pad;
+  if (ny < pad) ny = pad;
+  return { x: nx, y: ny };
+}
+
+function taskDetailUrl(taskId: number) {
+  if (typeof window === 'undefined') return `/tasks/${taskId}`;
+  return `${window.location.origin}/tasks/${taskId}`;
+}
+
+function memberLabel(m: ProjectMemberData): string {
+  return m.user.username || m.user.email || `User ${m.user.id}`;
+}
+
+type Props = {
+  state: TaskListRowContextMenuState;
+  menuMembers: ProjectMemberData[];
+  menuMembersLoading: boolean;
+  onRequestClose: () => void;
+  onOpenDetail: (taskId: number) => void;
+  onTaskDeleted: (taskId: number) => void;
+  onTaskPatched: (taskId: number, data: Partial<TaskData>) => void;
+};
+
+const itemClass =
+  'flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50';
+const subItemClass =
+  'flex w-full min-w-0 items-center px-3 py-1.5 pl-8 text-left text-xs text-gray-700 hover:bg-gray-100';
+
+export default function TaskListRowContextMenu({
+  state,
+  menuMembers,
+  menuMembersLoading,
+  onRequestClose,
+  onOpenDetail,
+  onTaskDeleted,
+  onTaskPatched,
+}: Props) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [pendingDelete, setPendingDelete] = useState<TaskData | null>(null);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+  const [expanded, setExpanded] = useState<ExpandedSection>(null);
+  const [patchBusy, setPatchBusy] = useState(false);
+
+  const closeMenu = onRequestClose;
+
+  useEffect(() => {
+    setExpanded(null);
+  }, [state?.task.id]);
+
+  useEffect(() => {
+    if (!state) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeMenu();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [state, closeMenu]);
+
+  useEffect(() => {
+    if (!state) return;
+    const onPointerDown = (e: PointerEvent) => {
+      const el = menuRef.current;
+      if (el && !el.contains(e.target as Node)) {
+        closeMenu();
+      }
+    };
+    document.addEventListener('pointerdown', onPointerDown, true);
+    return () => document.removeEventListener('pointerdown', onPointerDown, true);
+  }, [state, closeMenu]);
+
+  const taskIsReadOnly = state?.task.status === 'LOCKED';
+  const disabledPatch = patchBusy || taskIsReadOnly;
+  const projectId = state?.task.project_id ?? state?.task.project?.id ?? null;
+  const memberPickDisabled = disabledPatch || projectId == null;
+  const activeMembers = menuMembers.filter((m) => m.is_active);
+
+  const workflowItems = useMemo(
+    () => (state?.task ? getMvpWorkflowMenuItems(state.task) : []),
+    [state?.task]
+  );
+
+  const runWorkflow = useCallback(
+    async (kind: WorkflowMvpKind, successMessage: string) => {
+      const id = state?.task.id;
+      if (id == null || patchBusy) return;
+      setPatchBusy(true);
+      try {
+        const next = await runWorkflowMvpAction(id, kind);
+        onTaskPatched(id, next as Partial<TaskData>);
+        toast.success(successMessage);
+        closeMenu();
+      } catch (e) {
+        const data = (e as { response?: { data?: { detail?: string; error?: string } } })?.response?.data;
+        toast.error(data?.detail || data?.error || (e as Error)?.message || 'Action failed');
+      } finally {
+        setPatchBusy(false);
+      }
+    },
+    [state?.task.id, patchBusy, onTaskPatched, closeMenu]
+  );
+
+  const runPatch = useCallback(
+    async (payload: Partial<TaskData>, successMessage: string) => {
+      const id = state?.task.id;
+      if (id == null || patchBusy || taskIsReadOnly) return;
+      setPatchBusy(true);
+      try {
+        const res = await TaskAPI.updateTask(id, payload);
+        const data = res.data as TaskData;
+        const merged: Partial<TaskData> = {};
+        if ('priority' in payload) merged.priority = data.priority;
+        if ('due_date' in payload) merged.due_date = data.due_date ?? undefined;
+        if ('owner_id' in payload) {
+          merged.owner = data.owner;
+          if (data.owner_id !== undefined) merged.owner_id = data.owner_id;
+        }
+        if ('current_approver_id' in payload) {
+          merged.current_approver = data.current_approver;
+          if (data.current_approver_id !== undefined) merged.current_approver_id = data.current_approver_id;
+        }
+        onTaskPatched(id, merged);
+        toast.success(successMessage);
+        closeMenu();
+      } catch (e) {
+        toast.error(
+          (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail || 'Update failed'
+        );
+      } finally {
+        setPatchBusy(false);
+      }
+    },
+    [state?.task.id, patchBusy, taskIsReadOnly, onTaskPatched, closeMenu]
+  );
+
+  const handleOpen = () => {
+    const id = state?.task.id;
+    if (id == null) return;
+    closeMenu();
+    onOpenDetail(id);
+  };
+
+  const handleCopyLink = async () => {
+    const id = state?.task.id;
+    if (id == null) return;
+    const url = taskDetailUrl(id);
+    try {
+      await navigator.clipboard.writeText(url);
+      toast.success('Link copied');
+      closeMenu();
+    } catch {
+      toast.error('Could not copy link');
+    }
+  };
+
+  const handleDeleteClick = () => {
+    const task = state?.task;
+    closeMenu();
+    if (task?.id != null) setPendingDelete(task);
+  };
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (deleteBusy) return;
+    const id = pendingDelete?.id;
+    if (id == null) return;
+    setDeleteBusy(true);
+    try {
+      await TaskAPI.deleteTask(id);
+      toast.success('Task deleted');
+      onTaskDeleted(id);
+      setPendingDelete(null);
+    } catch (e) {
+      toast.error((e as { response?: { data?: { detail?: string } } })?.response?.data?.detail || 'Delete failed');
+    } finally {
+      setDeleteBusy(false);
+    }
+  }, [pendingDelete, onTaskDeleted, deleteBusy]);
+
+  const cancelDelete = () => setPendingDelete(null);
+
+  if (!state && !pendingDelete) return null;
+
+  const pos = state ? clampPosition(state.x, state.y, expanded) : { x: 0, y: 0 };
+  const deleteMessage = pendingDelete
+    ? `"${pendingDelete.summary || `Task #${pendingDelete.id}`}" will be permanently removed. This cannot be undone.`
+    : '';
+
+  const ownerApproverTitle =
+    projectId == null ? 'Task has no project' : taskIsReadOnly ? 'Task is locked' : undefined;
+
+  return (
+    <>
+      {state &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            ref={menuRef}
+            className="fixed z-[100] min-w-[220px] max-w-[260px] rounded-lg border border-gray-200 bg-white py-1 shadow-lg"
+            style={{ left: pos.x, top: pos.y }}
+            onContextMenu={(e) => e.preventDefault()}
+            role="menu"
+          >
+            <button type="button" role="menuitem" className={itemClass} onClick={handleOpen}>
+              <ExternalLink className="h-4 w-4 shrink-0 text-gray-500" aria-hidden />
+              Open task
+            </button>
+            <button type="button" role="menuitem" className={itemClass} onClick={() => void handleCopyLink()}>
+              <Link2 className="h-4 w-4 shrink-0 text-gray-500" aria-hidden />
+              Copy task link
+            </button>
+
+            {workflowItems.length > 0 ? (
+              <>
+                <button
+                  type="button"
+                  role="menuitem"
+                  disabled={patchBusy}
+                  className={`${itemClass} disabled:cursor-not-allowed disabled:opacity-50`}
+                  onClick={() => setExpanded((e) => (e === 'workflow' ? null : 'workflow'))}
+                >
+                  <GitBranch className="h-4 w-4 shrink-0 text-gray-500" aria-hidden />
+                  <span className="flex-1">Workflow</span>
+                  <ChevronRight
+                    className={`h-4 w-4 shrink-0 text-gray-400 transition-transform ${expanded === 'workflow' ? 'rotate-90' : ''}`}
+                    aria-hidden
+                  />
+                </button>
+                {expanded === 'workflow' && (
+                  <div className="max-h-48 overflow-y-auto border-t border-gray-100 bg-gray-50/80 py-1">
+                    {workflowItems.map(({ kind, label }) => (
+                      <button
+                        key={kind}
+                        type="button"
+                        role="menuitem"
+                        disabled={patchBusy}
+                        className={subItemClass}
+                        onClick={() => void runWorkflow(kind, `${label} succeeded`)}
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </>
+            ) : null}
+
+            <button
+              type="button"
+              role="menuitem"
+              disabled={disabledPatch || memberPickDisabled}
+              title={ownerApproverTitle}
+              className={`${itemClass} disabled:cursor-not-allowed disabled:opacity-50`}
+              onClick={() => setExpanded((e) => (e === 'owner' ? null : 'owner'))}
+            >
+              <User className="h-4 w-4 shrink-0 text-gray-500" aria-hidden />
+              <span className="flex-1">Owner</span>
+              <ChevronRight
+                className={`h-4 w-4 shrink-0 text-gray-400 transition-transform ${expanded === 'owner' ? 'rotate-90' : ''}`}
+                aria-hidden
+              />
+            </button>
+            {expanded === 'owner' && (
+              <div className="max-h-48 overflow-y-auto border-t border-gray-100 bg-gray-50/80 py-1">
+                {menuMembersLoading ? (
+                  <div className="px-3 py-2 text-xs text-gray-500">Loading…</div>
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      disabled={disabledPatch}
+                      className={subItemClass}
+                      onClick={() =>
+                        void runPatch({ owner_id: null } as unknown as Partial<TaskData>, 'Owner updated')
+                      }
+                    >
+                      Unassigned
+                    </button>
+                    {activeMembers.map((m) => (
+                      <button
+                        key={m.id}
+                        type="button"
+                        role="menuitem"
+                        disabled={disabledPatch}
+                        className={subItemClass}
+                        onClick={() =>
+                          void runPatch({ owner_id: m.user.id }, 'Owner updated')
+                        }
+                      >
+                        <span className="truncate">{memberLabel(m)}</span>
+                      </button>
+                    ))}
+                  </>
+                )}
+              </div>
+            )}
+
+            <button
+              type="button"
+              role="menuitem"
+              disabled={disabledPatch || memberPickDisabled}
+              title={ownerApproverTitle}
+              className={`${itemClass} disabled:cursor-not-allowed disabled:opacity-50`}
+              onClick={() => setExpanded((e) => (e === 'approver' ? null : 'approver'))}
+            >
+              <UserCheck className="h-4 w-4 shrink-0 text-gray-500" aria-hidden />
+              <span className="flex-1">Approver</span>
+              <ChevronRight
+                className={`h-4 w-4 shrink-0 text-gray-400 transition-transform ${expanded === 'approver' ? 'rotate-90' : ''}`}
+                aria-hidden
+              />
+            </button>
+            {expanded === 'approver' && (
+              <div className="max-h-48 overflow-y-auto border-t border-gray-100 bg-gray-50/80 py-1">
+                {menuMembersLoading ? (
+                  <div className="px-3 py-2 text-xs text-gray-500">Loading…</div>
+                ) : (
+                  activeMembers.map((m) => (
+                    <button
+                      key={m.id}
+                      type="button"
+                      role="menuitem"
+                      disabled={disabledPatch}
+                      className={subItemClass}
+                      title={m.role}
+                      onClick={() =>
+                        void runPatch({ current_approver_id: m.user.id }, 'Approver updated')
+                      }
+                    >
+                      <span className="min-w-0 flex-1 truncate">{memberLabel(m)}</span>
+                      <span className="shrink-0 pl-2 text-[10px] uppercase text-gray-400">{m.role}</span>
+                    </button>
+                  ))
+                )}
+              </div>
+            )}
+
+            <button
+              type="button"
+              role="menuitem"
+              disabled={disabledPatch}
+              title={taskIsReadOnly ? 'Task is locked' : undefined}
+              className={`${itemClass} disabled:cursor-not-allowed disabled:opacity-50`}
+              onClick={() => setExpanded((e) => (e === 'priority' ? null : 'priority'))}
+            >
+              <span className="flex min-w-0 flex-1 items-center gap-2">
+                <span className="inline-block h-2 w-2 shrink-0 rounded-full bg-amber-400" aria-hidden />
+                Priority
+              </span>
+              <ChevronRight
+                className={`h-4 w-4 shrink-0 text-gray-400 transition-transform ${expanded === 'priority' ? 'rotate-90' : ''}`}
+                aria-hidden
+              />
+            </button>
+            {expanded === 'priority' && (
+              <div className="border-t border-gray-100 bg-gray-50/80 py-1">
+                {PRIORITY_OPTIONS.map((p) => {
+                  const meta = PRIORITY_META[p];
+                  return (
+                    <button
+                      key={p}
+                      type="button"
+                      role="menuitem"
+                      disabled={disabledPatch}
+                      className={subItemClass}
+                      onClick={() => void runPatch({ priority: p }, 'Priority updated')}
+                    >
+                      <span className={`mr-2 inline-block h-2 w-2 shrink-0 rounded-full ${meta?.dot ?? 'bg-gray-300'}`} />
+                      {meta?.label ?? p}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+
+            <button
+              type="button"
+              role="menuitem"
+              disabled={disabledPatch}
+              title={taskIsReadOnly ? 'Task is locked' : undefined}
+              className={`${itemClass} disabled:cursor-not-allowed disabled:opacity-50`}
+              onClick={() => setExpanded((e) => (e === 'dueDate' ? null : 'dueDate'))}
+            >
+              <Calendar className="h-4 w-4 shrink-0 text-gray-500" aria-hidden />
+              <span className="flex-1">Due date</span>
+              <ChevronRight
+                className={`h-4 w-4 shrink-0 text-gray-400 transition-transform ${expanded === 'dueDate' ? 'rotate-90' : ''}`}
+                aria-hidden
+              />
+            </button>
+            {expanded === 'dueDate' && (
+              <div className="border-t border-gray-100 bg-gray-50/80 py-1">
+                {(
+                  [
+                    ['Today', () => dueDateToday()],
+                    ['Tomorrow', () => dueDateTomorrow()],
+                    ['Next week', () => dueDateNextWeek()],
+                  ] as const
+                ).map(([label, getDate]) => (
+                  <button
+                    key={label}
+                    type="button"
+                    role="menuitem"
+                    disabled={disabledPatch}
+                    className={subItemClass}
+                    onClick={() => void runPatch({ due_date: getDate() }, 'Due date updated')}
+                  >
+                    {label}
+                  </button>
+                ))}
+                <button
+                  type="button"
+                  role="menuitem"
+                  disabled={disabledPatch}
+                  className={subItemClass}
+                  onClick={() =>
+                    void runPatch({ due_date: null } as unknown as Partial<TaskData>, 'Due date updated')
+                  }
+                >
+                  Clear due date
+                </button>
+              </div>
+            )}
+
+            <button
+              type="button"
+              role="menuitem"
+              disabled
+              title={LABELS_NOT_SUPPORTED_TITLE}
+              className={`${itemClass} disabled:cursor-not-allowed disabled:opacity-50`}
+            >
+              <Tag className="h-4 w-4 shrink-0 text-gray-500" aria-hidden />
+              <span className="flex-1">Labels</span>
+            </button>
+
+            <button
+              type="button"
+              role="menuitem"
+              className={`${itemClass} text-rose-600 hover:bg-rose-50`}
+              onClick={handleDeleteClick}
+            >
+              <Trash2 className="h-4 w-4 shrink-0" aria-hidden />
+              Delete task…
+            </button>
+          </div>,
+          document.body
+        )}
+
+      <ConfirmDialog
+        isOpen={Boolean(pendingDelete)}
+        title="Delete task"
+        message={deleteMessage}
+        type="danger"
+        confirmText={deleteBusy ? 'Deleting…' : 'Delete'}
+        onConfirm={() => void handleConfirmDelete()}
+        onCancel={cancelDelete}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/tasks-v2/taskDueDateQuickPick.ts
+++ b/frontend/src/components/tasks-v2/taskDueDateQuickPick.ts
@@ -1,0 +1,23 @@
+/** Local calendar date as YYYY-MM-DD (Django DateField / HTML date input). */
+export function toDateOnlyLocal(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export function dueDateToday(now: Date = new Date()): string {
+  return toDateOnlyLocal(now);
+}
+
+export function dueDateTomorrow(now: Date = new Date()): string {
+  const d = new Date(now);
+  d.setDate(d.getDate() + 1);
+  return toDateOnlyLocal(d);
+}
+
+export function dueDateNextWeek(now: Date = new Date()): string {
+  const d = new Date(now);
+  d.setDate(d.getDate() + 7);
+  return toDateOnlyLocal(d);
+}

--- a/frontend/src/components/tasks-v2/taskWorkflowMvp.test.ts
+++ b/frontend/src/components/tasks-v2/taskWorkflowMvp.test.ts
@@ -1,0 +1,137 @@
+import { TaskAPI } from '@/lib/api/taskApi';
+import type { TaskData } from '@/types/task';
+import {
+  getMvpWorkflowMenuItems,
+  runWorkflowMvpAction,
+  taskFromWorkflowResponse,
+} from './taskWorkflowMvp';
+
+jest.mock('@/lib/api/taskApi', () => ({
+  __esModule: true,
+  TaskAPI: {
+    submitTask: jest.fn(),
+    startReview: jest.fn(),
+    makeApproval: jest.fn(),
+    cancelTask: jest.fn(),
+    lock: jest.fn(),
+    unlock: jest.fn(),
+    revise: jest.fn(),
+    getTask: jest.fn(),
+  },
+}));
+
+const base = (): TaskData => ({
+  id: 1,
+  project_id: 1,
+  type: 'task',
+  summary: 'Test',
+});
+
+describe('getMvpWorkflowMenuItems', () => {
+  it('DRAFT → Submit', () => {
+    expect(getMvpWorkflowMenuItems({ ...base(), status: 'DRAFT' })).toEqual([
+      { kind: 'submit', label: 'Submit' },
+    ]);
+  });
+
+  it('SUBMITTED → Start review, Cancel', () => {
+    expect(getMvpWorkflowMenuItems({ ...base(), status: 'SUBMITTED' })).toEqual([
+      { kind: 'startReview', label: 'Start review' },
+      { kind: 'cancel', label: 'Cancel' },
+    ]);
+  });
+
+  it('UNDER_REVIEW → Approve, Cancel', () => {
+    expect(getMvpWorkflowMenuItems({ ...base(), status: 'UNDER_REVIEW' })).toEqual([
+      { kind: 'approve', label: 'Approve' },
+      { kind: 'cancel', label: 'Cancel' },
+    ]);
+  });
+
+  it('APPROVED → Lock, Cancel', () => {
+    expect(getMvpWorkflowMenuItems({ ...base(), status: 'APPROVED' })).toEqual([
+      { kind: 'lock', label: 'Lock' },
+      { kind: 'cancel', label: 'Cancel' },
+    ]);
+  });
+
+  it('LOCKED → Unlock', () => {
+    expect(getMvpWorkflowMenuItems({ ...base(), status: 'LOCKED' })).toEqual([
+      { kind: 'unlock', label: 'Unlock' },
+    ]);
+  });
+
+  it('REJECTED → Revise', () => {
+    expect(getMvpWorkflowMenuItems({ ...base(), status: 'REJECTED' })).toEqual([
+      { kind: 'revise', label: 'Revise' },
+    ]);
+  });
+
+  it('CANCELLED → Revise', () => {
+    expect(getMvpWorkflowMenuItems({ ...base(), status: 'CANCELLED' })).toEqual([
+      { kind: 'revise', label: 'Revise' },
+    ]);
+  });
+
+  it('missing status defaults to DRAFT', () => {
+    const t = base();
+    delete (t as Partial<TaskData>).status;
+    expect(getMvpWorkflowMenuItems(t)).toEqual([{ kind: 'submit', label: 'Submit' }]);
+  });
+});
+
+describe('taskFromWorkflowResponse', () => {
+  it('returns task when data.task has id', () => {
+    const task = { id: 3, type: 'task' } as TaskData;
+    expect(taskFromWorkflowResponse({ task })).toEqual(task);
+  });
+
+  it('returns null when task missing or invalid', () => {
+    expect(taskFromWorkflowResponse(null)).toBeNull();
+    expect(taskFromWorkflowResponse({})).toBeNull();
+    expect(taskFromWorkflowResponse({ task: {} })).toBeNull();
+  });
+});
+
+describe('runWorkflowMvpAction', () => {
+  beforeEach(() => {
+    jest.mocked(TaskAPI.submitTask).mockReset();
+    jest.mocked(TaskAPI.startReview).mockReset();
+    jest.mocked(TaskAPI.makeApproval).mockReset();
+    jest.mocked(TaskAPI.cancelTask).mockReset();
+    jest.mocked(TaskAPI.lock).mockReset();
+    jest.mocked(TaskAPI.unlock).mockReset();
+    jest.mocked(TaskAPI.revise).mockReset();
+    jest.mocked(TaskAPI.getTask).mockReset();
+  });
+
+  it('returns task from response and does not call getTask', async () => {
+    const task = { id: 7, status: 'SUBMITTED', type: 'task' } as TaskData;
+    jest.mocked(TaskAPI.submitTask).mockResolvedValue({ data: { task } });
+
+    const out = await runWorkflowMvpAction(7, 'submit');
+
+    expect(out).toEqual(task);
+    expect(TaskAPI.submitTask).toHaveBeenCalledWith(7);
+    expect(TaskAPI.getTask).not.toHaveBeenCalled();
+  });
+
+  it('falls back to getTask when response has no task', async () => {
+    const loaded = { id: 9, status: 'APPROVED', type: 'task' } as TaskData;
+    jest.mocked(TaskAPI.unlock).mockResolvedValue({ data: {} });
+    jest.mocked(TaskAPI.getTask).mockResolvedValue({ data: loaded });
+
+    const out = await runWorkflowMvpAction(9, 'unlock');
+
+    expect(TaskAPI.unlock).toHaveBeenCalledWith(9);
+    expect(TaskAPI.getTask).toHaveBeenCalledWith(9);
+    expect(out).toEqual(loaded);
+  });
+
+  it('throws when task is missing from response and getTask', async () => {
+    jest.mocked(TaskAPI.lock).mockResolvedValue({ data: {} });
+    jest.mocked(TaskAPI.getTask).mockResolvedValue({ data: {} as TaskData });
+
+    await expect(runWorkflowMvpAction(1, 'lock')).rejects.toThrow('Task update response missing task');
+  });
+});

--- a/frontend/src/components/tasks-v2/taskWorkflowMvp.ts
+++ b/frontend/src/components/tasks-v2/taskWorkflowMvp.ts
@@ -1,0 +1,88 @@
+import { TaskAPI } from '@/lib/api/taskApi';
+import type { TaskData } from '@/types/task';
+
+export type WorkflowMvpKind =
+  | 'submit'
+  | 'startReview'
+  | 'approve'
+  | 'cancel'
+  | 'lock'
+  | 'unlock'
+  | 'revise';
+
+export function taskFromWorkflowResponse(data: unknown): TaskData | null {
+  if (!data || typeof data !== 'object') return null;
+  const d = data as { task?: TaskData };
+  const t = d.task;
+  if (t && typeof t === 'object' && t.id != null) return t;
+  return null;
+}
+
+/** MVP workflow actions only (no Reject / Forward). Mirrors FSMActionBar eligibility for these actions. */
+export function getMvpWorkflowMenuItems(task: TaskData): { kind: WorkflowMvpKind; label: string }[] {
+  const status = task.status ?? 'DRAFT';
+  const items: { kind: WorkflowMvpKind; label: string }[] = [];
+  switch (status) {
+    case 'DRAFT':
+      items.push({ kind: 'submit', label: 'Submit' });
+      break;
+    case 'SUBMITTED':
+      items.push({ kind: 'startReview', label: 'Start review' });
+      items.push({ kind: 'cancel', label: 'Cancel' });
+      break;
+    case 'UNDER_REVIEW':
+      items.push({ kind: 'approve', label: 'Approve' });
+      items.push({ kind: 'cancel', label: 'Cancel' });
+      break;
+    case 'APPROVED':
+      items.push({ kind: 'lock', label: 'Lock' });
+      items.push({ kind: 'cancel', label: 'Cancel' });
+      break;
+    case 'REJECTED':
+    case 'CANCELLED':
+      items.push({ kind: 'revise', label: 'Revise' });
+      break;
+    case 'LOCKED':
+      items.push({ kind: 'unlock', label: 'Unlock' });
+      break;
+    default:
+      break;
+  }
+  return items;
+}
+
+export async function runWorkflowMvpAction(taskId: number, kind: WorkflowMvpKind): Promise<TaskData> {
+  let res: { data: unknown };
+  switch (kind) {
+    case 'submit':
+      res = await TaskAPI.submitTask(taskId);
+      break;
+    case 'startReview':
+      res = await TaskAPI.startReview(taskId);
+      break;
+    case 'approve':
+      res = await TaskAPI.makeApproval(taskId, { action: 'approve' });
+      break;
+    case 'cancel':
+      res = await TaskAPI.cancelTask(taskId);
+      break;
+    case 'lock':
+      res = await TaskAPI.lock(taskId);
+      break;
+    case 'unlock':
+      res = await TaskAPI.unlock(taskId);
+      break;
+    case 'revise':
+      res = await TaskAPI.revise(taskId);
+      break;
+  }
+
+  const task = taskFromWorkflowResponse(res.data);
+  if (task) return task;
+
+  const fallback = await TaskAPI.getTask(taskId);
+  const loaded = fallback.data as TaskData;
+  if (loaded?.id != null) return loaded;
+
+  throw new Error('Task update response missing task');
+}


### PR DESCRIPTION
## Summary

This PR implements SMP-537: **Add Right-Click Quick Action Menu for Task List Items**.

Users can now right-click on a task row in the task list view to open a contextual quick action menu and perform common task actions without opening the task detail page.

## What changed

- Added `TaskListRowContextMenu` for task row right-click actions.
- Wired `ListView` task rows with `onContextMenu` to open the custom menu near the cursor position.
- Added disabled Labels row with tooltip because task labels are not currently supported by the existing Task model/API.
- Added helpers for local due-date quick picks and workflow menu action mapping.

## Testing

- `npm run test -- --testPathPattern=ListView.contextMenu`
  - 20 tests passed
- `npm run test -- --testPathPattern=taskWorkflowMvp`
  - Passed