### PR TITLE
feat: fixed bug when user create task for specific type and it prompt…

### DIFF
--- a/frontend/src/app/(project)/tasks/new/page.tsx
+++ b/frontend/src/app/(project)/tasks/new/page.tsx
@@ -152,10 +152,13 @@ export default function CreateTaskPage() {
     if (schema) {
       for (const field of schema.fields) {
         const filled = (typeFormState[field.key] ?? '').toString().trim().length > 0;
+        const isConditionallyRequired = field.conditionalRequired
+        ? field.conditionalRequired.values.includes(typeFormState[field.conditionalRequired.dependsOn] ?? '')
+        : false;
         base.push({
           key: `schema:${field.key}`,
           label: field.label,
-          required: field.required,
+          required: field.required || isConditionallyRequired,
           filled,
           anchorId: fieldId(schema.type, field.key),
         });

--- a/frontend/src/components/tasks-v2/new/TaskTypeFieldsSection.tsx
+++ b/frontend/src/components/tasks-v2/new/TaskTypeFieldsSection.tsx
@@ -50,6 +50,7 @@ export default function TaskTypeFieldsSection({ schema, values, onChange }: Prop
           value={values[field.key] ?? ''}
           options={field.options ?? optionsByKey[field.key] ?? []}
           onChange={(v) => onChange(field.key, v)}
+          values={values}
         />
       ))}
     </div>
@@ -65,20 +66,26 @@ function FieldRow({
   value,
   options,
   onChange,
+  values,
 }: {
   schemaType: string;
   field: FieldDef;
   value: string;
   options: FieldOption[];
   onChange: (v: string) => void;
+  values: Record<string, string>;
 }) {
   const id = fieldId(schemaType, field.key);
+  const isConditionallyRequired = field.conditionalRequired
+    ? field.conditionalRequired.values.includes(values[field.conditionalRequired.dependsOn] ?? '')
+    : false;
+  const isRequired = field.required || isConditionallyRequired;
 
   return (
     <div>
       <label htmlFor={id} className="mb-1.5 block text-[12px] font-medium uppercase tracking-wider text-gray-500">
         {field.label}
-        {field.required && <span className="ml-1 text-rose-500">*</span>}
+        {isRequired && <span className="ml-1 text-rose-500">*</span>}
       </label>
       {renderControl(id, field, value, options, onChange)}
       {field.helpText && (

--- a/frontend/src/lib/taskTypeConfigRegistry.tsx
+++ b/frontend/src/lib/taskTypeConfigRegistry.tsx
@@ -189,7 +189,7 @@ export const TASK_TYPE_CONFIG_STATIC: Record<string, TaskTypeConfigStatic> = {
         task: createdTask.id,
         communication_type: formData.communication_type,
         stakeholders: formData.stakeholders || "",
-        impacted_areas: formData.impacted_areas,
+        impacted_areas: [formData.impacted_areas],
         required_actions: formData.required_actions,
         client_deadline:
           formData.client_deadline && formData.client_deadline.trim() !== ""
@@ -235,15 +235,23 @@ export const TASK_TYPE_CONFIG_STATIC: Record<string, TaskTypeConfigStatic> = {
     api: ReportAPI.createReport,
     formComponent: ReportForm,
     requiredFields: [],
-    getPayload: (formData, _taskData, createdTask) => ({
+    getPayload: (formData, _taskData, createdTask) => {
+    if (
+      formData.audience_type === 'other' &&
+      !(formData.audience_details ?? '').trim()
+    ) {
+      throw new Error('Audience details are required when audience type is "Other".');
+    }
+    return {
       task: createdTask.id,
       audience_type: formData.audience_type,
-      audience_details: formData.audience_details || "",
+      audience_details: formData.audience_details || '',
       context: formData.context || defaultReportContext,
-      outcome_summary: formData.outcome_summary || "",
-      narrative_explanation: formData.narrative_explanation || "",
+      outcome_summary: formData.outcome_summary || '',
+      narrative_explanation: formData.narrative_explanation || '',
       key_actions: formData.key_actions || [],
-    }),
+    };
+  },
   },
   platform_policy_update: {
     contentType: "platformpolicyupdate",

--- a/frontend/src/lib/tasks-v2/typeFieldSchemas.ts
+++ b/frontend/src/lib/tasks-v2/typeFieldSchemas.ts
@@ -36,6 +36,10 @@ export interface FieldDef {
   label: string;
   kind: FieldKind;
   required: boolean;
+  conditionalRequired?: {
+    dependsOn: string;
+    values: string[];
+  };
   placeholder?: string;
   /** Rows for textarea kind. */
   rows?: number;
@@ -180,17 +184,28 @@ const REPORT: TypeSchema = {
     {
       key: 'audience_type',
       label: 'Audience type',
-      kind: 'text',
+      kind: 'select',
       required: true,
-      placeholder: 'e.g. executive, client, internal',
+      options: [
+        { value: 'client',        label: 'Client' },
+        { value: 'manager',       label: 'Manager' },
+        { value: 'internal_team', label: 'Internal Team' },
+        { value: 'self',          label: 'Self' },
+        { value: 'other',         label: 'Other' },
+      ],
     },
     {
       key: 'audience_details',
       label: 'Audience details',
       kind: 'textarea',
       required: false,
+      conditionalRequired: {
+        dependsOn: 'audience_type',
+        values: ['other'],
+      },
       rows: 2,
       placeholder: 'Names, roles, or distribution list',
+      helpText: 'Required when audience type is "Other"', 
     },
     {
       key: 'outcome_summary',
@@ -405,12 +420,11 @@ const COMMUNICATION: TypeSchema = {
       kind: 'select',
       required: true,
       options: [
-        { value: 'status_update', label: 'Status update' },
-        { value: 'policy_change', label: 'Policy change' },
-        { value: 'performance_review', label: 'Performance review' },
-        { value: 'budget_change', label: 'Budget change' },
-        { value: 'incident', label: 'Incident' },
-        { value: 'other', label: 'Other' },
+        { value: 'budget_change',     label: 'Budget Change' },
+        { value: 'creative_approval', label: 'Creative Approval' },
+        { value: 'kpi_update',        label: 'KPI Update' },
+        { value: 'targeting_change',  label: 'Targeting Change' },
+        { value: 'other',             label: 'Other' },
       ],
     },
     {
@@ -422,10 +436,22 @@ const COMMUNICATION: TypeSchema = {
       placeholder: 'Names or roles to notify',
     },
     {
+      key: 'impacted_areas',
+      label: 'Impacted areas',
+      kind: 'select',
+      required: true,
+      options: [
+        { value: 'budget',    label: 'Budget' },
+        { value: 'creative',  label: 'Creative' },
+        { value: 'kpi',       label: 'KPI' },
+        { value: 'targeting', label: 'Targeting' },
+      ],
+    },
+    {
       key: 'required_actions',
       label: 'Required actions',
       kind: 'textarea',
-      required: false,
+      required: true,
       rows: 2,
       placeholder: 'What you need the client to do',
     },


### PR DESCRIPTION
# **Solution**

## Fixed case 1
### Report Work Type: Invalid audience_type input

The audience_type field was a free-text input, allowing users to enter invalid characters (e.g. . ,) that the backend rejected. Fixed by changing the field kind from text to select in typeFieldSchemas.ts, restricting input to the valid backend enum values: client, manager, internal_team, self, other. Additionally, added conditional validation in taskTypeConfigRegistry.ts so that when audience_type is other, audience_details becomes required before submission.

<img width="659" height="550" alt="image" src="https://github.com/user-attachments/assets/5652a785-9eb8-4d6f-826f-c743708111e6" />
When audience type is a value other than 'Other'
<img width="983" height="535" alt="image" src="https://github.com/user-attachments/assets/9385326a-caa5-4b8c-86bb-333dda593ed7" />

When audience type is a value 'Other'
<img width="1387" height="518" alt="image" src="https://github.com/user-attachments/assets/de9fdf3f-9b25-433f-84d6-17126f960758" />
It won't prompt the wrong hint anymore

## Fixed case 2
### Three issues were identified:

communication_type options in the frontend schema did not match the backend enum values (status_update, policy_change etc. were replaced with the correct values: budget_change, creative_approval, kpi_update, targeting_change, other).

impacted_areas was not collected from the user at all, causing the backend clean() validation to always fail. Fixed by adding the field to the schema as a select with valid options, and updating getPayload to wrap the selected value in an array.

required_actions was marked required: false in the frontend schema but the backend model has no blank=True, causing empty submissions to fail. Fixed by setting required: true.
<img width="1028" height="721" alt="image" src="https://github.com/user-attachments/assets/130ab806-4a56-404b-adb5-3293469b269e" />
After filling up the blank, it successfully create without any wrong hint.
<img width="1398" height="402" alt="image" src="https://github.com/user-attachments/assets/a2d6ce19-d772-4c29-9f60-22d0f4827608" />

