### PR TITLE
feature(agent): Implement approval request in chatbox

### DIFF
--- a/backend/agent/admin.py
+++ b/backend/agent/admin.py
@@ -3,6 +3,7 @@ from .models import (
     AgentSession, AgentMessage, ImportedCSVFile,
     AgentWorkflowRun, AgentWorkflowDefinition,
     AgentWorkflowStep, AgentStepExecution,
+    AgentPendingExternalApproval,
     FieldCategory, DataSchemaTemplate,
     ImportedDataField, ImportedDataRecord,
 )
@@ -10,7 +11,7 @@ from .models import (
 
 @admin.register(AgentSession)
 class AgentSessionAdmin(admin.ModelAdmin):
-    list_display = ('id', 'user', 'project', 'title', 'status', 'created_at')
+    list_display = ('id', 'user', 'project', 'title', 'status', 'approval_required', 'created_at')
     list_filter = ('status',)
     search_fields = ('title',)
 
@@ -49,6 +50,13 @@ class AgentWorkflowStepAdmin(admin.ModelAdmin):
 class AgentStepExecutionAdmin(admin.ModelAdmin):
     list_display = ('id', 'workflow_run', 'step_name', 'step_order', 'status', 'started_at')
     list_filter = ('status',)
+
+
+@admin.register(AgentPendingExternalApproval)
+class AgentPendingExternalApprovalAdmin(admin.ModelAdmin):
+    list_display = ('id', 'session', 'kind', 'status', 'workflow_run', 'created_at')
+    list_filter = ('status', 'kind')
+    readonly_fields = ('created_at', 'updated_at')
 
 
 @admin.register(FieldCategory)

--- a/backend/agent/approval_gate.py
+++ b/backend/agent/approval_gate.py
@@ -1,0 +1,529 @@
+"""
+Single entry for agent commits that affect systems outside the agent sandbox.
+
+Toggle off: commits run immediately. Toggle on: persist AgentPendingExternalApproval
+and pause (workflow) or return events for the client (non-workflow).
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+
+import requests as http_requests
+
+logger = logging.getLogger(__name__)
+
+KIND_TASK = 'task'
+KIND_MIRO_BOARD = 'miro_board'
+KIND_CALENDAR_EVENT = 'calendar_event'
+KIND_FORWARD_MESSAGE = 'forward_message'
+KIND_DISTRIBUTE_BULK = 'distribute_bulk'
+KIND_CUSTOM_API = 'custom_api'
+KIND_EMAIL = 'email'
+
+
+@dataclass
+class ExternalCommitResult:
+    paused: bool
+    sse_events: list
+    pending_id: str | None
+    # When not paused: merged output for workflow executor / orchestrator
+    output_data: dict | None
+    workflow_run_patch: dict | None  # e.g. created_tasks, miro ids — applied by caller
+
+
+def _project_destination_options(project) -> list[dict]:
+    return [
+        {
+            'id': str(project.id),
+            'label': getattr(project, 'name', str(project.id)),
+            'value': {'project_id': str(project.id)},
+        }
+    ]
+
+
+def _user_accessible_projects(user):
+    from core.models import Project, ProjectMember
+
+    ids = ProjectMember.objects.filter(user=user, is_active=True).values_list(
+        'project_id', flat=True
+    )
+    return list(
+        Project.objects.filter(id__in=ids, is_deleted=False).order_by('name')[:50]
+    )
+
+
+def build_destination_options(
+    *,
+    kind: str,
+    session,
+    project,
+    user,
+    draft: dict,
+    commit_context: dict,
+) -> tuple[list[dict], dict | None]:
+    """Return (options, default_destination)."""
+    if kind in (KIND_TASK, KIND_MIRO_BOARD):
+        # Destination is always the session project for tasks + miro boards.
+        # Keep default destination for internal commit plumbing, but do not offer options.
+        default = {'project_id': str(project.id)}
+        return [], default
+
+    if kind == KIND_CALENDAR_EVENT:
+        from calendars.models import Calendar as CalendarModel
+
+        org_id = commit_context.get('organization_id')
+        if not org_id:
+            return [], None
+        cals = list(
+            CalendarModel.objects.filter(
+                organization_id=org_id,
+                owner=user,
+                is_deleted=False,
+            ).order_by('-is_primary', 'name')[:30]
+        )
+        opts = [
+            {'id': str(c.id), 'label': c.name, 'value': {'calendar_id': str(c.id)}}
+            for c in cals
+        ]
+        primary = next((c for c in cals if getattr(c, 'is_primary', False)), cals[0] if cals else None)
+        default = {'calendar_id': str(primary.id)} if primary else None
+        return opts, default
+
+    if kind in (KIND_FORWARD_MESSAGE, KIND_DISTRIBUTE_BULK):
+        forwards = draft.get('forwards') or []
+        opts = []
+        for i, f in enumerate(forwards):
+            un = (f.get('username') or '').strip()
+            if not un:
+                continue
+            opts.append({
+                'id': f'{un}:{i}',
+                'label': un,
+                'value': {'username': un},
+            })
+        all_usernames = [o['value']['username'] for o in opts]
+        default = {'usernames': all_usernames} if all_usernames else None
+        return opts, default
+
+    if kind == KIND_CUSTOM_API:
+        return [{'id': 'default', 'label': 'External API', 'value': {}}], {}
+
+    if kind == KIND_EMAIL:
+        return [], None
+
+    return [], None
+
+
+def _commit_task(orchestrator, draft: dict, destination: dict | None, commit_context: dict):
+    from django.contrib.contenttypes.models import ContentType
+
+    from decision.models import Decision
+    from task.models import Task
+
+    project = orchestrator.project
+
+    tasks_data = draft.get('recommended_tasks') or []
+    if not tasks_data:
+        raise ValueError('No tasks in draft')
+
+    decision = None
+    did = commit_context.get('decision_id')
+    if did:
+        try:
+            decision = Decision.objects.get(id=did, project=project)
+        except Decision.DoesNotExist:
+            decision = None
+
+    if decision:
+        decision_ct = ContentType.objects.get_for_model(Decision)
+        link_kwargs = {'content_type': decision_ct, 'object_id': str(decision.id)}
+        desc_suffix = f' (Decision: {decision.title})'
+    else:
+        link_kwargs = {}
+        desc_suffix = ''
+
+    input_data = commit_context.get('input_data') or {}
+    analysis = commit_context.get('analysis_result') or input_data.get('analysis_result')
+
+    created_ids = []
+    created_tasks = []
+    for idx, task_data in enumerate(tasks_data):
+        original_index = task_data.get('index', idx)
+        try:
+            original_index = int(original_index)
+        except Exception:
+            original_index = idx
+        summary = (task_data.get('summary') or 'AI Agent Generated Task')[:255]
+        ai_description = (task_data.get('description') or '').strip()
+        description = ai_description or f'Auto-generated from AI analysis{desc_suffix}'
+        task = Task.objects.create(
+            summary=summary,
+            description=description,
+            type=task_data.get('type', 'optimization'),
+            priority=task_data.get('priority', 'MEDIUM'),
+            project=project,
+            owner=orchestrator.user,
+            **link_kwargs,
+        )
+        created_ids.append(task.id)
+        created_tasks.append(
+            {
+                'index': original_index,
+                'task_id': task.id,
+                'summary': summary,
+            }
+        )
+
+    wf_patch = {'created_tasks': created_ids}
+    out = {**input_data, 'analysis_result': analysis}
+    sse = [
+        {
+            'type': 'task_created',
+            'content': f'Created {len(created_ids)} tasks.',
+            'data': {
+                'task_ids': created_ids,
+                'created_tasks': created_tasks,
+                'decision_id': decision.id if decision else None,
+            },
+        }
+    ]
+    return out, sse, wf_patch
+
+
+def _commit_miro_board(orchestrator, draft: dict, destination: dict | None, commit_context: dict):
+    from .miro_board_service import create_board_from_snapshot
+    from .models import AgentWorkflowRun
+
+    project = orchestrator.project
+
+    run_id = commit_context.get('workflow_run_id')
+    if not run_id:
+        raise ValueError('workflow_run_id required for miro commit')
+    workflow_run = AgentWorkflowRun.objects.get(id=run_id, session=orchestrator.session)
+    snapshot = draft.get('snapshot') or workflow_run.miro_snapshot
+    if not snapshot:
+        raise ValueError('No miro snapshot in draft or workflow run')
+
+    board, persisted_snapshot = create_board_from_snapshot(
+        project=project,
+        session=orchestrator.session,
+        workflow_run=workflow_run,
+        snapshot=snapshot,
+    )
+    workflow_run.miro_board = board
+    workflow_run.miro_snapshot = persisted_snapshot
+    workflow_run.save(update_fields=['miro_board', 'miro_snapshot', 'updated_at'])
+    wf_patch = {'miro_board_id': str(board.id), 'miro_snapshot': persisted_snapshot}
+    out = {
+        **commit_context.get('merge_output', {}),
+        'miro_snapshot': persisted_snapshot,
+        'miro_board_id': str(board.id),
+    }
+    sse = [
+        {
+            'type': 'miro_board_created',
+            'content': f'Miro board created: {board.title}',
+            'data': {'board_id': str(board.id)},
+        }
+    ]
+    return out, sse, wf_patch
+
+
+def _commit_calendar_events(orchestrator, draft: dict, destination: dict | None, commit_context: dict):
+    from calendars.models import Calendar as CalendarModel, Event as EventModel
+    from dateutil import parser as date_parser
+    import pytz
+
+    org_id = commit_context.get('organization_id')
+    if not org_id:
+        raise ValueError('organization_id required')
+
+    cal_id = (destination or {}).get('calendar_id')
+    if not cal_id:
+        raise ValueError('calendar_id destination required')
+    cal = CalendarModel.objects.get(
+        id=cal_id,
+        organization_id=org_id,
+        owner=orchestrator.user,
+        is_deleted=False,
+    )
+
+    user_tz_name = commit_context.get('user_timezone') or 'UTC'
+    try:
+        user_tz = pytz.timezone(user_tz_name)
+    except pytz.UnknownTimeZoneError:
+        user_tz = pytz.utc
+
+    def _parse_dt(dt_str):
+        if not dt_str:
+            return None
+        raw = str(dt_str).strip()
+        date_part = raw.split(' ')[0] if ' ' in raw else raw
+        dt = date_parser.parse(date_part)
+        if dt.tzinfo is None and user_tz:
+            dt = user_tz.localize(dt)
+        elif dt.tzinfo is None:
+            dt = pytz.utc.localize(dt)
+        return dt
+
+    events_specs = draft.get('events') or []
+    created = []
+    for spec in events_specs:
+        if not isinstance(spec, dict):
+            continue
+        ev = EventModel.objects.create(
+            organization_id=org_id,
+            calendar=cal,
+            created_by=orchestrator.user,
+            title=spec.get('title', 'New Event'),
+            description=spec.get('description', ''),
+            start_datetime=_parse_dt(spec.get('start_datetime')),
+            end_datetime=_parse_dt(spec.get('end_datetime')),
+            timezone=str(user_tz),
+            location=spec.get('location') or '',
+        )
+        created.append(str(ev.id))
+
+    sse = []
+    if created:
+        sse.append({'type': 'calendar_updated', 'content': '', 'data': {'event_ids': created}})
+    return {}, sse, {'created_event_ids': created}
+
+
+def _commit_forward(orchestrator, draft: dict, destination: dict | None, commit_context: dict):
+    from .services import _forward_to_users
+
+    forwards = draft.get('forwards') or []
+    if destination and destination.get('usernames'):
+        allow = {u.lower() for u in destination['usernames']}
+        forwards = [f for f in forwards if (f.get('username') or '').lower() in allow]
+    results = _forward_to_users(forwards, orchestrator.user, orchestrator.project)
+    sent = [r['username'] for r in results if r.get('status') == 'sent']
+    failed = [r['username'] for r in results if r.get('status') != 'sent']
+    sse = []
+    if sent:
+        sse.append({'type': 'text', 'content': f'Message forwarded to: {", ".join(sent)}'})
+    if failed:
+        sse.append({'type': 'text', 'content': f'Could not forward to: {", ".join(failed)}'})
+    return {}, sse, {}
+
+
+def _commit_distribute(orchestrator, draft: dict, destination: dict | None, commit_context: dict):
+    from .services import _forward_to_users
+
+    forwards = draft.get('forwards') or []
+    if destination and destination.get('usernames'):
+        allow = {u.lower() for u in destination['usernames']}
+        forwards = [f for f in forwards if (f.get('username') or '').lower() in allow]
+    if not forwards:
+        raise ValueError('No recipients selected for distribution')
+    results = _forward_to_users(forwards, orchestrator.user, orchestrator.project)
+    sent = [r for r in results if r.get('status') == 'sent']
+    failed = [r for r in results if r.get('status') != 'sent']
+    parts = []
+    if sent:
+        parts.append(
+            f"Message sent to {len(sent)} member(s): {', '.join(r['username'] for r in sent)}."
+        )
+    if failed:
+        parts.append(
+            f"Failed to send to: {', '.join(r['username'] for r in failed)}."
+        )
+    content = ' '.join(parts) if parts else 'Distribution complete.'
+    sse = [{'type': 'text', 'content': content}]
+    return {}, sse, {}
+
+
+def _commit_custom_api(_orchestrator, draft: dict, _destination: dict | None, commit_context: dict):
+    method = (draft.get('method') or commit_context.get('method') or 'POST').upper()
+    url = draft.get('url') or commit_context.get('url')
+    headers = draft.get('headers') or commit_context.get('headers') or {}
+    body = draft.get('body')
+    timeout = int(commit_context.get('timeout', 30))
+    if not url:
+        raise ValueError('No URL for custom API commit')
+    if body is not None and not isinstance(body, (str, bytes)):
+        body = json.dumps(body)
+    resp = http_requests.request(method, url, headers=headers, data=body, timeout=timeout)
+    resp.raise_for_status()
+    try:
+        api_json = resp.json()
+    except Exception:
+        api_json = {'raw': resp.text[:2000]}
+    out = {**commit_context.get('merge_output', {}), 'api_response': api_json}
+    sse = [
+        {
+            'type': 'text',
+            'content': f'Custom API call completed ({resp.status_code}).',
+        }
+    ]
+    return out, sse, {}
+
+
+COMMIT_REGISTRY = {
+    KIND_TASK: _commit_task,
+    KIND_MIRO_BOARD: _commit_miro_board,
+    KIND_CALENDAR_EVENT: _commit_calendar_events,
+    KIND_FORWARD_MESSAGE: _commit_forward,
+    KIND_DISTRIBUTE_BULK: _commit_distribute,
+    KIND_CUSTOM_API: _commit_custom_api,
+}
+
+
+def run_commit(
+    *,
+    orchestrator,
+    kind: str,
+    draft: dict,
+    destination: dict | None,
+    commit_context: dict,
+) -> ExternalCommitResult:
+    fn = COMMIT_REGISTRY.get(kind)
+    if not fn:
+        raise ValueError(f'Unknown external outcome kind: {kind}')
+    output_data, sse_events, wf_patch = fn(orchestrator, draft, destination, commit_context)
+    return ExternalCommitResult(
+        paused=False,
+        sse_events=sse_events,
+        pending_id=None,
+        output_data=output_data,
+        workflow_run_patch=wf_patch or {},
+    )
+
+
+def request_external_commit(
+    *,
+    orchestrator,
+    workflow_run,
+    step_execution,
+    kind: str,
+    draft: dict,
+    commit_context: dict,
+) -> ExternalCommitResult:
+    """
+    If session.approval_required: create pending row and return paused=True.
+    Otherwise run commit immediately.
+    """
+    from .models import AgentPendingExternalApproval
+
+    session = orchestrator.session
+    session.refresh_from_db(fields=['approval_required'])
+    project = orchestrator.project
+    user = orchestrator.user
+
+    if not session.approval_required:
+        _, default_dest = build_destination_options(
+            kind=kind,
+            session=session,
+            project=project,
+            user=user,
+            draft=draft,
+            commit_context=commit_context,
+        )
+        return run_commit(
+            orchestrator=orchestrator,
+            kind=kind,
+            draft=draft,
+            destination=default_dest,
+            commit_context=commit_context,
+        )
+
+    _dest_opts, default_dest = build_destination_options(
+        kind=kind,
+        session=session,
+        project=project,
+        user=user,
+        draft=draft,
+        commit_context=commit_context,
+    )
+
+    pending = AgentPendingExternalApproval.objects.create(
+        session=session,
+        workflow_run=workflow_run,
+        step_execution=step_execution,
+        kind=kind,
+        status='pending',
+        draft=draft,
+        commit_context=commit_context,
+        destination_options=[],
+        default_destination=default_dest,
+    )
+
+    sse = [
+        {
+            'type': 'approval_request',
+            'content': f'Approval required before {kind.replace("_", " ")}.',
+            'data': {
+                'approval_id': str(pending.id),
+                'kind': kind,
+                'draft': draft,
+            },
+        }
+    ]
+    return ExternalCommitResult(
+        paused=True,
+        sse_events=sse,
+        pending_id=str(pending.id),
+        output_data=None,
+        workflow_run_patch=None,
+    )
+
+
+def resolve_pending(
+    *,
+    orchestrator,
+    pending_id,
+    decision: str,
+    draft: dict | None,
+    destination: dict | None,
+) -> ExternalCommitResult:
+    from .models import AgentPendingExternalApproval
+
+    try:
+        pending = AgentPendingExternalApproval.objects.select_related(
+            'session', 'workflow_run', 'step_execution'
+        ).get(id=pending_id, session=orchestrator.session, is_deleted=False)
+    except AgentPendingExternalApproval.DoesNotExist as e:
+        raise ValueError('Approval request not found.') from e
+
+    if pending.status != 'pending':
+        raise ValueError('Approval is no longer pending')
+
+    if decision == 'reject':
+        pending.status = 'rejected'
+        pending.save(update_fields=['status', 'updated_at'])
+        return ExternalCommitResult(
+            paused=False,
+            sse_events=[
+                {
+                    'type': 'text',
+                    'content': f'Action rejected ({pending.kind}).',
+                    'data': {'approval_id': str(pending.id), 'rejected': True},
+                }
+            ],
+            pending_id=str(pending.id),
+            output_data=None,
+            workflow_run_patch={'rejected': True, 'kind': pending.kind},
+        )
+
+    merged_draft = {**pending.draft, **(draft or {})}
+    # Destination overrides are no longer accepted from the client.
+    dest = pending.default_destination
+    result = run_commit(
+        orchestrator=orchestrator,
+        kind=pending.kind,
+        draft=merged_draft,
+        destination=dest,
+        commit_context=pending.commit_context,
+    )
+    pending.status = 'approved'
+    pending.save(update_fields=['status', 'updated_at'])
+    return ExternalCommitResult(
+        paused=False,
+        sse_events=result.sse_events,
+        pending_id=str(pending.id),
+        output_data=result.output_data,
+        workflow_run_patch=result.workflow_run_patch,
+    )

--- a/backend/agent/executors.py
+++ b/backend/agent/executors.py
@@ -6,7 +6,6 @@ the logic for that particular action.
 """
 import logging
 import os
-import requests as http_requests
 
 logger = logging.getLogger(__name__)
 
@@ -14,11 +13,19 @@ logger = logging.getLogger(__name__)
 class StepResult:
     """Unified return type for all executors."""
 
-    def __init__(self, success, output_data=None, error=None, sse_events=None):
+    def __init__(
+        self,
+        success,
+        output_data=None,
+        error=None,
+        sse_events=None,
+        pause_external_approval=False,
+    ):
         self.success = success
         self.output_data = output_data
         self.error = error
         self.sse_events = sse_events or []
+        self.pause_external_approval = pause_external_approval
 
 
 class BaseStepExecutor:
@@ -29,6 +36,7 @@ class BaseStepExecutor:
         self.workflow_run = workflow_run
         self.orchestrator = orchestrator
         self.config = step.config or {}
+        self.step_execution = None  # set by workflow engine before execute()
 
     def execute(self, input_data: dict) -> StepResult:
         raise NotImplementedError
@@ -195,15 +203,10 @@ class CreateDecisionExecutor(BaseStepExecutor):
 
 
 class CreateTasksExecutor(BaseStepExecutor):
-    """Creates Tasks from analysis recommended_tasks.
-
-    Mirrors the logic in AgentOrchestrator.create_tasks_from_analysis().
-    """
+    """Creates Tasks from analysis recommended_tasks via the external approval gate."""
 
     def execute(self, input_data):
-        from django.contrib.contenttypes.models import ContentType
-        from decision.models import Decision
-        from task.models import Task
+        from .approval_gate import KIND_TASK, request_external_commit
 
         analysis = input_data.get('analysis_result')
         if not analysis:
@@ -211,51 +214,43 @@ class CreateTasksExecutor(BaseStepExecutor):
 
         try:
             tasks_data = analysis.get('recommended_tasks', [])
-            user = self.orchestrator.user
-            project = self.orchestrator.project
+            if not tasks_data:
+                return StepResult(success=False, error='No recommended_tasks in analysis.')
+
             decision = self.workflow_run.decision
+            draft = {'recommended_tasks': tasks_data}
+            commit_context = {
+                'input_data': input_data,
+                'analysis_result': analysis,
+                'decision_id': decision.id if decision else None,
+            }
+            gate = request_external_commit(
+                orchestrator=self.orchestrator,
+                workflow_run=self.workflow_run,
+                step_execution=self.step_execution,
+                kind=KIND_TASK,
+                draft=draft,
+                commit_context=commit_context,
+            )
 
-            if decision:
-                decision_ct = ContentType.objects.get_for_model(Decision)
-                link_kwargs = {
-                    'content_type': decision_ct,
-                    'object_id': str(decision.id),
-                }
-                desc_suffix = f" (Decision: {decision.title})"
-            else:
-                link_kwargs = {}
-                desc_suffix = ""
-
-            created_ids = []
-            for task_data in tasks_data:
-                summary = task_data.get('summary', 'AI Agent Generated Task')[:255]
-                ai_description = (task_data.get('description') or '').strip()
-                description = ai_description or f"Auto-generated from AI analysis{desc_suffix}"
-                task = Task.objects.create(
-                    summary=summary,
-                    description=description,
-                    type=task_data.get('type', 'optimization'),
-                    priority=task_data.get('priority', 'MEDIUM'),
-                    project=project,
-                    owner=user,
-                    **link_kwargs,
+            if gate.paused:
+                return StepResult(
+                    success=True,
+                    output_data=input_data,
+                    sse_events=gate.sse_events,
+                    pause_external_approval=True,
                 )
-                created_ids.append(task.id)
 
+            wf = gate.workflow_run_patch or {}
+            created_ids = wf.get('created_tasks') or []
             self.workflow_run.created_tasks = created_ids
             self.workflow_run.save(update_fields=['created_tasks'])
 
+            base_out = gate.output_data or {**input_data, 'analysis_result': analysis}
             return StepResult(
                 success=True,
-                output_data={**input_data, 'created_task_ids': created_ids},
-                sse_events=[{
-                    'type': 'task_created',
-                    'content': f'Created {len(created_ids)} tasks.',
-                    'data': {
-                        'task_ids': created_ids,
-                        'decision_id': decision.id if decision else None,
-                    },
-                }],
+                output_data={**base_out, 'created_task_ids': created_ids},
+                sse_events=gate.sse_events,
             )
         except Exception as e:
             logger.exception("CreateTasksExecutor failed")
@@ -302,6 +297,7 @@ class CreateMiroBoardExecutor(BaseStepExecutor):
     """Create a persisted Miro board from a validated snapshot."""
 
     def execute(self, input_data):
+        from .approval_gate import KIND_MIRO_BOARD, request_external_commit
         from .miro_board_service import create_board_from_snapshot
 
         snapshot = input_data.get('miro_snapshot') or self.workflow_run.miro_snapshot
@@ -309,29 +305,74 @@ class CreateMiroBoardExecutor(BaseStepExecutor):
             return StepResult(success=False, error='No miro_snapshot available for board creation')
 
         try:
-            board, persisted_snapshot = create_board_from_snapshot(
-                project=self.orchestrator.project,
-                session=self.orchestrator.session,
-                workflow_run=self.workflow_run,
-                snapshot=snapshot,
-            )
+            # For sessions that don't require approval, persist immediately.
+            # This also keeps unit tests (which use stub workflow runs) isolated from DB lookups.
+            if not bool(getattr(self.orchestrator.session, 'approval_required', False)):
+                board, persisted_snapshot = create_board_from_snapshot(
+                    project=self.orchestrator.project,
+                    session=self.orchestrator.session,
+                    workflow_run=self.workflow_run,
+                    snapshot=snapshot,
+                )
+                self.workflow_run.miro_board = board
+                self.workflow_run.miro_snapshot = persisted_snapshot
+                self.workflow_run.save(update_fields=['miro_board', 'miro_snapshot'])
+                return StepResult(
+                    success=True,
+                    output_data={
+                        **input_data,
+                        'miro_snapshot': persisted_snapshot,
+                        'miro_board_id': str(getattr(board, 'id', None)),
+                    },
+                    sse_events=[{
+                        'type': 'miro_board_created',
+                        'content': f'Miro board created: {getattr(board, "title", "")}'.strip(),
+                        'data': {'board_id': str(getattr(board, 'id', None))},
+                    }],
+                )
 
-            self.workflow_run.miro_board = board
-            self.workflow_run.miro_snapshot = persisted_snapshot
+            draft = {'snapshot': snapshot}
+            commit_context = {
+                'workflow_run_id': str(self.workflow_run.id),
+                'merge_output': {**input_data},
+            }
+            gate = request_external_commit(
+                orchestrator=self.orchestrator,
+                workflow_run=self.workflow_run,
+                step_execution=self.step_execution,
+                kind=KIND_MIRO_BOARD,
+                draft=draft,
+                commit_context=commit_context,
+            )
+            if gate.paused:
+                return StepResult(
+                    success=True,
+                    output_data=input_data,
+                    sse_events=gate.sse_events,
+                    pause_external_approval=True,
+                )
+
+            wf = gate.workflow_run_patch or {}
+            bid = wf.get('miro_board_id')
+            persisted_snapshot = wf.get('miro_snapshot')
+            if bid:
+                # Only hit DB if we actually need to attach the persisted Board object.
+                from miro.models import Board
+
+                self.workflow_run.miro_board = Board.objects.get(id=bid)
+            if persisted_snapshot is not None:
+                self.workflow_run.miro_snapshot = persisted_snapshot
             self.workflow_run.save(update_fields=['miro_board', 'miro_snapshot'])
 
             return StepResult(
                 success=True,
-                output_data={
+                output_data=gate.output_data
+                or {
                     **input_data,
                     'miro_snapshot': persisted_snapshot,
-                    'miro_board_id': str(board.id),
+                    'miro_board_id': bid,
                 },
-                sse_events=[{
-                    'type': 'miro_board_created',
-                    'content': f'Miro board created: {board.title}',
-                    'data': {'board_id': str(board.id)},
-                }],
+                sse_events=gate.sse_events,
             )
         except Exception as e:
             logger.exception("CreateMiroBoardExecutor failed")
@@ -360,6 +401,8 @@ class CustomAPIExecutor(BaseStepExecutor):
     def execute(self, input_data):
         import json
 
+        from .approval_gate import KIND_CUSTOM_API, request_external_commit
+
         method = self.config.get('method', 'POST').upper()
         url = self.config.get('url')
         headers = self.config.get('headers', {})
@@ -374,18 +417,34 @@ class CustomAPIExecutor(BaseStepExecutor):
             if body_template:
                 body = json.dumps(input_data) if body_template == '__input__' else body_template
 
-            resp = http_requests.request(
-                method, url, headers=headers, data=body, timeout=timeout,
+            draft = {'method': method, 'url': url, 'headers': dict(headers), 'body': body}
+            commit_context = {
+                'method': method,
+                'url': url,
+                'headers': dict(headers),
+                'timeout': timeout,
+                'merge_output': {**input_data},
+            }
+            gate = request_external_commit(
+                orchestrator=self.orchestrator,
+                workflow_run=self.workflow_run,
+                step_execution=self.step_execution,
+                kind=KIND_CUSTOM_API,
+                draft=draft,
+                commit_context=commit_context,
             )
-            resp.raise_for_status()
+            if gate.paused:
+                return StepResult(
+                    success=True,
+                    output_data=input_data,
+                    sse_events=gate.sse_events,
+                    pause_external_approval=True,
+                )
 
             return StepResult(
                 success=True,
-                output_data={**input_data, 'api_response': resp.json()},
-                sse_events=[{
-                    'type': 'text',
-                    'content': f'Custom API call completed ({resp.status_code}).',
-                }],
+                output_data=gate.output_data or {**input_data},
+                sse_events=gate.sse_events,
             )
         except Exception as e:
             logger.exception("CustomAPIExecutor failed")

--- a/backend/agent/migrations/0013_agentsession_approval_required_and_external_approval.py
+++ b/backend/agent/migrations/0013_agentsession_approval_required_and_external_approval.py
@@ -1,0 +1,125 @@
+import uuid
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("agent", "0012_remove_importeddatafield_unique_imported_data_field_position_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="agentsession",
+            name="approval_required",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.CreateModel(
+            name="AgentPendingExternalApproval",
+            fields=[
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("is_deleted", models.BooleanField(default=False)),
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                (
+                    "kind",
+                    models.CharField(
+                        max_length=64,
+                        help_text="Registry key: task, miro_board, calendar_event, forward_message, distribute_bulk, custom_api, email",
+                    ),
+                ),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("pending", "Pending"),
+                            ("approved", "Approved"),
+                            ("rejected", "Rejected"),
+                        ],
+                        default="pending",
+                        max_length=20,
+                    ),
+                ),
+                ("draft", models.JSONField(default=dict)),
+                ("commit_context", models.JSONField(default=dict)),
+                ("destination_options", models.JSONField(default=list)),
+                ("default_destination", models.JSONField(blank=True, null=True)),
+                (
+                    "session",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="pending_external_approvals",
+                        to="agent.agentsession",
+                    ),
+                ),
+                (
+                    "workflow_run",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="pending_external_approvals",
+                        to="agent.agentworkflowrun",
+                    ),
+                ),
+                (
+                    "step_execution",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="pending_external_approvals",
+                        to="agent.agentstepexecution",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+            },
+        ),
+        migrations.AlterField(
+            model_name="agentworkflowrun",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("analyzing", "Analyzing"),
+                    ("awaiting_confirmation", "Awaiting Confirmation"),
+                    ("awaiting_external_approval", "Awaiting External Approval"),
+                    ("creating_decision", "Creating Decision"),
+                    ("creating_tasks", "Creating Tasks"),
+                    ("completed", "Completed"),
+                    ("failed", "Failed"),
+                ],
+                default="analyzing",
+                max_length=40,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="agentmessage",
+            name="message_type",
+            field=models.CharField(
+                choices=[
+                    ("text", "Text"),
+                    ("analysis", "Analysis"),
+                    ("decision_draft", "Decision Draft"),
+                    ("task_created", "Task Created"),
+                    ("confirmation_request", "Confirmation Request"),
+                    ("approval_request", "Approval Request"),
+                    ("follow_up_prompt", "Follow-up Prompt"),
+                    ("error", "Error"),
+                ],
+                default="text",
+                max_length=30,
+            ),
+        ),
+    ]

--- a/backend/agent/models.py
+++ b/backend/agent/models.py
@@ -24,6 +24,10 @@ class AgentSession(TimeStampedModel):
     )
     title = models.CharField(max_length=255, blank=True, default='')
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='active')
+    approval_required = models.BooleanField(
+        default=False,
+        help_text="When true, external side effects require user approval before commit.",
+    )
 
     class Meta:
         ordering = ['-created_at']
@@ -44,6 +48,7 @@ class AgentMessage(TimeStampedModel):
         ('decision_draft', 'Decision Draft'),
         ('task_created', 'Task Created'),
         ('confirmation_request', 'Confirmation Request'),
+        ('approval_request', 'Approval Request'),
         ('follow_up_prompt', 'Follow-up Prompt'),
         ('error', 'Error'),
     ]
@@ -455,6 +460,7 @@ class AgentWorkflowRun(TimeStampedModel):
     STATUS_CHOICES = [
         ('analyzing', 'Analyzing'),
         ('awaiting_confirmation', 'Awaiting Confirmation'),
+        ('awaiting_external_approval', 'Awaiting External Approval'),
         ('creating_decision', 'Creating Decision'),
         ('creating_tasks', 'Creating Tasks'),
         ('completed', 'Completed'),
@@ -488,7 +494,7 @@ class AgentWorkflowRun(TimeStampedModel):
         blank=True,
         related_name='workflow_runs',
     )
-    status = models.CharField(max_length=30, choices=STATUS_CHOICES, default='analyzing')
+    status = models.CharField(max_length=40, choices=STATUS_CHOICES, default='analyzing')
     current_step_order = models.PositiveIntegerField(null=True, blank=True)
     analysis_result = models.JSONField(null=True, blank=True)
     created_tasks = models.JSONField(default=list, blank=True)
@@ -548,3 +554,49 @@ class AgentStepExecution(TimeStampedModel):
 
     def __str__(self):
         return f"Run {self.workflow_run_id} - Step {self.step_order}: {self.status}"
+
+
+class AgentPendingExternalApproval(TimeStampedModel):
+    """Human-in-the-loop gate before agent commits an external side effect."""
+
+    STATUS_CHOICES = [
+        ('pending', 'Pending'),
+        ('approved', 'Approved'),
+        ('rejected', 'Rejected'),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    session = models.ForeignKey(
+        AgentSession,
+        on_delete=models.CASCADE,
+        related_name='pending_external_approvals',
+    )
+    workflow_run = models.ForeignKey(
+        AgentWorkflowRun,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name='pending_external_approvals',
+    )
+    step_execution = models.ForeignKey(
+        AgentStepExecution,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name='pending_external_approvals',
+    )
+    kind = models.CharField(
+        max_length=64,
+        help_text='Registry key, e.g. task, miro_board, calendar_event, forward_message.',
+    )
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='pending')
+    draft = models.JSONField(default=dict)
+    commit_context = models.JSONField(default=dict)
+    destination_options = models.JSONField(default=list)
+    default_destination = models.JSONField(null=True, blank=True)
+
+    class Meta:
+        ordering = ['-created_at']
+
+    def __str__(self):
+        return f"PendingExternalApproval {self.id} ({self.kind}) {self.status}"

--- a/backend/agent/serializers.py
+++ b/backend/agent/serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 from .models import (
     AgentSession, AgentMessage, AgentWorkflowRun, ImportedCSVFile,
     AgentWorkflowDefinition, AgentWorkflowStep, AgentStepExecution,
+    AgentPendingExternalApproval,
 )
 
 
@@ -19,7 +20,7 @@ class AgentSessionListSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = AgentSession
-        fields = ['id', 'title', 'status', 'created_at', 'message_count']
+        fields = ['id', 'title', 'status', 'approval_required', 'created_at', 'message_count']
         read_only_fields = ['id', 'created_at']
 
     def get_message_count(self, obj):
@@ -33,7 +34,10 @@ class AgentSessionDetailSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = AgentSession
-        fields = ['id', 'title', 'status', 'created_at', 'updated_at', 'messages', 'follow_up_available', 'follow_up_started']
+        fields = [
+            'id', 'title', 'status', 'approval_required',
+            'created_at', 'updated_at', 'messages', 'follow_up_available', 'follow_up_started',
+        ]
         read_only_fields = ['id', 'status', 'created_at', 'updated_at']
 
     def get_follow_up_available(self, obj):
@@ -51,6 +55,22 @@ class AgentSessionDetailSerializer(serializers.ModelSerializer):
             chat_followed_up=False,
             is_deleted=False,
         ).exists()
+
+
+class AgentPendingExternalApprovalSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AgentPendingExternalApproval
+        fields = [
+            'id', 'kind', 'status', 'draft', 'destination_options',
+            'default_destination', 'created_at',
+        ]
+        read_only_fields = fields
+
+
+class ResolveExternalApprovalSerializer(serializers.Serializer):
+    decision = serializers.ChoiceField(choices=['approve', 'reject'])
+    draft = serializers.JSONField(required=False, default=dict)
+    destination = serializers.JSONField(required=False, allow_null=True)
 
 
 class AgentWorkflowRunSerializer(serializers.ModelSerializer):
@@ -89,10 +109,18 @@ class ChatInputSerializer(serializers.Serializer):
             'analyze', 'confirm_decision', 'create_tasks', 'generate_miro',
             'distribute_message', 'start_follow_up', 'cancel_follow_up',
             'confirm_columns',
+            'resolve_external_approval',
         ],
         required=False,
         allow_null=True,
     )
+    approval_id = serializers.UUIDField(required=False, allow_null=True)
+    approval_decision = serializers.ChoiceField(
+        choices=['approve', 'reject'],
+        required=False,
+        allow_null=True,
+    )
+    approval_draft = serializers.JSONField(required=False, allow_null=True)
     calendar_context = serializers.JSONField(required=False, allow_null=True)
     workflow_id = serializers.UUIDField(required=False, allow_null=True)
     # User-approved column mapping for confirm_columns action.

--- a/backend/agent/services.py
+++ b/backend/agent/services.py
@@ -21,6 +21,11 @@ from .agent_utils import json_input, serialize_agent_messages
 
 logger = logging.getLogger(__name__)
 
+# Legacy SSE + persisted assistant row — distinct from the board-ready message Celery sends later.
+MIRO_LEGACY_BG_QUEUED_MESSAGE = (
+    "Queued Miro board generation — we'll notify you here when the board is ready."
+)
+
 
 def _create_agent_status_message(session, content, *, event_type, message_type='text', **metadata):
     if not isinstance(session, AgentSession):
@@ -470,30 +475,54 @@ def _call_gemini_chat(
 
 
 def _generate_miro_board_for_workflow_run(orchestrator, workflow_run):
-    """Generate and persist a Miro board from an existing workflow run."""
-    from .miro_board_service import create_board_from_snapshot
+    """Generate Miro snapshot (Gemini), then persist (optionally via approval gate)."""
     from .miro_generation import (
         build_miro_generation_context_from_run,
         call_gemini_miro_generator,
     )
+    from .approval_gate import KIND_MIRO_BOARD, request_external_commit
+    from .miro_board_service import create_board_from_snapshot
 
     context = build_miro_generation_context_from_run(
         session=orchestrator.session,
         workflow_run=workflow_run,
     )
-    snapshot = call_gemini_miro_generator(context, user_id=orchestrator.user.id)
-    board, persisted_snapshot = create_board_from_snapshot(
-        project=orchestrator.project,
-        session=orchestrator.session,
-        workflow_run=workflow_run,
-        snapshot=snapshot,
+    snapshot = call_gemini_miro_generator(
+        context,
+        user_id=str(orchestrator.user.id),
     )
 
-    workflow_run.miro_snapshot = persisted_snapshot
-    workflow_run.miro_board = board
-    workflow_run.save(update_fields=['miro_snapshot', 'miro_board'])
+    # If approval isn't required for the session, persist immediately without gating.
+    if not bool(getattr(orchestrator.session, 'approval_required', False)):
+        board, persisted_snapshot = create_board_from_snapshot(
+            project=orchestrator.project,
+            session=orchestrator.session,
+            workflow_run=workflow_run,
+            snapshot=snapshot,
+        )
+        workflow_run.miro_snapshot = persisted_snapshot
+        workflow_run.miro_board = board
+        workflow_run.save(update_fields=['miro_snapshot', 'miro_board'])
+        return persisted_snapshot, board
 
-    return persisted_snapshot, board
+    gate = request_external_commit(
+        orchestrator=orchestrator,
+        workflow_run=workflow_run,
+        step_execution=None,
+        kind=KIND_MIRO_BOARD,
+        draft={'snapshot': snapshot},
+        commit_context={
+            'workflow_run_id': str(workflow_run.id),
+            'merge_output': {},
+        },
+    )
+    if gate.paused:
+        workflow_run.miro_snapshot = snapshot
+        workflow_run.save(update_fields=['miro_snapshot', 'updated_at'])
+        return snapshot, None
+
+    workflow_run.refresh_from_db()
+    return workflow_run.miro_snapshot, workflow_run.miro_board
 
 
 def _enqueue_miro_generation_for_workflow_run(orchestrator, workflow_run):
@@ -506,6 +535,8 @@ def _enqueue_miro_generation_for_workflow_run(orchestrator, workflow_run):
         orchestrator.session.id,
     )
     generate_miro_board_for_workflow_run_task.delay(str(workflow_run.id))
+
+
 def _get_or_create_bot_private_chat(bot, target_user, project):
     """Find or create a private chat with exactly 2 participants: bot and target.
 
@@ -626,13 +657,104 @@ class AgentOrchestrator:
         self.project = project
         self.session = session
 
+    def resolve_external_approval_stream(
+        self,
+        approval_id,
+        decision,
+        draft=None,
+        destination=None,
+    ):
+        """Complete or reject a pending external commit; resume workflow when applicable."""
+        from django.utils import timezone as tz
+
+        from .approval_gate import resolve_pending
+        from .models import AgentPendingExternalApproval
+        from miro.models import Board
+
+        try:
+            result = resolve_pending(
+                orchestrator=self,
+                pending_id=str(approval_id),
+                decision=decision,
+                draft=draft or {},
+                destination=destination,
+            )
+        except ValueError as e:
+            yield {'type': 'error', 'content': str(e)}
+            return
+
+        for ev in result.sse_events:
+            yield ev
+
+        try:
+            pending = AgentPendingExternalApproval.objects.get(
+                id=approval_id, session=self.session, is_deleted=False,
+            )
+        except AgentPendingExternalApproval.DoesNotExist:
+            return
+
+        wr = pending.workflow_run
+        ex = pending.step_execution
+
+        if decision == 'reject':
+            if wr:
+                wr.status = 'failed'
+                wr.error_message = 'External action rejected by user.'
+                wr.save(update_fields=['status', 'error_message', 'updated_at'])
+            if ex:
+                ex.status = 'failed'
+                ex.error_message = 'Rejected by user'
+                ex.completed_at = tz.now()
+                ex.save(update_fields=['status', 'error_message', 'completed_at', 'updated_at'])
+            return
+
+        if ex and wr and wr.workflow_definition_id:
+            ex.status = 'completed'
+            ex.output_data = result.output_data
+            ex.completed_at = tz.now()
+            ex.save(update_fields=['status', 'output_data', 'completed_at', 'updated_at'])
+
+            wf_patch = result.workflow_run_patch or {}
+            uf = ['status', 'current_step_order', 'updated_at', 'error_message']
+            wr.error_message = None
+            if 'created_tasks' in wf_patch:
+                wr.created_tasks = wf_patch['created_tasks']
+                uf.append('created_tasks')
+            if wf_patch.get('miro_board_id'):
+                wr.miro_board = Board.objects.get(id=wf_patch['miro_board_id'])
+                uf.append('miro_board')
+            if wf_patch.get('miro_snapshot') is not None:
+                wr.miro_snapshot = wf_patch['miro_snapshot']
+                uf.append('miro_snapshot')
+
+            wr.status = 'analyzing'
+            wr.current_step_order = ex.step_order + 1
+            wr.save(update_fields=uf)
+
+            yield from self._execute_steps(wr, result.output_data or {})
+
     def handle_message(self, message, spreadsheet_id=None, csv_filename=None,
                        action=None, file_id=None, calendar_context=None,
-                       workflow_id=None, column_mapping=None):
+                       workflow_id=None, column_mapping=None,
+                       approval_id=None, approval_decision=None,
+                       approval_draft=None):
         """Main entry point. Routes calendar context first, then workflow engine or legacy logic.
 
         Yields SSE chunks as dicts.
         """
+        if action == 'resolve_external_approval':
+            if not approval_id or not approval_decision:
+                yield {'type': 'error', 'content': 'approval_id and approval_decision are required.'}
+                return
+            yield from self.resolve_external_approval_stream(
+                approval_id,
+                approval_decision,
+                draft=approval_draft,
+                destination=None,
+            )
+            yield {'type': 'done'}
+            return
+
         # --- Calendar context takes priority over all other routing ---
         if calendar_context:
             yield from self.answer_calendar_question(message, calendar_context)
@@ -976,31 +1098,55 @@ class AgentOrchestrator:
             events_to_create = []
             had_creation_intent = False
 
-        # Create all suggested events
         org_id = getattr(self.user, 'organization_id', None)
         created_count = 0
         failed_count = 0
+        calendar_refresh_emitted = False
         if events_to_create and org_id:
-            for event_spec in events_to_create:
-                if not isinstance(event_spec, dict):
-                    continue
-                event_id_created = self._create_calendar_event(org_id, event_spec, user_tz=user_tz)
-                if event_id_created:
-                    created_count += 1
-                else:
-                    failed_count += 1
+            from .approval_gate import KIND_CALENDAR_EVENT, request_external_commit
 
-            if created_count:
-                answer_text += f"\n\n✅ {created_count} calendar event{'s' if created_count != 1 else ''} created successfully."
-            if failed_count:
-                answer_text += f"\n⚠️ {failed_count} event{'s' if failed_count != 1 else ''} could not be created automatically."
+            draft_events = [e for e in events_to_create if isinstance(e, dict)]
+            gate = request_external_commit(
+                orchestrator=self,
+                workflow_run=None,
+                step_execution=None,
+                kind=KIND_CALENDAR_EVENT,
+                draft={'events': draft_events},
+                commit_context={
+                    'organization_id': str(org_id),
+                    'user_timezone': user_tz_name,
+                },
+            )
+            for ev in gate.sse_events:
+                yield ev
+                if ev.get('type') == 'calendar_updated':
+                    calendar_refresh_emitted = True
+            if gate.paused:
+                answer_text += (
+                    '\n\n⏸ Event creation is waiting for your approval '
+                    'in the approval panel.'
+                )
+            else:
+                wf = gate.workflow_run_patch or {}
+                created_ids = wf.get('created_event_ids') or []
+                created_count = len(created_ids)
+                failed_count = max(0, len(draft_events) - created_count)
+                if created_count:
+                    answer_text += (
+                        f"\n\n✅ {created_count} calendar event"
+                        f"{'s' if created_count != 1 else ''} created successfully."
+                    )
+                if failed_count:
+                    answer_text += (
+                        f"\n\n⚠️ {failed_count} event"
+                        f"{'s' if failed_count != 1 else ''} could not be created automatically."
+                    )
 
         yield {
             "type": "text",
             "content": answer_text,
         }
-        if created_count:
-            # Notify the calendar page to refresh
+        if created_count and not calendar_refresh_emitted:
             yield {"type": "calendar_updated"}
         elif not had_creation_intent:
             # Only invite when the user asked a general calendar question,
@@ -1259,23 +1405,20 @@ class AgentOrchestrator:
             return
 
         forwards = [{"username": m["username"], "content": content} for m in members]
-        results = _forward_to_users(forwards, sender, project)
+        from .approval_gate import KIND_DISTRIBUTE_BULK, request_external_commit
 
-        sent = [r for r in results if r.get("status") == "sent"]
-        failed = [r for r in results if r.get("status") != "sent"]
-
-        summary_parts = []
-        if sent:
-            names = ", ".join(r["username"] for r in sent)
-            summary_parts.append(f"Message sent to {len(sent)} member(s): {names}.")
-        if failed:
-            names = ", ".join(r["username"] for r in failed)
-            summary_parts.append(f"Failed to send to: {names}.")
-
-        yield {
-            "type": "text",
-            "content": " ".join(summary_parts) if summary_parts else "Distribution complete.",
-        }
+        gate = request_external_commit(
+            orchestrator=self,
+            workflow_run=workflow_run,
+            step_execution=None,
+            kind=KIND_DISTRIBUTE_BULK,
+            draft={'forwards': forwards, 'body': content},
+            commit_context={},
+        )
+        for ev in gate.sse_events:
+            yield ev
+        if gate.paused:
+            return
 
     def create_decision_draft(self, analysis_result, workflow_run=None):
         """Create a Decision draft with Signals and Options from analysis."""
@@ -1373,41 +1516,31 @@ class AgentOrchestrator:
             yield {"type": "error", "content": "No recommended tasks found in analysis."}
             return
 
-        # If a decision exists, link tasks to it; otherwise leave unlinked
         decision = workflow_run.decision
-        if decision:
-            decision_ct = ContentType.objects.get_for_model(Decision)
-            link_kwargs = {
-                "content_type": decision_ct,
-                "object_id": str(decision.id),
-            }
-            desc_suffix = f" (Decision: {decision.title})"
-        else:
-            link_kwargs = {}
-            desc_suffix = ""
+        from .approval_gate import KIND_TASK, request_external_commit
 
-        task_ids = []
-        for task_data in recommended_tasks:
-            summary = task_data.get("summary", "AI Agent Generated Task")[:255]
-            task = Task.objects.create(
-                summary=summary,
-                description=f"Auto-generated from AI analysis{desc_suffix}",
-                type=task_data.get("type", "optimization"),
-                priority=task_data.get("priority", "MEDIUM"),
-                project=self.project,
-                owner=self.user,
-                **link_kwargs,
-            )
-            task_ids.append(task.id)
+        draft = {'recommended_tasks': recommended_tasks}
+        commit_context = {
+            'input_data': {'analysis_result': analysis},
+            'analysis_result': analysis,
+            'decision_id': decision.id if decision else None,
+        }
+        gate = request_external_commit(
+            orchestrator=self,
+            workflow_run=workflow_run,
+            step_execution=None,
+            kind=KIND_TASK,
+            draft=draft,
+            commit_context=commit_context,
+        )
+        for ev in gate.sse_events:
+            yield ev
+        if gate.paused:
+            return
 
+        task_ids = (gate.workflow_run_patch or {}).get('created_tasks') or []
         workflow_run.created_tasks = task_ids
         workflow_run.save(update_fields=['created_tasks'])
-
-        yield {
-            "type": "task_created",
-            "content": f"Created {len(task_ids)} tasks.",
-            "data": {"task_ids": task_ids, "decision_id": decision.id if decision else None},
-        }
 
         workflow_run.status = 'completed'
         workflow_run.save(update_fields=['status'])
@@ -1542,9 +1675,19 @@ class AgentOrchestrator:
             }
 
             executor = get_executor(step, workflow_run, self)
+            executor.step_execution = execution
             result = executor.execute(current_data)
 
             if result.success:
+                if getattr(result, 'pause_external_approval', False):
+                    execution.status = 'awaiting'
+                    execution.save(update_fields=['status', 'updated_at'])
+                    workflow_run.status = 'awaiting_external_approval'
+                    workflow_run.save(update_fields=['status', 'updated_at'])
+                    for event in result.sse_events:
+                        yield event
+                    return
+
                 execution.status = 'completed'
                 execution.output_data = result.output_data
                 execution.completed_at = tz.now()
@@ -1576,6 +1719,50 @@ class AgentOrchestrator:
 
         workflow_run.status = 'completed'
         workflow_run.save()
+
+    def _legacy_start_miro_background_if_needed(self, workflow_run):
+        """Enqueue Celery job and persist started row at most once per workflow run."""
+        from django.db import transaction
+
+        from .models import AgentMessage, AgentWorkflowRun
+
+        wr_pk = workflow_run.pk
+        with transaction.atomic():
+            # IMPORTANT: do not join the nullable `miro_board` FK while taking a row lock.
+            # Postgres rejects `FOR UPDATE` on the nullable side of an outer join.
+            locked = AgentWorkflowRun.objects.select_for_update().get(pk=wr_pk)
+
+            if getattr(locked, 'miro_board_id', None):
+                # Fetch title without a locking join.
+                title = ''
+                try:
+                    from miro.models import Board
+                    board = Board.objects.filter(id=locked.miro_board_id).only('title').first()
+                    title = (getattr(board, 'title', None) or '') if board else ''
+                except Exception:
+                    title = ''
+                return 'already_exists', locked, title
+
+            dup = AgentMessage.objects.filter(
+                session=self.session,
+                role='assistant',
+                metadata__contains={
+                    'event_type': 'miro_generation_started',
+                    'workflow_run_id': str(locked.id),
+                },
+            ).exists()
+
+            if dup:
+                return 'already_started', locked, None
+
+            _enqueue_miro_generation_for_workflow_run(self, locked)
+            _create_agent_status_message(
+                self.session,
+                MIRO_LEGACY_BG_QUEUED_MESSAGE,
+                event_type='miro_generation_started',
+                workflow_run_id=str(locked.id),
+            )
+            return 'started', locked, None
 
     def _resume_workflow(self, workflow_run, extra_input=None):
         """Resume a paused workflow from the last completed step's output.
@@ -1610,33 +1797,35 @@ class AgentOrchestrator:
             if not workflow_run or not workflow_run.analysis_result:
                 yield {"type": "error", "content": "No analysis found to generate a Miro board from."}
                 return
-            if getattr(workflow_run, "miro_board_id", None):
+            try:
+                outcome, locked_run, board_title = self._legacy_start_miro_background_if_needed(
+                    workflow_run
+                )
+            except Exception as e:
+                logger.exception(
+                    "Failed to enqueue legacy Miro generation for workflow_run=%s",
+                    getattr(workflow_run, 'id', workflow_run),
+                )
+                yield {"type": "error", "content": f"Failed to start Miro generation: {e}"}
+                return
+
+            if outcome == 'already_exists':
                 logger.info(
                     "Generate Miro requested but board already exists for workflow_run=%s board=%s",
-                    workflow_run.id,
-                    workflow_run.miro_board_id,
+                    locked_run.id,
+                    locked_run.miro_board_id,
                 )
                 yield {
                     "type": "text",
-                    "content": f"Miro board already exists: {workflow_run.miro_board.title}",
+                    "content": f"Miro board already exists: {board_title}",
                 }
                 return
-            try:
-                _enqueue_miro_generation_for_workflow_run(self, workflow_run)
-                _create_agent_status_message(
-                    self.session,
-                    "Miro board generation started in background.",
-                    event_type="miro_generation_started",
-                    workflow_run_id=str(workflow_run.id),
-                )
-                yield {
-                    "type": "miro_status",
-                    "content": "Miro board generation started in background.",
-                    "data": {"workflow_run_id": str(workflow_run.id), "status": "running"},
-                }
-            except Exception as e:
-                logger.exception("Failed to enqueue legacy Miro generation for workflow_run=%s", workflow_run.id)
-                yield {"type": "error", "content": f"Failed to start Miro generation: {e}"}
+
+            yield {
+                "type": "miro_status",
+                "content": MIRO_LEGACY_BG_QUEUED_MESSAGE,
+                "data": {"workflow_run_id": str(locked_run.id), "status": "running"},
+            }
 
     def _legacy_handle(self, message, spreadsheet_id=None, csv_filename=None,
                        action=None, file_id=None):
@@ -1724,13 +1913,18 @@ class AgentOrchestrator:
                     yield {"type": "text", "content": reply}
 
                     if forwards:
-                        fwd_results = _forward_to_users(forwards, self.user, self.project)
-                        sent = [r["username"] for r in fwd_results if r["status"] == "sent"]
-                        failed = [r["username"] for r in fwd_results if r["status"] != "sent"]
-                        if sent:
-                            yield {"type": "text", "content": f"Message forwarded to: {', '.join(sent)}"}
-                        if failed:
-                            yield {"type": "text", "content": f"Could not forward to: {', '.join(failed)}"}
+                        from .approval_gate import KIND_FORWARD_MESSAGE, request_external_commit
+
+                        gate = request_external_commit(
+                            orchestrator=self,
+                            workflow_run=latest_run,
+                            step_execution=None,
+                            kind=KIND_FORWARD_MESSAGE,
+                            draft={'forwards': forwards},
+                            commit_context={},
+                        )
+                        for ev in gate.sse_events:
+                            yield ev
                 except Exception as e:
                     logger.error(f"Dify chat call failed: {e}")
                     yield {"type": "error", "content": str(e)}

--- a/backend/agent/tasks.py
+++ b/backend/agent/tasks.py
@@ -74,6 +74,28 @@ def generate_miro_board_for_workflow_run_task(workflow_run_id: str):
         )
         return
 
+    if board is None:
+        from .models import AgentPendingExternalApproval
+
+        pend = AgentPendingExternalApproval.objects.filter(
+            workflow_run=workflow_run,
+            status='pending',
+            kind='miro_board',
+        ).order_by('-created_at').first()
+        if pend:
+            AgentMessage.objects.create(
+                session=workflow_run.session,
+                role='assistant',
+                content='Approval required before creating the Miro board.',
+                message_type='approval_request',
+                metadata={
+                    'approval_id': str(pend.id),
+                    'kind': pend.kind,
+                    'draft': pend.draft,
+                },
+            )
+        return
+
     logger.info(
         "Background Miro generation completed for workflow_run=%s board=%s",
         workflow_run_id,

--- a/backend/agent/test_approval_gate.py
+++ b/backend/agent/test_approval_gate.py
@@ -1,0 +1,195 @@
+import pytest
+from django.contrib.auth import get_user_model
+
+from core.models import Organization, Project, ProjectMember
+from decision.models import Decision
+from task.models import Task
+
+from .approval_gate import KIND_TASK, request_external_commit, resolve_pending
+from .models import AgentPendingExternalApproval, AgentSession, AgentWorkflowRun
+from .services import AgentOrchestrator
+
+User = get_user_model()
+
+
+@pytest.fixture
+def approval_org_project_user(db):
+    org = Organization.objects.create(name='Apr Org', slug='apr-org')
+    user = User.objects.create_user(
+        username='apruser',
+        email='apruser@test.com',
+        password='x',
+        organization=org,
+    )
+    user.organization = org
+    user.save()
+    project = Project.objects.create(
+        name='Apr Proj',
+        organization=org,
+        owner=user,
+    )
+    ProjectMember.objects.create(project=project, user=user, is_active=True)
+    return org, project, user
+
+
+@pytest.mark.django_db
+def test_request_external_commit_auto_creates_tasks(approval_org_project_user):
+    _org, project, user = approval_org_project_user
+    session = AgentSession.objects.create(user=user, project=project, approval_required=False)
+    wf = AgentWorkflowRun.objects.create(session=session, status='analyzing')
+    decision = Decision.objects.create(
+        title='D',
+        project=project,
+        project_seq=1,
+        author=user,
+    )
+    wf.decision = decision
+    wf.save()
+    orch = AgentOrchestrator(user, project, session)
+    draft = {
+        'recommended_tasks': [
+            {'summary': 'T1', 'description': 'd', 'type': 'execution', 'priority': 'LOW'},
+        ],
+    }
+    ctx = {
+        'input_data': {'analysis_result': {'recommended_tasks': draft['recommended_tasks']}},
+        'analysis_result': {'recommended_tasks': draft['recommended_tasks']},
+        'decision_id': decision.id,
+    }
+    gate = request_external_commit(
+        orchestrator=orch,
+        workflow_run=wf,
+        step_execution=None,
+        kind=KIND_TASK,
+        draft=draft,
+        commit_context=ctx,
+    )
+    assert gate.paused is False
+    assert gate.workflow_run_patch.get('created_tasks')
+    assert gate.sse_events
+    ev = next((e for e in gate.sse_events if e.get('type') == 'task_created'), None)
+    assert ev is not None
+    data = ev.get('data') or {}
+    assert isinstance(data.get('created_tasks'), list)
+    assert data['created_tasks'][0]['index'] == 0
+    assert data['created_tasks'][0]['summary'] == 'T1'
+    assert isinstance(data['created_tasks'][0]['task_id'], int)
+    assert not AgentPendingExternalApproval.objects.filter(session=session).exists()
+
+
+@pytest.mark.django_db
+def test_request_external_commit_creates_pending_when_required(approval_org_project_user):
+    _org, project, user = approval_org_project_user
+    session = AgentSession.objects.create(user=user, project=project, approval_required=True)
+    wf = AgentWorkflowRun.objects.create(session=session, status='analyzing')
+    orch = AgentOrchestrator(user, project, session)
+    draft = {'recommended_tasks': [{'summary': 'T', 'type': 'execution', 'priority': 'LOW'}]}
+    ctx = {'input_data': {}, 'analysis_result': draft, 'decision_id': None}
+    gate = request_external_commit(
+        orchestrator=orch,
+        workflow_run=wf,
+        step_execution=None,
+        kind=KIND_TASK,
+        draft=draft,
+        commit_context=ctx,
+    )
+    assert gate.paused is True
+    assert AgentPendingExternalApproval.objects.filter(session=session, status='pending').exists()
+    assert gate.sse_events
+    ev = gate.sse_events[0]
+    assert ev.get('type') == 'approval_request'
+    data = ev.get('data') or {}
+    assert data.get('approval_id')
+    assert data.get('kind') == KIND_TASK
+    assert isinstance(data.get('draft'), dict)
+
+
+@pytest.mark.django_db
+def test_resolve_pending_reject(approval_org_project_user):
+    _org, project, user = approval_org_project_user
+    session = AgentSession.objects.create(user=user, project=project, approval_required=True)
+    wf = AgentWorkflowRun.objects.create(session=session, status='analyzing')
+    pending = AgentPendingExternalApproval.objects.create(
+        session=session,
+        workflow_run=wf,
+        step_execution=None,
+        kind=KIND_TASK,
+        status='pending',
+        draft={'recommended_tasks': []},
+        commit_context={'input_data': {}, 'analysis_result': {}, 'decision_id': None},
+        destination_options=[],
+        default_destination=None,
+    )
+    orch = AgentOrchestrator(user, project, session)
+    result = resolve_pending(
+        orchestrator=orch,
+        pending_id=str(pending.id),
+        decision='reject',
+        draft={},
+        destination=None,
+    )
+    assert any('rejected' in (e.get('content') or '') for e in result.sse_events)
+    pending.refresh_from_db()
+    assert pending.status == 'rejected'
+
+
+@pytest.mark.django_db
+def test_resolve_pending_task_can_override_recommended_tasks_and_preserve_indexes(approval_org_project_user):
+    _org, project, user = approval_org_project_user
+    session = AgentSession.objects.create(user=user, project=project, approval_required=True)
+    wf = AgentWorkflowRun.objects.create(session=session, status='analyzing')
+    decision = Decision.objects.create(
+        title='D',
+        project=project,
+        project_seq=1,
+        author=user,
+    )
+    wf.decision = decision
+    wf.save()
+
+    orch = AgentOrchestrator(user, project, session)
+    base_tasks = [
+        {'summary': 'T0', 'description': 'd0', 'type': 'execution', 'priority': 'LOW'},
+        {'summary': 'T1', 'description': 'd1', 'type': 'execution', 'priority': 'LOW'},
+        {'summary': 'T2', 'description': 'd2', 'type': 'execution', 'priority': 'LOW'},
+    ]
+    ctx = {
+        'input_data': {'analysis_result': {'recommended_tasks': base_tasks}},
+        'analysis_result': {'recommended_tasks': base_tasks},
+        'decision_id': decision.id,
+    }
+    gate = request_external_commit(
+        orchestrator=orch,
+        workflow_run=wf,
+        step_execution=None,
+        kind=KIND_TASK,
+        draft={'recommended_tasks': base_tasks},
+        commit_context=ctx,
+    )
+    assert gate.paused is True
+    approval_id = gate.pending_id
+    assert approval_id
+
+    # Select only tasks 0 and 2 and preserve their original indexes.
+    override = [
+        {**base_tasks[0], 'index': 0},
+        {**base_tasks[2], 'index': 2},
+    ]
+    before_count = Task.objects.filter(project=project, owner=user).count()
+    result = resolve_pending(
+        orchestrator=orch,
+        pending_id=str(approval_id),
+        decision='approve',
+        draft={'recommended_tasks': override},
+        destination=None,
+    )
+    assert result.paused is False
+    ev = next((e for e in result.sse_events if e.get('type') == 'task_created'), None)
+    assert ev is not None
+    data = ev.get('data') or {}
+    created = data.get('created_tasks') or []
+    assert len(created) == 2
+    assert {c.get('index') for c in created} == {0, 2}
+
+    after_count = Task.objects.filter(project=project, owner=user).count()
+    assert after_count - before_count == 2

--- a/backend/agent/test_miro_workflow_step_unit.py
+++ b/backend/agent/test_miro_workflow_step_unit.py
@@ -3,7 +3,11 @@ from unittest.mock import patch, Mock
 from agent.executors import CreateMiroBoardExecutor, GenerateMiroSnapshotExecutor
 from agent.miro_generation import normalize_miro_snapshot_layout, call_gemini_miro_generator
 from agent.miro_board_service import _materialize_snapshot_ids
-from agent.services import _generate_miro_board_for_workflow_run, AgentOrchestrator
+from agent.services import (
+    MIRO_LEGACY_BG_QUEUED_MESSAGE,
+    _generate_miro_board_for_workflow_run,
+    AgentOrchestrator,
+)
 
 
 def _test_snapshot():
@@ -125,6 +129,7 @@ class _SessionStub:
     def __init__(self):
         self.id = "session-1"
         self.title = "Analysis session"
+        self.approval_required = False
         self.project = type("ProjectStub", (), {"id": 99})()
         self.user = type("UserStub", (), {"id": 7, "is_authenticated": True})()
         messages = [
@@ -132,6 +137,10 @@ class _SessionStub:
             type("MessageStub", (), {"role": "assistant", "content": "Found anomalies"})(),
         ]
         self.messages = type("MessageManagerStub", (), {"order_by": lambda self, *_args: messages})()
+
+    def refresh_from_db(self, *args, **kwargs):
+        # Agent approval gate expects a Django model; unit tests use a stub.
+        return None
 
 
 class _OrchestratorStub:
@@ -275,8 +284,8 @@ def test_create_tasks_from_analysis_is_idempotent_when_tasks_and_miro_exist(mock
     assert len(events) == 2
 
 
-@patch("agent.services._enqueue_miro_generation_for_workflow_run")
-def test_generate_miro_action_enqueues_background_generation(mock_enqueue):
+@patch.object(AgentOrchestrator, "_legacy_start_miro_background_if_needed")
+def test_generate_miro_action_yields_miro_status_when_generation_claim_succeeds(mock_claim):
     orchestrator = AgentOrchestrator(
         user=type("UserStub", (), {"id": 7})(),
         project=type("ProjectStub", (), {"id": 99})(),
@@ -285,12 +294,13 @@ def test_generate_miro_action_enqueues_background_generation(mock_enqueue):
     workflow_run = _WorkflowRunStub()
     workflow_run.analysis_result = {"recommended_tasks": [{"summary": "Audit placements"}]}
     workflow_run.created_tasks = [11, 12]
+    mock_claim.return_value = ("started", workflow_run, None)
 
     events = list(orchestrator._legacy_confirm("generate_miro", workflow_run))
 
     assert events[0]["type"] == "miro_status"
-    assert events[0]["content"] == "Miro board generation started in background."
-    mock_enqueue.assert_called_once_with(orchestrator, workflow_run)
+    assert events[0]["content"] == MIRO_LEGACY_BG_QUEUED_MESSAGE
+    mock_claim.assert_called_once_with(workflow_run)
 
 
 def test_normalize_miro_snapshot_layout_pushes_overlapping_items_down():

--- a/backend/agent/views.py
+++ b/backend/agent/views.py
@@ -135,11 +135,15 @@ class ChatView(EnglishResponseMixin, APIView):
         calendar_context = serializer.validated_data.get('calendar_context')
         workflow_id = serializer.validated_data.get('workflow_id')
         column_mapping = serializer.validated_data.get('column_mapping')
+        approval_id = serializer.validated_data.get('approval_id')
+        approval_decision = serializer.validated_data.get('approval_decision')
+        approval_draft = serializer.validated_data.get('approval_draft')
 
         should_persist_user_message = action not in {
             'start_follow_up', 'cancel_follow_up',
             'confirm_decision', 'create_tasks', 'generate_miro',
             'distribute_message', 'confirm_columns',
+            'resolve_external_approval',
         }
 
         # Auto-generate title from first real user message
@@ -169,7 +173,6 @@ class ChatView(EnglishResponseMixin, APIView):
             assistant_content_parts = []
             assistant_metadata = {}
             last_message_type = 'text'
-            standalone_message_types = {'miro_status', 'miro_suggestion'}
 
             def _flush_message():
                 """Save accumulated content as an assistant message and reset state."""
@@ -197,6 +200,9 @@ class ChatView(EnglishResponseMixin, APIView):
                     calendar_context=calendar_context,
                     workflow_id=workflow_id,
                     column_mapping=column_mapping,
+                    approval_id=approval_id,
+                    approval_decision=approval_decision,
+                    approval_draft=approval_draft,
                 ):
                     chunk_type = chunk.get('type', 'text')
                     content = chunk.get('content', '')
@@ -216,6 +222,28 @@ class ChatView(EnglishResponseMixin, APIView):
                                 message_type='calendar_invite',
                                 metadata={},
                             )
+                        continue
+
+                    if chunk_type == 'approval_request':
+                        _flush_message()
+                        sse_data = json.dumps(chunk, default=str)
+                        yield f"data: {sse_data}\n\n"
+                        AgentMessage.objects.create(
+                            session=session,
+                            role='assistant',
+                            content=content or 'Approval required.',
+                            message_type='approval_request',
+                            metadata=data or {},
+                        )
+                        continue
+
+                    # Miro status is persisted separately (_create_agent_status_message in the
+                    # orchestrator). Do not merge its text into the prior assistant bubble or
+                    # the final flush — that would duplicate the same line in chat history.
+                    if chunk_type == 'miro_status':
+                        _flush_message()
+                        sse_data = json.dumps(chunk, default=str)
+                        yield f"data: {sse_data}\n\n"
                         continue
 
                     # Skip internal signalling events from content accumulation

--- a/frontend/src/components/agent/AgentSidePanel.tsx
+++ b/frontend/src/components/agent/AgentSidePanel.tsx
@@ -5,6 +5,8 @@ import { X, Bot } from 'lucide-react';
 import { AgentLayoutProvider } from './AgentLayoutContext';
 import { AgentChatPage } from './chat/AgentChatPage';
 import { useAgentSidePanelStore } from '@/lib/agentSidePanelStore';
+import { ApprovalToggle } from './chat/ApprovalToggle';
+import { AgentAPI } from '@/lib/api/agentApi';
 
 const MIN_WIDTH = 280;
 const MAX_WIDTH = 420;
@@ -12,6 +14,8 @@ const MAX_WIDTH = 420;
 export default function AgentSidePanel() {
   const { isOpen, close } = useAgentSidePanelStore();
   const [width, setWidth] = useState(MAX_WIDTH);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [approvalRequired, setApprovalRequired] = useState(false);
   const isDragging = useRef(false);
   const startX = useRef(0);
   const startWidth = useRef(MAX_WIDTH);
@@ -45,6 +49,51 @@ export default function AgentSidePanel() {
     };
   }, []);
 
+  // Initialize approval state when opening the panel (covers first open + refresh).
+  useEffect(() => {
+    if (!isOpen) return;
+    const prefRaw = localStorage.getItem('agent-approval-required-default');
+    if (prefRaw === 'true' || prefRaw === 'false') {
+      setApprovalRequired(prefRaw === 'true');
+    }
+    const stored = sessionStorage.getItem('agent-session-id');
+    if (!stored) {
+      setSessionId(null);
+      return;
+    }
+    setSessionId(stored);
+    AgentAPI.getSession(stored)
+      .then((s) => setApprovalRequired(Boolean(s.approval_required)))
+      .catch(() => {
+        // keep last known value
+      });
+  }, [isOpen]);
+
+  // Sync from AgentChatPage broadcasts.
+  useEffect(() => {
+    const onSessionId = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { sessionId?: string | null } | undefined;
+      if (!detail) return;
+      setSessionId(detail.sessionId ?? null);
+    };
+    const onSessionState = (e: Event) => {
+      const detail = (e as CustomEvent).detail as
+        | { sessionId?: string; approvalRequired?: boolean }
+        | undefined;
+      if (!detail?.sessionId) return;
+      setSessionId(String(detail.sessionId));
+      if (typeof detail.approvalRequired === 'boolean') {
+        setApprovalRequired(detail.approvalRequired);
+      }
+    };
+    window.addEventListener('agent:session-id', onSessionId);
+    window.addEventListener('agent:session-state', onSessionState);
+    return () => {
+      window.removeEventListener('agent:session-id', onSessionId);
+      window.removeEventListener('agent:session-state', onSessionState);
+    };
+  }, []);
+
   return (
     <aside
       className={`h-screen border-l border-gray-200 bg-white shrink-0 overflow-hidden flex ${
@@ -71,19 +120,42 @@ export default function AgentSidePanel() {
               AI
             </span>
           </div>
-          <button
-            onClick={close}
-            className="p-1 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
-            aria-label="Close AI Agent panel"
-          >
-            <X className="w-4 h-4" />
-          </button>
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2">
+              <span className="text-[11px] text-gray-500 font-medium">Approval</span>
+              <ApprovalToggle
+                sessionId={sessionId}
+                value={approvalRequired}
+                onChange={(next) => {
+                  setApprovalRequired(next);
+                  localStorage.setItem('agent-approval-required-default', String(next));
+                  if (sessionId) {
+                    window.dispatchEvent(
+                      new CustomEvent('agent:approval-changed', { detail: { sessionId, value: next } })
+                    );
+                    window.dispatchEvent(
+                      new CustomEvent('agent:session-state', {
+                        detail: { sessionId, approvalRequired: next },
+                      })
+                    );
+                  }
+                }}
+              />
+            </div>
+            <button
+              onClick={close}
+              className="p-1 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+              aria-label="Close AI Agent panel"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
         </div>
 
         {/* Chat content */}
         <div className="min-h-0 flex-1 overflow-hidden">
           <AgentLayoutProvider initialView="overview">
-            <AgentChatPage />
+            <AgentChatPage embeddedInFloating />
           </AgentLayoutProvider>
         </div>
       </div>

--- a/frontend/src/components/agent/chat/ActionBar.tsx
+++ b/frontend/src/components/agent/chat/ActionBar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { FileCheck, ListTodo, UploadCloud } from "lucide-react"
+import { FileCheck, UploadCloud } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import type { WorkflowStepState } from "@/types/agent"
 
@@ -28,20 +28,6 @@ export function ActionBar({ stepState, onAction, onReupload, disabled }: ActionB
           Create Decision
         </Button>
       )}
-
-      {stepState.decisionCreated && !stepState.tasksCreated && (
-        <Button
-          size="sm"
-          variant="outline"
-          className="gap-1.5 text-xs"
-          disabled={disabled}
-          onClick={() => onAction("create_tasks")}
-        >
-          <ListTodo className="h-3.5 w-3.5" />
-          Create Tasks
-        </Button>
-      )}
-
 
       <Button
         size="sm"

--- a/frontend/src/components/agent/chat/AgentChatPage.tsx
+++ b/frontend/src/components/agent/chat/AgentChatPage.tsx
@@ -7,10 +7,13 @@ import { WelcomeScreen } from "./WelcomeScreen"
 import { MessageList, type ChatMessage } from "./MessageList"
 import { ChatInput } from "./ChatInput"
 import { ActionBar } from "./ActionBar"
+import { ApprovalToggle } from "./ApprovalToggle"
+import type { PendingExternalApproval } from "./ExternalApprovalModal"
 import { AgentAPI } from "@/lib/api/agentApi"
 import type { SSEEvent, AgentAction, AgentMessage, AnalysisResult, WorkflowStepState, ColumnDetectionData } from "@/types/agent"
 import { AGENT_MESSAGES } from "@/lib/agentMessages"
 import type { StepProgressItem } from "./StepProgress"
+import type { TaskGenerationStatus } from "./TaskListCard"
 
 function getPendingMiroWorkflowRunIds(messages: ChatMessage[]): string[] {
   // Only treat "miro_board_created" as done — a prior failure can be retried for the same
@@ -47,6 +50,7 @@ function restoreMessage(m: AgentMessage): ChatMessage {
   let navigateLabel: string | undefined
   let navigateDisabled = false
   let navigateHref: string | undefined
+  let approval: PendingExternalApproval | undefined
   const isFollowUpPrompt = m.message_type === "follow_up_prompt"
 
 
@@ -75,8 +79,13 @@ function restoreMessage(m: AgentMessage): ChatMessage {
     navigateLabel = "Go to Tasks"
   } else if (m.message_type === "decision_draft" || m.data?.decision_id) {
     type = "decision_created"
-    navigateTo = "decisions"
-    navigateLabel = "Review Pre-Draft"
+  } else if (m.message_type === "approval_request" && m.data?.approval_id) {
+    type = "approval_request"
+    approval = {
+      id: String(m.data.approval_id),
+      kind: String(m.data.kind ?? ""),
+      draft: (m.data.draft as Record<string, unknown>) ?? {},
+    }
   }
 
   return {
@@ -95,10 +104,129 @@ function restoreMessage(m: AgentMessage): ChatMessage {
     eventType,
     workflowRunId: m.data?.workflow_run_id,
     decisionId: m.data?.decision_id ? Number(m.data.decision_id) : undefined,
+    approval,
   }
 }
 
+/** Matches backend `MIRO_LEGACY_BG_QUEUED_MESSAGE` (queued vs board-ready lines differ). */
+const LEGACY_MIRO_QUEUED_FALLBACK =
+  "Queued Miro board generation — we'll notify you here when the board is ready."
+
+function dedupeMiroGenerationStartedMessages(messages: ChatMessage[]): ChatMessage[] {
+  const seen = new Set<string>()
+  const out: ChatMessage[] = []
+  for (const m of messages) {
+    if (m.eventType === "miro_generation_started" && m.workflowRunId) {
+      if (seen.has(m.workflowRunId)) continue
+      seen.add(m.workflowRunId)
+    }
+    out.push(m)
+  }
+  return out
+}
+
+function mergeMiroGenerationStartedIntoMessages(
+  prev: ChatMessage[],
+  aiMsgId: string,
+  patch: Pick<
+    ChatMessage,
+    | "content"
+    | "type"
+    | "navigateTo"
+    | "navigateLabel"
+    | "navigateDisabled"
+    | "navigateHref"
+    | "eventType"
+    | "workflowRunId"
+  >
+): ChatMessage[] {
+  const wrid = patch.workflowRunId
+  const updated = prev.map((p) => (p.id === aiMsgId ? { ...p, ...patch } : p))
+  const stripped =
+    wrid != null && wrid !== ""
+      ? updated.filter(
+          (p) =>
+            !(
+              p.id !== aiMsgId &&
+              p.workflowRunId === wrid &&
+              p.eventType === "miro_generation_started"
+            )
+        )
+      : updated
+  return dedupeMiroGenerationStartedMessages(stripped)
+}
+
 type CalendarPreload = { message: string; context: Record<string, unknown> }
+
+function appendMiroResultMessage(prev: ChatMessage[], event: SSEEvent): ChatMessage[] {
+  if (event.type !== "miro_status") return prev
+  const eventType = event.data?.event_type
+  if (!eventType || (eventType !== "miro_board_created" && eventType !== "miro_generation_failed")) return prev
+
+  const rawWr = event.data?.workflow_run_id
+  const workflowRunId =
+    typeof rawWr === "string" ? rawWr : rawWr != null ? String(rawWr) : undefined
+
+  // Prevent duplicates when polling/restoring replays the same event
+  const alreadyAdded = prev.some(
+    (m) => m.eventType === eventType && (workflowRunId ? m.workflowRunId === workflowRunId : true)
+  )
+  if (alreadyAdded) return prev
+
+  // Broadcast a right-panel dialog update (success/failure).
+  // Keep this ephemeral (not persisted) and only emit once per terminal event.
+  if (typeof window !== "undefined") {
+    if (eventType === "miro_board_created" && event.data?.board_id) {
+      window.dispatchEvent(new CustomEvent("agent:miro-status", {
+        detail: {
+          status: "success",
+          boardId: String(event.data.board_id),
+          workflowRunId,
+        }
+      }))
+    } else if (eventType === "miro_generation_failed") {
+      window.dispatchEvent(new CustomEvent("agent:miro-status", {
+        detail: {
+          status: "failed",
+          workflowRunId,
+        }
+      }))
+    }
+  }
+
+  if (eventType === "miro_board_created" && event.data?.board_id) {
+    return [
+      ...prev,
+      {
+        id: `miro-created-${workflowRunId ?? Date.now()}`,
+        role: "assistant",
+        content: event.content || "",
+        type: "miro_status",
+        navigateTo: "miro",
+        navigateLabel: "Open Miro",
+        navigateHref: `/miro/${event.data.board_id}`,
+        eventType,
+        workflowRunId,
+      },
+    ]
+  }
+
+  if (eventType === "miro_generation_failed") {
+    return [
+      ...prev,
+      {
+        id: `miro-failed-${workflowRunId ?? Date.now()}`,
+        role: "assistant",
+        content: event.content || "",
+        type: "text",
+        eventType,
+        workflowRunId,
+      },
+    ]
+  }
+
+  return prev
+}
 
 // Module-level flag — persists across React StrictMode's unmount+remount cycles.
 // Reset to false each time new calendar context is loaded so the auto-send fires once per navigation.
@@ -129,9 +257,14 @@ function buildCalendarPreload(): CalendarPreload | null {
   }
 }
 
-export function AgentChatPage() {
+type AgentChatPageProps = {
+  /** Hide title + approval row; used when the floating window title bar shows them. */
+  embeddedInFloating?: boolean
+}
+
+export function AgentChatPage({ embeddedInFloating = false }: AgentChatPageProps) {
   const router = useRouter()
-  const { setActiveView, floatingChat, toggleMaximize, setPendingDecisionId } = useAgentLayout()
+  const { setActiveView, floatingChat, toggleMaximize, setPendingDecisionId, setFloatingSessionId } = useAgentLayout()
   const [sessionId, setSessionIdState] = useState<string | null>(null)
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [isStreaming, setIsStreaming] = useState(false)
@@ -144,6 +277,17 @@ export function AgentChatPage() {
   })
   const [followUpAvailable, setFollowUpAvailable] = useState(false)
   const [followUpStarted, setFollowUpStarted] = useState(false)
+  const [sessionTitle, setSessionTitle] = useState("Chat")
+  const [approvalRequired, setApprovalRequired] = useState(false)
+  const [generatedTaskIndexes, setGeneratedTaskIndexes] = useState<number[]>([])
+  const [skippedTaskIndexes, setSkippedTaskIndexes] = useState<number[]>([])
+  const [createdTaskIdByIndex, setCreatedTaskIdByIndex] = useState<Record<number, number>>({})
+  const [pendingTaskApproval, setPendingTaskApproval] = useState<PendingExternalApproval | null>(null)
+  const [pendingMiroApproval, setPendingMiroApproval] = useState<PendingExternalApproval | null>(null)
+  const [selectedTaskIndexes, setSelectedTaskIndexes] = useState<number[]>([])
+  const [tasksApprovalGenerating, setTasksApprovalGenerating] = useState(false)
+  const [miroApprovalGenerating, setMiroApprovalGenerating] = useState(false)
+  const [taskGenerationStatus, setTaskGenerationStatus] = useState<TaskGenerationStatus>("idle")
   const abortRef = useRef<AbortController | null>(null)
   const [pendingCalendarPreload] = useState<CalendarPreload | null>(buildCalendarPreload)
   // Persist calendar context for the lifetime of this session so follow-up messages
@@ -176,6 +320,8 @@ export function AgentChatPage() {
   const handleConfirmColumnsRef = useRef<((m: Record<string, string>) => void) | null>(null)
   // Stores recommended tasks from latest analysis so decision_created messages can show TaskListCard
   const latestRecommendedTasksRef = useRef<import("@/types/agent").RecommendedTask[] | null>(null)
+  const autoExternalActionsTriggeredRef = useRef(false)
+  const autoActionQueueRef = useRef<string[]>([])
 
   const setSessionId = useCallback((id: string | null) => {
     sessionIdRef.current = id
@@ -185,6 +331,47 @@ export function AgentChatPage() {
     } else {
       sessionStorage.removeItem("agent-session-id")
     }
+    // Keep floating title bar state in sync when embedded.
+    if (embeddedInFloating) {
+      setFloatingSessionId(id)
+    }
+    // Broadcast session id so container headers (e.g. side panel) can sync.
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent("agent:session-id", { detail: { sessionId: id } }))
+    }
+  }, [embeddedInFloating, setFloatingSessionId])
+
+  const getApprovalPref = useCallback(() => {
+    if (typeof window === "undefined") return false
+    return localStorage.getItem("agent-approval-required-default") === "true"
+  }, [])
+
+  // Ensure approval state is initialized/refreshed whenever the chatbox opens (especially floating/embedded).
+  useEffect(() => {
+    if (!embeddedInFloating) return
+    const id = floatingChat.sessionId ?? sessionStorage.getItem("agent-session-id")
+    if (!id) {
+      setApprovalRequired(false)
+      return
+    }
+    AgentAPI.getSession(id)
+      .then((s) => setApprovalRequired(Boolean(s.approval_required)))
+      .catch(() => {
+        // keep current value on failure
+      })
+  }, [embeddedInFloating, floatingChat.sessionId])
+
+  // Keep approvalRequired in sync with the toggle (floating title bar + inline header).
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { sessionId?: string; value?: boolean } | undefined
+      if (!detail?.sessionId) return
+      const current = sessionIdRef.current
+      if (!current || String(current) !== String(detail.sessionId)) return
+      if (typeof detail.value === "boolean") setApprovalRequired(detail.value)
+    }
+    window.addEventListener("agent:approval-changed", handler)
+    return () => window.removeEventListener("agent:approval-changed", handler)
   }, [])
 
   const applySessionState = useCallback((session: Awaited<ReturnType<typeof AgentAPI.getSession>>) => {
@@ -203,9 +390,40 @@ export function AgentChatPage() {
         restored[i] = { ...restored[i], recommendedTasks: lastTasks }
       }
     }
-    setMessages(restored)
+    setMessages(dedupeMiroGenerationStartedMessages(restored))
     setFollowUpAvailable(Boolean(session.follow_up_available))
     setFollowUpStarted(Boolean(session.follow_up_started))
+    setSessionTitle((session.title && session.title.trim()) || "Chat")
+    setApprovalRequired(Boolean(session.approval_required))
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent("agent:session-state", {
+        detail: {
+          sessionId: String(session.id),
+          title: (session.title && session.title.trim()) || "Chat",
+          approvalRequired: Boolean(session.approval_required),
+        }
+      }))
+    }
+    const lastTaskCreated = [...session.messages].reverse().find(
+      (m) => m.message_type === "task_created" || (m.data?.task_ids && m.data.task_ids.length > 0)
+    )
+    const created = (lastTaskCreated as any)?.data?.created_tasks
+    if (Array.isArray(created)) {
+      const idxs = created
+        .map((c: any) => Number(c?.index))
+        .filter((n: unknown) => typeof n === "number" && Number.isFinite(n))
+      setGeneratedTaskIndexes(Array.from(new Set(idxs)))
+      // If any previously-skipped tasks later get created (e.g. user runs create_tasks again),
+      // clear them from the skipped list so the UI stays consistent.
+      setSkippedTaskIndexes((prev) => prev.filter((i) => !idxs.includes(i)))
+      const pairs = created
+        .map((c: any) => [Number(c?.index), Number(c?.task_id)] as const)
+        .filter(([idx, tid]) => Number.isFinite(idx) && Number.isFinite(tid))
+      setCreatedTaskIdByIndex(Object.fromEntries(pairs))
+    } else {
+      setGeneratedTaskIndexes([])
+      setCreatedTaskIdByIndex({})
+    }
     broadcastRestoredAnomalies(session.messages)
     // Derive step state from restored messages.
     // Each new analysis event starts a fresh cycle — reset downstream flags so that
@@ -225,6 +443,17 @@ export function AgentChatPage() {
       if (m.message_type === "task_created" || m.data?.task_ids) restoredStepState.tasksCreated = true
     }
     setStepState(restoredStepState)
+    // Restore task generation status heuristically (keeps right-panel status consistent after refresh).
+    if (restoredStepState.tasksCreated) {
+      setTaskGenerationStatus("completed")
+    } else if (Boolean(session.approval_required) && restoredStepState.decisionCreated) {
+      // With approval required, tasks may be awaiting approval rather than created.
+      // If there is a pending task approval, AgentChatPage will set it from SSE; on restore we can't know,
+      // so treat as idle until user triggers create.
+      setTaskGenerationStatus("idle")
+    } else {
+      setTaskGenerationStatus("idle")
+    }
   }, [setSessionId])
 
   const refreshFollowUpState = useCallback(async (id: string) => {
@@ -232,6 +461,64 @@ export function AgentChatPage() {
       const session = await AgentAPI.getSession(id)
       setFollowUpAvailable(Boolean(session.follow_up_available))
       setFollowUpStarted(Boolean(session.follow_up_started))
+      setApprovalRequired(Boolean(session.approval_required))
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent("agent:session-state", {
+          detail: {
+            sessionId: String(session.id),
+            title: (session.title && session.title.trim()) || "Chat",
+            approvalRequired: Boolean(session.approval_required),
+          }
+        }))
+      }
+    } catch {
+      // ignore refresh failures; next restore/poll can retry
+    }
+  }, [])
+
+  const refreshSession = useCallback(async (id: string) => {
+    try {
+      const session = await AgentAPI.getSession(id)
+      // Re-apply the same backfill logic as applySessionState so that
+      // decision_created messages don't lose their recommendedTasks after refreshes
+      // (the backend does not persist recommended_tasks on decision events).
+      const restored = session.messages.map(restoreMessage)
+      let lastTasks: import("@/types/agent").RecommendedTask[] | undefined
+      for (let i = 0; i < restored.length; i++) {
+        if (restored[i].type === "analysis") {
+          lastTasks = restored[i].recommendedTasks
+        } else if (restored[i].type === "decision_created" && lastTasks && !restored[i].recommendedTasks) {
+          restored[i] = { ...restored[i], recommendedTasks: lastTasks }
+        }
+      }
+      setMessages(dedupeMiroGenerationStartedMessages(restored))
+      setApprovalRequired(Boolean(session.approval_required))
+      setFollowUpAvailable(Boolean(session.follow_up_available))
+      setFollowUpStarted(Boolean(session.follow_up_started))
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent("agent:session-state", {
+          detail: {
+            sessionId: String(session.id),
+            title: (session.title && session.title.trim()) || "Chat",
+            approvalRequired: Boolean(session.approval_required),
+          }
+        }))
+      }
+      const lastTaskCreated = [...session.messages].reverse().find(
+        (m) => m.message_type === "task_created" || (m.data?.task_ids && m.data.task_ids.length > 0)
+      )
+      const created = (lastTaskCreated as any)?.data?.created_tasks
+      if (Array.isArray(created)) {
+        const idxs = created
+          .map((c: any) => Number(c?.index))
+          .filter((n: unknown) => typeof n === "number" && Number.isFinite(n))
+        setGeneratedTaskIndexes(Array.from(new Set(idxs)))
+        setSkippedTaskIndexes((prev) => prev.filter((i) => !idxs.includes(i)))
+        const pairs = created
+          .map((c: any) => [Number(c?.index), Number(c?.task_id)] as const)
+          .filter(([idx, tid]) => Number.isFinite(idx) && Number.isFinite(tid))
+        setCreatedTaskIdByIndex(Object.fromEntries(pairs))
+      }
     } catch {
       // ignore refresh failures; next restore/poll can retry
     }
@@ -261,9 +548,24 @@ export function AgentChatPage() {
             restored[i] = { ...restored[i], recommendedTasks: lastTasks }
           }
         }
-        setMessages(restored)
+        setMessages(dedupeMiroGenerationStartedMessages(restored))
         setFollowUpAvailable(Boolean(session.follow_up_available))
         setFollowUpStarted(Boolean(session.follow_up_started))
+        setApprovalRequired(Boolean(session.approval_required))
+        const lastTaskCreated = [...session.messages].reverse().find(
+          (m) => m.message_type === "task_created" || (m.data?.task_ids && m.data.task_ids.length > 0)
+        )
+        const created = (lastTaskCreated as any)?.data?.created_tasks
+        if (Array.isArray(created)) {
+          const idxs = created
+            .map((c: any) => Number(c?.index))
+            .filter((n: unknown) => typeof n === "number" && Number.isFinite(n))
+          setGeneratedTaskIndexes(Array.from(new Set(idxs)))
+          const pairs = created
+            .map((c: any) => [Number(c?.index), Number(c?.task_id)] as const)
+            .filter(([idx, tid]) => Number.isFinite(idx) && Number.isFinite(tid))
+          setCreatedTaskIdByIndex(Object.fromEntries(pairs))
+        }
       } catch {
         // ignore polling failures; next cycle can retry
       }
@@ -281,14 +583,16 @@ export function AgentChatPage() {
         .catch(() => {
           sessionStorage.removeItem("agent-session-id")
         })
+    } else {
+      // If there is no active session, initialize the toggle from the persisted preference.
+      setApprovalRequired(getApprovalPref())
     }
-  }, [applySessionState])
+  }, [applySessionState, getApprovalPref])
 
   // Listen for sidebar events
   useEffect(() => {
     const handleNewChat = () => {
-      setSessionIdState(null)
-      sessionStorage.removeItem("agent-session-id")
+      setSessionId(null)
       sessionStorage.removeItem("agent-session-calendar-context")
       setMessages([])
       setSessionCalendarContext(null)
@@ -296,6 +600,8 @@ export function AgentChatPage() {
       setIsStreaming(false)
       setFollowUpAvailable(false)
       setFollowUpStarted(false)
+      setSessionTitle("Chat")
+      setApprovalRequired(false)
       setStepState({ analysisComplete: false, decisionCreated: false, tasksCreated: false })
       abortRef.current?.abort()
     }
@@ -318,7 +624,7 @@ export function AgentChatPage() {
       window.removeEventListener("agent:new-chat", handleNewChat)
       window.removeEventListener("agent:load-session", handleLoadSession)
     }
-  }, [applySessionState])
+  }, [applySessionState, setSessionId])
 
   /** Append a new message and return its id */
   const addMessage = useCallback((msg: ChatMessage) => {
@@ -338,6 +644,11 @@ export function AgentChatPage() {
     setHasStarted(true)
     // Reset workflow state so a new file always starts from "Create Decision"
     setStepState({ analysisComplete: false, decisionCreated: false, tasksCreated: false })
+    setGeneratedTaskIndexes([])
+    setSkippedTaskIndexes([])
+    setCreatedTaskIdByIndex({})
+    autoExternalActionsTriggeredRef.current = false
+    autoActionQueueRef.current = []
 
     // Show user message
     const userMsgId = `user-${Date.now()}`
@@ -364,9 +675,25 @@ export function AgentChatPage() {
     let analysisData: AnalysisResult | null = null
     let columnMappingReceived = false
 
+    let sid = sessionId
+    if (!sid) {
+      try {
+        const session = await AgentAPI.createSession({ approval_required: getApprovalPref() })
+        sid = String(session.id)
+        setSessionId(sid)
+        setSessionTitle("New Chat")
+        setApprovalRequired(Boolean(session.approval_required))
+        window.dispatchEvent(new CustomEvent("agent:sessions-changed"))
+      } catch {
+        updateMessage(aiMsgId, { content: AGENT_MESSAGES.SESSION_CREATE_FAILED, type: "error" })
+        setIsStreaming(false)
+        return
+      }
+    }
+
     abortRef.current = AgentAPI.uploadAndAnalyze(
       file,
-      sessionId,
+      sid,
       (event: SSEEvent) => {
         if (event.type === "file_uploaded") {
           // File confirmed uploaded — update thinking message
@@ -421,6 +748,9 @@ export function AgentChatPage() {
           setFollowUpAvailable(true)
           setFollowUpStarted(false)
           setStepState((prev) => ({ ...prev, analysisComplete: true }))
+          setGeneratedTaskIndexes([])
+          setSkippedTaskIndexes([])
+          setCreatedTaskIdByIndex({})
           updateMessage(aiMsgId, {
             content: contentParts.join("\n"),
             type: "analysis",
@@ -428,6 +758,13 @@ export function AgentChatPage() {
             suggestedDecision: analysisData?.suggested_decision,
             recommendedTasks: analysisData?.recommended_tasks,
           })
+          if (!approvalRequired && !autoExternalActionsTriggeredRef.current) {
+            // With approval OFF, auto-run the whole chain. Some workflows pause
+            // at an "await_confirmation" step before tasks; enqueue confirm_decision first
+            // so create_tasks doesn't resume into the decision-confirmation pause.
+            autoExternalActionsTriggeredRef.current = true
+            autoActionQueueRef.current = ["confirm_decision", "create_tasks", "generate_miro"]
+          }
           // Individual anomalies are added to the right panel via the
           // AnomalyCard "+ Add" button — no auto-broadcast on new analysis.
         } else if (event.type === "confirmation_request") {
@@ -436,6 +773,30 @@ export function AgentChatPage() {
           if (!columnMappingReceived) {
             contentParts.push(event.content || "")
             updateMessage(aiMsgId, { content: contentParts.join("\n") })
+          }
+        } else if (event.type === "approval_request" && event.data) {
+          const d = event.data as Record<string, unknown>
+          const approvalId = d.approval_id
+          const kind = String(d.kind ?? "")
+          if (typeof approvalId !== "string") return
+
+          const pending: PendingExternalApproval = {
+            id: approvalId,
+            kind,
+            draft: (d.draft as Record<string, unknown>) ?? {},
+          }
+
+          if (kind === "task") {
+            setPendingTaskApproval(pending)
+            setTasksApprovalGenerating(false)
+            setSkippedTaskIndexes([])
+            const tasks = (pending.draft as any)?.recommended_tasks
+            const tasksLen =
+              Array.isArray(tasks) ? tasks.length : (latestRecommendedTasksRef.current?.length ?? 0)
+            if (tasksLen > 0) setSelectedTaskIndexes(Array.from({ length: tasksLen }, (_, i) => i))
+          } else if (kind === "miro_board") {
+            setPendingMiroApproval(pending)
+            setMiroApprovalGenerating(false)
           }
         } else if (event.type === "follow_up_prompt") {
           contentParts.push(event.content || "")
@@ -489,7 +850,7 @@ export function AgentChatPage() {
         setIsStreaming(false)
       }
     )
-  }, [sessionId, addMessage, updateMessage, setSessionId, refreshFollowUpState])
+  }, [sessionId, addMessage, updateMessage, setSessionId, refreshFollowUpState, getApprovalPref])
 
   /** Confirm detected column mapping and resume paused workflow */
   const handleConfirmColumns = useCallback(async (mapping: Record<string, string>) => {
@@ -499,6 +860,9 @@ export function AgentChatPage() {
     const aiMsgId = `ai-${Date.now()}`
     addMessage({ id: aiMsgId, role: "assistant", content: AGENT_MESSAGES.CHAT_THINKING, type: "text" })
     setIsStreaming(true)
+    setGeneratedTaskIndexes([])
+    setSkippedTaskIndexes([])
+    setCreatedTaskIdByIndex({})
     // Preserve step names from the upload phase; reset steps 3+ to pending
     setStepProgress((prev) =>
       prev.map((s) => ({
@@ -555,12 +919,19 @@ export function AgentChatPage() {
           setFollowUpAvailable(true)
           setFollowUpStarted(false)
           setStepState((prev) => ({ ...prev, analysisComplete: true }))
+          setGeneratedTaskIndexes([])
+          setSkippedTaskIndexes([])
+          setCreatedTaskIdByIndex({})
           updateMessage(aiMsgId, {
             type: "analysis",
             anomalies: data.anomalies,
             suggestedDecision: data.suggested_decision,
             recommendedTasks: data.recommended_tasks,
           })
+          if (!approvalRequired && !autoExternalActionsTriggeredRef.current) {
+            autoExternalActionsTriggeredRef.current = true
+            autoActionQueueRef.current = ["confirm_decision", "create_tasks", "generate_miro"]
+          }
         }
         if (event.type === "decision_draft" && event.data) {
           const decisionId = event.data?.decision_id
@@ -568,14 +939,29 @@ export function AgentChatPage() {
           updateMessage(aiMsgId, {
             content: contentParts.join("\n"),
             type: "decision_created",
-            navigateTo: "decisions",
-            navigateLabel: "Review Pre-Draft",
             decisionId: decisionId ? Number(decisionId) : undefined,
             recommendedTasks: latestRecommendedTasksRef.current || undefined,
           })
         }
         if (event.type === "task_created" && event.data) {
           setStepState((prev) => ({ ...prev, tasksCreated: true }))
+          setPendingTaskApproval(null)
+          setTasksApprovalGenerating(false)
+          const created = (event.data as any)?.created_tasks
+          if (Array.isArray(created)) {
+            const idxs = created
+              .map((c: any) => Number(c?.index))
+              .filter((n: unknown) => typeof n === "number" && Number.isFinite(n))
+            setGeneratedTaskIndexes(Array.from(new Set(idxs)))
+            setSkippedTaskIndexes((prev) => prev.filter((i) => !idxs.includes(i)))
+            const pairs = created
+              .map((c: any) => [Number(c?.index), Number(c?.task_id)] as const)
+              .filter(([idx, tid]) => Number.isFinite(idx) && Number.isFinite(tid))
+            setCreatedTaskIdByIndex(Object.fromEntries(pairs))
+          } else {
+            const tasksLen = latestRecommendedTasksRef.current?.length ?? 0
+            if (tasksLen > 0) setGeneratedTaskIndexes(Array.from({ length: tasksLen }, (_, i) => i))
+          }
           updateMessage(aiMsgId, {
             content: contentParts.join("\n"),
             type: "tasks_created",
@@ -614,8 +1000,7 @@ export function AgentChatPage() {
   const handleReupload = useCallback(() => {
     sessionIdRef.current = null
     stepProgressMsgIdRef.current = null
-    setSessionIdState(null)
-    sessionStorage.removeItem("agent-session-id")
+    setSessionId(null)
     setMessages([])
     setHasStarted(false)
     setIsStreaming(false)
@@ -623,9 +1008,13 @@ export function AgentChatPage() {
     setFollowUpStarted(false)
     setStepProgress([])
     setStepState({ analysisComplete: false, decisionCreated: false, tasksCreated: false })
+    setGeneratedTaskIndexes([])
+    setSkippedTaskIndexes([])
     latestRecommendedTasksRef.current = null
+    autoExternalActionsTriggeredRef.current = false
+    autoActionQueueRef.current = []
     abortRef.current?.abort()
-  }, [])
+  }, [setSessionId])
 
   /** Handle text message send */
   const handleSendMessage = useCallback(async (text: string, calendarContext?: Record<string, unknown>) => {
@@ -643,9 +1032,11 @@ export function AgentChatPage() {
     let sid = sessionId
     if (!sid) {
       try {
-        const session = await AgentAPI.createSession({})
+        const session = await AgentAPI.createSession({ approval_required: getApprovalPref() })
         sid = String(session.id)
         setSessionId(sid)
+        setSessionTitle("New Chat")
+        setApprovalRequired(Boolean(session.approval_required))
         window.dispatchEvent(new CustomEvent("agent:sessions-changed"))
       } catch {
         addMessage({
@@ -701,6 +1092,25 @@ export function AgentChatPage() {
           return
         }
 
+        if (event.type === "approval_request" && event.data) {
+          const d = event.data as Record<string, unknown>
+          const approvalId = d.approval_id
+          if (typeof approvalId === "string") {
+            addMessage({
+              id: `approval-${approvalId}`,
+              role: "assistant",
+              content: event.content || "Approval required.",
+              type: "approval_request",
+              approval: {
+                id: approvalId,
+                kind: String(d.kind ?? ""),
+                draft: (d.draft as Record<string, unknown>) ?? {},
+              },
+            })
+          }
+          return
+        }
+
         if (event.type === "step_progress" && event.data) {
           const { step_order, step_name, total_steps } = event.data
           if (step_order != null && step_name && total_steps) {
@@ -749,6 +1159,9 @@ export function AgentChatPage() {
           setFollowUpAvailable(true)
           setFollowUpStarted(false)
           setStepState((prev) => ({ ...prev, analysisComplete: true }))
+          setGeneratedTaskIndexes([])
+          setSkippedTaskIndexes([])
+          setCreatedTaskIdByIndex({})
           updateMessage(aiMsgId, {
             type: "analysis",
             anomalies: data.anomalies,
@@ -757,6 +1170,10 @@ export function AgentChatPage() {
           })
           // Individual anomalies are added to the right panel via the
           // AnomalyCard "+ Add" button — no auto-broadcast on new analysis.
+          if (!approvalRequired && !autoExternalActionsTriggeredRef.current) {
+            autoExternalActionsTriggeredRef.current = true
+            autoActionQueueRef.current = ["confirm_decision", "create_tasks", "generate_miro"]
+          }
         }
         if (event.type === "decision_draft" && event.data) {
           const decisionId = event.data?.decision_id
@@ -764,14 +1181,26 @@ export function AgentChatPage() {
           updateMessage(aiMsgId, {
             content: contentParts.join("\n"),
             type: "decision_created",
-            navigateTo: "decisions",
-            navigateLabel: "Review Pre-Draft",
             decisionId: decisionId ? Number(decisionId) : undefined,
             recommendedTasks: latestRecommendedTasksRef.current || undefined,
           })
         }
         if (event.type === "task_created" && event.data) {
           setStepState((prev) => ({ ...prev, tasksCreated: true }))
+          const created = (event.data as any)?.created_tasks
+          if (Array.isArray(created)) {
+            const idxs = created
+              .map((c: any) => Number(c?.index))
+              .filter((n: unknown) => typeof n === "number" && Number.isFinite(n))
+            setGeneratedTaskIndexes(Array.from(new Set(idxs)))
+            const pairs = created
+              .map((c: any) => [Number(c?.index), Number(c?.task_id)] as const)
+              .filter(([idx, tid]) => Number.isFinite(idx) && Number.isFinite(tid))
+            setCreatedTaskIdByIndex(Object.fromEntries(pairs))
+          } else {
+            const tasksLen = latestRecommendedTasksRef.current?.length ?? 0
+            if (tasksLen > 0) setGeneratedTaskIndexes(Array.from({ length: tasksLen }, (_, i) => i))
+          }
           updateMessage(aiMsgId, {
             content: contentParts.join("\n"),
             type: "tasks_created",
@@ -780,14 +1209,24 @@ export function AgentChatPage() {
           })
         }
         if (event.type === "miro_status") {
-          updateMessage(aiMsgId, {
-            content: event.content || "Miro board generation started in background.",
-            type: "miro_status",
-            navigateTo: "miro",
-            navigateLabel: "Generating Miro...",
-            navigateDisabled: true,
-            eventType: "miro_generation_started",
-            workflowRunId: event.data?.workflow_run_id,
+          setPendingMiroApproval(null)
+          setMiroApprovalGenerating(false)
+          const rawWr = event.data?.workflow_run_id
+          const workflowRunId =
+            typeof rawWr === "string" ? rawWr : rawWr != null ? String(rawWr) : undefined
+
+          setMessages((prev) => {
+            const next = mergeMiroGenerationStartedIntoMessages(prev, aiMsgId, {
+              content: event.content || LEGACY_MIRO_QUEUED_FALLBACK,
+              type: "miro_status",
+              navigateTo: "miro",
+              navigateLabel: "Generating Miro...",
+              navigateDisabled: true,
+              navigateHref: undefined,
+              eventType: "miro_generation_started",
+              workflowRunId,
+            })
+            return appendMiroResultMessage(next, event)
           })
         }
         if (event.type === "follow_up_prompt") {
@@ -823,7 +1262,7 @@ export function AgentChatPage() {
         setIsStreaming(false)
       }
     )
-  }, [sessionId, sessionCalendarContext, addMessage, updateMessage, setSessionId, refreshFollowUpState])
+  }, [sessionId, sessionCalendarContext, addMessage, updateMessage, setMessages, setSessionId, refreshFollowUpState, getApprovalPref])
 
   // Keep ref always pointing to the latest handleSendMessage
   handleSendMessageRef.current = handleSendMessage
@@ -831,6 +1270,10 @@ export function AgentChatPage() {
   /** Handle action buttons (Create Decision, Create Tasks) */
   const handleAction = useCallback(async (action: string) => {
     if (!sessionId) return
+
+    // #region agent log
+    fetch('http://127.0.0.1:7484/ingest/c9ef1ef2-1ac5-477a-9651-16a2d50b98d2',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'821864'},body:JSON.stringify({sessionId:'821864',runId:'pre-fix',hypothesisId:'F4',location:'frontend/src/components/agent/chat/AgentChatPage.tsx:handleAction',message:'handleAction invoked',data:{sessionId:String(sessionId),action:String(action),approvalRequired:Boolean(approvalRequired),autoQueueLen:autoActionQueueRef.current.length,isStreaming:Boolean(isStreaming)},timestamp:Date.now()})}).catch(()=>{});
+    // #endregion
 
     const actionMap: Record<string, AgentAction> = {
       confirm_decision: "confirm_decision",
@@ -843,10 +1286,15 @@ export function AgentChatPage() {
     const agentAction = actionMap[action]
     if (!agentAction) return
 
+    if (action === "create_tasks") {
+      setTaskGenerationStatus("generating")
+    }
+
     const aiMsgId = `ai-${Date.now()}`
     addMessage({ id: aiMsgId, role: "assistant", content: AGENT_MESSAGES.CHAT_THINKING, type: "text" })
 
     setIsStreaming(true)
+    if (action === "create_tasks") setGeneratedTaskIndexes([])
     let contentParts: string[] = []
 
     abortRef.current = AgentAPI.sendMessage(
@@ -897,14 +1345,30 @@ export function AgentChatPage() {
           updateMessage(aiMsgId, {
             content: contentParts.join("\n"),
             type: "decision_created",
-            navigateTo: "decisions",
-            navigateLabel: "Review Pre-Draft",
             decisionId: decisionId ? Number(decisionId) : undefined,
             recommendedTasks: latestRecommendedTasksRef.current || undefined,
           })
         }
         if (event.type === "task_created") {
           setStepState((prev) => ({ ...prev, tasksCreated: true }))
+          setPendingTaskApproval(null)
+          setTasksApprovalGenerating(false)
+          setTaskGenerationStatus("completed")
+          const created = (event.data as any)?.created_tasks
+          if (Array.isArray(created)) {
+            const idxs = created
+              .map((c: any) => Number(c?.index))
+              .filter((n: unknown) => typeof n === "number" && Number.isFinite(n))
+            setGeneratedTaskIndexes(Array.from(new Set(idxs)))
+            setSkippedTaskIndexes((prev) => prev.filter((i) => !idxs.includes(i)))
+            const pairs = created
+              .map((c: any) => [Number(c?.index), Number(c?.task_id)] as const)
+              .filter(([idx, tid]) => Number.isFinite(idx) && Number.isFinite(tid))
+            setCreatedTaskIdByIndex(Object.fromEntries(pairs))
+          } else {
+            const tasksLen = latestRecommendedTasksRef.current?.length ?? 0
+            if (tasksLen > 0) setGeneratedTaskIndexes(Array.from({ length: tasksLen }, (_, i) => i))
+          }
           updateMessage(aiMsgId, {
             content: contentParts.join("\n"),
             type: "tasks_created",
@@ -913,14 +1377,24 @@ export function AgentChatPage() {
           })
         }
         if (event.type === "miro_status") {
-          updateMessage(aiMsgId, {
-            content: event.content || "Miro board generation started in background.",
-            type: "miro_status",
-            navigateTo: "miro",
-            navigateLabel: "Generating Miro...",
-            navigateDisabled: true,
-            eventType: "miro_generation_started",
-            workflowRunId: event.data?.workflow_run_id,
+          setPendingMiroApproval(null)
+          setMiroApprovalGenerating(false)
+          const rawWr = event.data?.workflow_run_id
+          const workflowRunId =
+            typeof rawWr === "string" ? rawWr : rawWr != null ? String(rawWr) : undefined
+
+          setMessages((prev) => {
+            const next = mergeMiroGenerationStartedIntoMessages(prev, aiMsgId, {
+              content: event.content || LEGACY_MIRO_QUEUED_FALLBACK,
+              type: "miro_status",
+              navigateTo: "miro",
+              navigateLabel: "Generating Miro...",
+              navigateDisabled: true,
+              navigateHref: undefined,
+              eventType: "miro_generation_started",
+              workflowRunId,
+            })
+            return appendMiroResultMessage(next, event)
           })
         }
         if (event.type === "follow_up_prompt") {
@@ -932,9 +1406,35 @@ export function AgentChatPage() {
             isFollowUpPrompt: true,
           })
         }
+        if (event.type === "approval_request" && event.data) {
+          const d = event.data as Record<string, unknown>
+          const approvalId = d.approval_id
+          const kind = String(d.kind ?? "")
+          if (typeof approvalId !== "string") return
+
+          const pending: PendingExternalApproval = {
+            id: approvalId,
+            kind,
+            draft: (d.draft as Record<string, unknown>) ?? {},
+          }
+
+          if (kind === "task") {
+            setPendingTaskApproval(pending)
+            setTasksApprovalGenerating(false)
+            setTaskGenerationStatus("awaiting_approval")
+            const tasks = (pending.draft as any)?.recommended_tasks
+            const tasksLen =
+              Array.isArray(tasks) ? tasks.length : (latestRecommendedTasksRef.current?.length ?? 0)
+            if (tasksLen > 0) setSelectedTaskIndexes(Array.from({ length: tasksLen }, (_, i) => i))
+          } else if (kind === "miro_board") {
+            setPendingMiroApproval(pending)
+            setMiroApprovalGenerating(false)
+          }
+        }
       },
       (error) => {
         updateMessage(aiMsgId, { content: `Error: ${error.message}`, type: "error" })
+        if (action === "create_tasks") setTaskGenerationStatus("error")
         setIsStreaming(false)
       },
       () => {
@@ -954,7 +1454,102 @@ export function AgentChatPage() {
         setIsStreaming(false)
       }
     )
-  }, [sessionId, addMessage, updateMessage, refreshFollowUpState])
+  }, [sessionId, addMessage, updateMessage, setMessages, refreshFollowUpState])
+
+  const resolveExternalApproval = useCallback(
+    (
+      pending: PendingExternalApproval,
+      decision: "approve" | "reject",
+      draft?: Record<string, unknown>
+    ) => {
+      if (!sessionId) return
+      AgentAPI.sendMessage(
+        sessionId,
+        {
+          message: ".",
+          action: "resolve_external_approval",
+          approval_id: pending.id,
+          approval_decision: decision,
+          approval_draft: decision === "approve" ? draft : undefined,
+        },
+        (_ev: SSEEvent) => {
+          /* streamed chunks ignored; subsequent events update UI */
+        },
+        () => {
+          if (pending.kind === "task") setTasksApprovalGenerating(false)
+          if (pending.kind === "miro_board") setMiroApprovalGenerating(false)
+        },
+        () => {
+          void refreshSession(String(sessionId))
+        }
+      )
+    },
+    [sessionId, refreshSession]
+  )
+
+  const handleApproveSelectedTasks = useCallback(
+    (selected: number[]) => {
+      if (!pendingTaskApproval) return
+      const tasks =
+        (pendingTaskApproval.draft as any)?.recommended_tasks ??
+        (latestRecommendedTasksRef.current ?? [])
+      if (!Array.isArray(tasks) || tasks.length === 0) return
+
+      // Mark unselected recommendations as explicitly skipped so the UI shows a red X
+      // instead of falling back to "awaiting approval".
+      const selectedSet = new Set(selected)
+      const skipped = Array.from({ length: tasks.length }, (_, i) => i).filter((i) => !selectedSet.has(i))
+      setSkippedTaskIndexes(skipped)
+
+      const filtered = tasks
+        .map((t: any, idx: number) => ({ ...t, index: idx }))
+        .filter((_t: any, idx: number) => selectedSet.has(idx))
+
+      setTasksApprovalGenerating(true)
+      // Optimistic UI: immediately exit checkbox/approval mode so the right panel
+      // doesn't appear "stuck" after clicking Create Tasks.
+      setPendingTaskApproval(null)
+      setSelectedTaskIndexes([])
+      setTaskGenerationStatus("generating")
+      resolveExternalApproval(pendingTaskApproval, "approve", { recommended_tasks: filtered })
+    },
+    [pendingTaskApproval, resolveExternalApproval]
+  )
+
+  const handleRejectTasksApproval = useCallback(() => {
+    if (!pendingTaskApproval) return
+    setTasksApprovalGenerating(false)
+    resolveExternalApproval(pendingTaskApproval, "reject")
+    setPendingTaskApproval(null)
+  }, [pendingTaskApproval, resolveExternalApproval])
+
+  const handleApproveMiroApproval = useCallback(
+    () => {
+      if (!pendingMiroApproval) return
+      setMiroApprovalGenerating(true)
+      resolveExternalApproval(pendingMiroApproval, "approve", {})
+      setPendingMiroApproval(null)
+    },
+    [pendingMiroApproval, resolveExternalApproval]
+  )
+
+  const handleRejectMiroApproval = useCallback(() => {
+    if (!pendingMiroApproval) return
+    setMiroApprovalGenerating(false)
+    resolveExternalApproval(pendingMiroApproval, "reject")
+    setPendingMiroApproval(null)
+  }, [pendingMiroApproval, resolveExternalApproval])
+
+  // Auto-run queued external actions when streaming is idle.
+  useEffect(() => {
+    if (isStreaming) return
+    if (!sessionId) return
+    if (autoActionQueueRef.current.length === 0) return
+    const next = autoActionQueueRef.current.shift()
+    if (next) {
+      void handleAction(next)
+    }
+  }, [isStreaming, sessionId, handleAction])
 
   // Auto-send calendar context message when arriving from calendar/event page (once only).
   // Uses a module-level flag + ref to handleSendMessage so this effect only fires on mount
@@ -967,19 +1562,73 @@ export function AgentChatPage() {
     handleSendMessageRef.current?.(pendingCalendarPreload.message, pendingCalendarPreload.context)
   }, [pendingCalendarPreload, hasStarted])
 
-  if (!hasStarted) {
-    return (
-      <WelcomeScreen
-        onSend={handleSendMessage}
-        onFileUpload={handleFileUpload}
-        disabled={isStreaming}
-      />
-    )
-  }
-
   return (
     <div className="flex h-full flex-col">
-      <MessageList messages={messages} onAction={handleAction} onConfirmColumns={handleConfirmColumns} onReupload={handleReupload} latestAnalysisMessageId={latestAnalysisMessageId} showFollowUpToggle={followUpAvailable || followUpStarted} followUpActive={followUpStarted} stepState={stepState} onNavigate={(view, msg) => {
+      {!embeddedInFloating && (
+        <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2 shrink-0 bg-background">
+          <h2 className="text-sm font-semibold truncate text-foreground">{sessionTitle}</h2>
+          {sessionId ? (
+            <div className="flex items-center gap-2 shrink-0">
+              <span className="text-[11px] text-muted-foreground font-medium">
+                Approval
+              </span>
+              <ApprovalToggle
+                sessionId={sessionId}
+                value={approvalRequired}
+                onChange={(next) => {
+                  setApprovalRequired(next)
+                  if (typeof window !== "undefined") {
+                    window.dispatchEvent(new CustomEvent("agent:approval-changed", { detail: { sessionId, value: next } }))
+                    window.dispatchEvent(
+                      new CustomEvent("agent:session-state", {
+                        detail: { sessionId, title: sessionTitle, approvalRequired: next },
+                      })
+                    )
+                  }
+                }}
+                disabled={isStreaming}
+              />
+            </div>
+          ) : null}
+        </div>
+      )}
+      {!hasStarted ? (
+        <WelcomeScreen
+          onSend={handleSendMessage}
+          onFileUpload={handleFileUpload}
+          disabled={isStreaming}
+          showComposer={false}
+        />
+      ) : (
+      <MessageList
+        {...({
+          messages,
+          sessionId,
+          approvalDisabled: isStreaming,
+          approvalRequired,
+          generatedTaskIndexes,
+          skippedTaskIndexes,
+          createdTaskIdByIndex,
+          generatingTasks: !approvalRequired && stepState.analysisComplete && !stepState.tasksCreated,
+          taskGenerationStatus,
+          pendingTaskApproval,
+          selectedTaskIndexes,
+          onSelectedTaskIndexesChange: setSelectedTaskIndexes,
+          tasksApprovalGenerating,
+          onApproveSelectedTasks: handleApproveSelectedTasks,
+          onRejectTasksApproval: handleRejectTasksApproval,
+          pendingMiroApproval,
+          miroApprovalGenerating,
+          onApproveMiroApproval: handleApproveMiroApproval,
+          onRejectMiroApproval: handleRejectMiroApproval,
+          onAction: handleAction,
+          onConfirmColumns: handleConfirmColumns,
+          onReupload: handleReupload,
+          latestAnalysisMessageId,
+          showFollowUpToggle: followUpAvailable || followUpStarted,
+          followUpActive: followUpStarted,
+          stepState,
+          onNavigate: (view: string, msg?: ChatMessage) => {
         if (msg?.navigateHref && typeof window !== "undefined") {
           window.location.href = msg.navigateHref
           return
@@ -994,7 +1643,10 @@ export function AgentChatPage() {
         }
         setActiveView(view as AgentView)
         if (floatingChat.mode === "maximized") toggleMaximize()
-      }} />
+          },
+        } as any)}
+      />
+      )}
       <ActionBar stepState={stepState} onAction={handleAction} onReupload={handleReupload} disabled={isStreaming} />
       <ChatInput
         onSend={handleSendMessage}

--- a/frontend/src/components/agent/chat/ApprovalToggle.tsx
+++ b/frontend/src/components/agent/chat/ApprovalToggle.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import { useCallback, useState } from "react"
+import { cn } from "@/lib/utils"
+import { AgentAPI } from "@/lib/api/agentApi"
+
+type ApprovalToggleProps = {
+  /** When omitted, toggle becomes local-only (no API call). */
+  sessionId?: string | null
+  value: boolean
+  onChange?: (next: boolean) => void
+  disabled?: boolean
+}
+
+/** Green pill switch — matches approval-required “on” styling. */
+export function ApprovalToggle({ sessionId, value, onChange, disabled }: ApprovalToggleProps) {
+  const [pending, setPending] = useState(false)
+
+  const toggle = useCallback(async () => {
+    if (disabled || pending) return
+    const next = !value
+    // No session yet: let the parent persist the preference.
+    if (!sessionId) {
+      onChange?.(next)
+      return
+    }
+    setPending(true)
+    try {
+      await AgentAPI.updateSession(sessionId, { approval_required: next })
+      onChange?.(next)
+    } catch {
+      // keep prior value on failure
+    } finally {
+      setPending(false)
+    }
+  }, [disabled, pending, sessionId, value, onChange])
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={value}
+      aria-label="Require approval before external actions"
+      title={value ? "Approval required for external actions" : "External actions run without approval"}
+      disabled={disabled || pending}
+      onClick={toggle}
+      className={cn(
+        "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#22c55e]/80 disabled:opacity-50",
+        value ? "bg-[#22c55e]" : "bg-muted-foreground/30"
+      )}
+    >
+      <span
+        className={cn(
+          "pointer-events-none absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
+          value ? "translate-x-4" : "translate-x-0"
+        )}
+      />
+    </button>
+  )
+}

--- a/frontend/src/components/agent/chat/ExternalApprovalCard.tsx
+++ b/frontend/src/components/agent/chat/ExternalApprovalCard.tsx
@@ -1,0 +1,144 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { ChevronDown, ChevronRight, ShieldAlert } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+import { cn } from "@/lib/utils"
+import { AgentAPI } from "@/lib/api/agentApi"
+import type { AgentChatRequest, SSEEvent } from "@/types/agent"
+
+export type PendingExternalApproval = {
+  id: string
+  kind: string
+  draft: Record<string, unknown>
+}
+
+type ExternalApprovalCardProps = {
+  sessionId: string
+  pending: PendingExternalApproval
+  disabled?: boolean
+  onResolved?: () => void
+}
+
+export function ExternalApprovalCard({ sessionId, pending, disabled, onResolved }: ExternalApprovalCardProps) {
+  const [expanded, setExpanded] = useState(false)
+  const [draftJson, setDraftJson] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    try {
+      setDraftJson(JSON.stringify(pending.draft ?? {}, null, 2))
+    } catch {
+      setDraftJson("{}")
+    }
+    setError(null)
+  }, [pending])
+
+  const submit = useCallback(
+    (decision: "approve" | "reject") => {
+      if (disabled || submitting) return
+      setSubmitting(true)
+      setError(null)
+
+      let parsedDraft: Record<string, unknown> | undefined
+      if (decision === "approve") {
+        try {
+          parsedDraft = JSON.parse(draftJson) as Record<string, unknown>
+        } catch {
+          setError("Draft must be valid JSON.")
+          setSubmitting(false)
+          return
+        }
+      }
+
+      const body: AgentChatRequest = {
+        message: ".",
+        action: "resolve_external_approval",
+        approval_id: pending.id,
+        approval_decision: decision,
+        approval_draft: decision === "approve" ? parsedDraft : undefined,
+      }
+
+      AgentAPI.sendMessage(
+        sessionId,
+        body,
+        (_ev: SSEEvent) => {
+          /* streamed chunks ignored here; parent refreshes session on complete */
+        },
+        (err) => {
+          setError(err.message)
+          setSubmitting(false)
+        },
+        () => {
+          setSubmitting(false)
+          onResolved?.()
+        }
+      )
+    },
+    [disabled, submitting, sessionId, pending.id, draftJson, onResolved]
+  )
+
+  return (
+    <Card className="bg-card border-border">
+      <CardHeader className="pb-3 pt-4 px-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-amber-500/15 shrink-0">
+              <ShieldAlert className="h-4 w-4 text-amber-600" />
+            </div>
+            <div className="min-w-0">
+              <CardTitle className="text-sm font-semibold text-card-foreground truncate">
+                Approval required
+              </CardTitle>
+              <p className="text-xs text-muted-foreground truncate">
+                Type: <span className="font-medium text-foreground">{pending.kind.replace(/_/g, " ")}</span>
+              </p>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            className={cn(
+              "inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground",
+              (disabled || submitting) && "opacity-50 pointer-events-none"
+            )}
+            onClick={() => setExpanded((v) => !v)}
+          >
+            {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+            Draft
+          </button>
+        </div>
+      </CardHeader>
+
+      <CardContent className="px-4 pb-4 pt-0 space-y-3">
+        {expanded && (
+          <div className="space-y-2">
+            <Label htmlFor={`approval-draft-${pending.id}`}>Draft (JSON)</Label>
+            <textarea
+              id={`approval-draft-${pending.id}`}
+              className="w-full min-h-[160px] rounded-md border border-input bg-background px-3 py-2 font-mono text-xs"
+              value={draftJson}
+              onChange={(e) => setDraftJson(e.target.value)}
+              disabled={disabled || submitting}
+            />
+          </div>
+        )}
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        <div className="flex items-center justify-end gap-2">
+          <Button type="button" variant="outline" size="sm" disabled={disabled || submitting} onClick={() => submit("reject")}>
+            Reject
+          </Button>
+          <Button type="button" size="sm" disabled={disabled || submitting} onClick={() => submit("approve")}>
+            Approve
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+

--- a/frontend/src/components/agent/chat/ExternalApprovalModal.tsx
+++ b/frontend/src/components/agent/chat/ExternalApprovalModal.tsx
@@ -1,0 +1,125 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { AgentAPI } from "@/lib/api/agentApi"
+import type { AgentChatRequest, SSEEvent } from "@/types/agent"
+
+export type PendingExternalApproval = {
+  id: string
+  kind: string
+  draft: Record<string, unknown>
+}
+
+type ExternalApprovalModalProps = {
+  open: boolean
+  sessionId: string
+  pending: PendingExternalApproval | null
+  onClose: () => void
+  onResolved: () => void
+}
+
+export function ExternalApprovalModal({
+  open,
+  sessionId,
+  pending,
+  onClose,
+  onResolved,
+}: ExternalApprovalModalProps) {
+  const [draftJson, setDraftJson] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!pending) return
+    try {
+      setDraftJson(JSON.stringify(pending.draft, null, 2))
+    } catch {
+      setDraftJson("{}")
+    }
+    setError(null)
+  }, [pending])
+
+  const submit = useCallback(
+    (decision: "approve" | "reject") => {
+      if (!pending) return
+      setSubmitting(true)
+      setError(null)
+      let parsedDraft: Record<string, unknown> | undefined
+      if (decision === "approve") {
+        try {
+          parsedDraft = JSON.parse(draftJson) as Record<string, unknown>
+        } catch {
+          setError("Draft must be valid JSON.")
+          setSubmitting(false)
+          return
+        }
+      }
+      const body: AgentChatRequest = {
+        message: ".",
+        action: "resolve_external_approval",
+        approval_id: pending.id,
+        approval_decision: decision,
+        approval_draft: decision === "approve" ? parsedDraft : undefined,
+      }
+      AgentAPI.sendMessage(
+        sessionId,
+        body,
+        (_ev: SSEEvent) => {
+          /* streamed chunks ignored here; chat list updates on next refresh */
+        },
+        (err) => {
+          setError(err.message)
+          setSubmitting(false)
+        },
+        () => {
+          setSubmitting(false)
+          onResolved()
+          onClose()
+        }
+      )
+    },
+    [pending, sessionId, draftJson, onClose, onResolved]
+  )
+
+  if (!pending) return null
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && !submitting && onClose()}>
+      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Approve external action</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground">
+          Type: <span className="font-medium text-foreground">{pending.kind.replace(/_/g, " ")}</span>
+        </p>
+        <div className="space-y-2">
+          <Label htmlFor="approval-draft">Draft (JSON)</Label>
+          <textarea
+            id="approval-draft"
+            className="w-full min-h-[160px] rounded-md border border-input bg-background px-3 py-2 font-mono text-xs"
+            value={draftJson}
+            onChange={(e) => setDraftJson(e.target.value)}
+          />
+        </div>
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button type="button" variant="outline" disabled={submitting} onClick={() => submit("reject")}>
+            Reject
+          </Button>
+          <Button type="button" disabled={submitting} onClick={() => submit("approve")}>
+            Approve
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/agent/chat/FloatingChatWindow.tsx
+++ b/frontend/src/components/agent/chat/FloatingChatWindow.tsx
@@ -23,20 +23,28 @@ export function FloatingChatWindow() {
   } = useFloatingChat()
   const dragControls = useDragControls()
   const [title, setTitle] = useState("New Chat")
+  const [approvalRequired, setApprovalRequired] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
 
   const isOpen = floatingChat.mode !== "closed"
   const isMaximized = floatingChat.mode === "maximized"
 
-  // Fetch session title when sessionId changes
+  // Fetch session title + approval toggle when sessionId changes
   useEffect(() => {
     if (!floatingChat.sessionId) {
       setTitle("New Chat")
+      setApprovalRequired(false)
       return
     }
     AgentAPI.getSession(floatingChat.sessionId)
-      .then((s) => setTitle(s.title || "Untitled"))
-      .catch(() => setTitle("Chat"))
+      .then((s) => {
+        setTitle(s.title || "Untitled")
+        setApprovalRequired(Boolean(s.approval_required))
+      })
+      .catch(() => {
+        setTitle("Chat")
+        setApprovalRequired(false)
+      })
   }, [floatingChat.sessionId])
 
   // Listen for session changes — update title or close if deleted
@@ -44,7 +52,10 @@ export function FloatingChatWindow() {
     const handler = () => {
       if (!floatingChat.sessionId) return
       AgentAPI.getSession(floatingChat.sessionId)
-        .then((s) => setTitle(s.title || "Untitled"))
+        .then((s) => {
+          setTitle(s.title || "Untitled")
+          setApprovalRequired(Boolean(s.approval_required))
+        })
         .catch(() => closeFloatingChat())
     }
     window.addEventListener("agent:sessions-changed", handler)
@@ -125,9 +136,12 @@ export function FloatingChatWindow() {
           <FloatingTitleBar
             title={title}
             onPointerDown={handleTitleBarPointerDown}
+            sessionId={floatingChat.sessionId}
+            approvalRequired={approvalRequired}
+            onApprovalChange={setApprovalRequired}
           />
           <div className="flex-1 overflow-hidden min-h-0">
-            <AgentChatPage />
+            <AgentChatPage embeddedInFloating />
           </div>
 
           {/* Resize handle — bottom-right corner, visible only when floating */}

--- a/frontend/src/components/agent/chat/FloatingTitleBar.tsx
+++ b/frontend/src/components/agent/chat/FloatingTitleBar.tsx
@@ -2,13 +2,26 @@
 
 import { GripVertical, Maximize2, Minimize2, X } from "lucide-react"
 import { useAgentLayout } from "../AgentLayoutContext"
+import { ApprovalToggle } from "./ApprovalToggle"
 
 interface FloatingTitleBarProps {
   title: string
   onPointerDown?: (e: React.PointerEvent) => void
+  /** When set, shows the same approval pill as the inline chat header. */
+  sessionId?: string | null
+  approvalRequired?: boolean
+  onApprovalChange?: (next: boolean) => void
+  approvalToggleDisabled?: boolean
 }
 
-export function FloatingTitleBar({ title, onPointerDown }: FloatingTitleBarProps) {
+export function FloatingTitleBar({
+  title,
+  onPointerDown,
+  sessionId,
+  approvalRequired = false,
+  onApprovalChange,
+  approvalToggleDisabled,
+}: FloatingTitleBarProps) {
   const { floatingChat, toggleMaximize, closeFloatingChat } = useAgentLayout()
   const isMaximized = floatingChat.mode === "maximized"
 
@@ -27,6 +40,23 @@ export function FloatingTitleBar({ title, onPointerDown }: FloatingTitleBarProps
       <span className="flex-1 text-sm font-medium text-foreground truncate px-1">
         {title}
       </span>
+
+      {sessionId ? (
+        <div
+          className="flex items-center gap-1.5 shrink-0 mr-1"
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          <span className="text-[11px] text-muted-foreground font-medium">
+            Approval
+          </span>
+          <ApprovalToggle
+            sessionId={sessionId}
+            value={approvalRequired}
+            onChange={onApprovalChange}
+            disabled={approvalToggleDisabled}
+          />
+        </div>
+      ) : null}
 
       {/* Maximize / Restore */}
       <button

--- a/frontend/src/components/agent/chat/MessageList.tsx
+++ b/frontend/src/components/agent/chat/MessageList.tsx
@@ -1,21 +1,34 @@
 "use client"
 
-import { useEffect, useRef } from "react"
+import { useEffect, useLayoutEffect, useRef } from "react"
 import { Bot, User, FileSpreadsheet, ArrowRight, CalendarPlus, UploadCloud } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { AGENT_MESSAGES } from "@/lib/agentMessages"
 import { AnomalyCard } from "./AnomalyCard"
 import { ColumnMappingCard } from "./ColumnMappingCard"
-import { DecisionCard } from "./DecisionCard"
 import { FollowUpCard } from "./FollowUpCard"
 import { MiroGenerateCard } from "./MiroGenerateCard"
 import { DistributeMessageCard } from "./DistributeMessageCard"
 import { TaskListCard } from "./TaskListCard"
+import { RecommendedMiroBoardCard } from "./RecommendedMiroBoardCard"
 import type { AnomalyItem, SuggestedDecision, RecommendedTask, WorkflowStepState, ColumnDetectionData } from "@/types/agent"
 import { StepProgress, type StepProgressItem } from "./StepProgress"
+import type { PendingExternalApproval } from "./ExternalApprovalModal"
+import type { TaskGenerationStatus } from "./TaskListCard"
 
-export type ChatMessageType = "text" | "analysis" | "file_uploaded" | "decision_created" | "tasks_created" | "miro_status" | "step_progress" | "error" | "calendar_invite" | "column_mapping"
+export type ChatMessageType =
+  | "text"
+  | "analysis"
+  | "file_uploaded"
+  | "decision_created"
+  | "tasks_created"
+  | "miro_status"
+  | "step_progress"
+  | "error"
+  | "calendar_invite"
+  | "column_mapping"
+  | "approval_request"
 
 export interface ChatMessage {
   id: string
@@ -36,18 +49,37 @@ export interface ChatMessage {
   workflowRunId?: string
   decisionId?: number
   stepProgress?: StepProgressItem[]
+  approval?: PendingExternalApproval
 }
 
-interface MessageListProps {
+export interface MessageListProps {
   messages: ChatMessage[]
   onAction?: (action: string) => void
   onNavigate?: (view: string, message?: ChatMessage) => void
   onConfirmColumns?: (mapping: Record<string, string>) => void
   onReupload?: () => void
+  sessionId?: string | null
+  approvalDisabled?: boolean
+  approvalRequired?: boolean
+  generatedTaskIndexes?: number[]
+  skippedTaskIndexes?: number[]
+  createdTaskIdByIndex?: Record<number, number>
+  generatingTasks?: boolean
+  pendingTaskApproval?: PendingExternalApproval | null
+  selectedTaskIndexes?: number[]
+  onSelectedTaskIndexesChange?: (next: number[]) => void
+  tasksApprovalGenerating?: boolean
+  onApproveSelectedTasks?: (selectedIndexes: number[], destination?: Record<string, unknown>) => void
+  onRejectTasksApproval?: () => void
+  pendingMiroApproval?: PendingExternalApproval | null
+  miroApprovalGenerating?: boolean
+  onApproveMiroApproval?: (destination?: Record<string, unknown>) => void
+  onRejectMiroApproval?: () => void
   latestAnalysisMessageId?: string | null
   showFollowUpToggle?: boolean
   followUpActive?: boolean
   stepState?: WorkflowStepState
+  taskGenerationStatus?: TaskGenerationStatus
 }
 
 export function MessageList({
@@ -56,20 +88,86 @@ export function MessageList({
   onNavigate,
   onConfirmColumns,
   onReupload,
+  sessionId,
+  approvalDisabled,
+  approvalRequired,
+  generatedTaskIndexes,
+  skippedTaskIndexes,
+  createdTaskIdByIndex,
+  generatingTasks,
+  pendingTaskApproval,
+  selectedTaskIndexes,
+  onSelectedTaskIndexesChange,
+  tasksApprovalGenerating,
+  onApproveSelectedTasks,
+  onRejectTasksApproval,
+  pendingMiroApproval,
+  miroApprovalGenerating,
+  onApproveMiroApproval,
+  onRejectMiroApproval,
   latestAnalysisMessageId,
   showFollowUpToggle,
   followUpActive,
   stepState,
+  taskGenerationStatus,
 }: MessageListProps) {
-  const bottomRef = useRef<HTMLDivElement>(null)
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const prevScrollTopRef = useRef(0)
+  const prevScrollHeightRef = useRef(0)
+  const wasAtBottomRef = useRef(true)
+  const hasAnalysisTaskCard = messages.some(
+    (m) => m.type === "analysis" && Array.isArray(m.recommendedTasks) && m.recommendedTasks.length > 0
+  )
+  const latestAnalysisWithTasks = [...messages]
+    .reverse()
+    .find((m) => m.type === "analysis" && Array.isArray(m.recommendedTasks) && m.recommendedTasks.length > 0)
 
+  // Track whether the user is currently at (or near) the bottom.
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" })
+    const el = scrollContainerRef.current
+    if (!el) return
+
+    const thresholdPx = 24
+    const update = () => {
+      const distanceFromBottom = el.scrollHeight - (el.scrollTop + el.clientHeight)
+      wasAtBottomRef.current = distanceFromBottom <= thresholdPx
+      prevScrollTopRef.current = el.scrollTop
+      prevScrollHeightRef.current = el.scrollHeight
+    }
+
+    update()
+    el.addEventListener("scroll", update, { passive: true })
+    return () => el.removeEventListener("scroll", update)
+  }, [])
+
+  // On new messages:
+  // - if user is at bottom, keep them at bottom
+  // - otherwise, preserve their viewport position (so new messages don't jump the scroll)
+  useLayoutEffect(() => {
+    const el = scrollContainerRef.current
+    if (!el) return
+
+    const prevScrollTop = prevScrollTopRef.current
+    const prevScrollHeight = prevScrollHeightRef.current
+    const nextScrollHeight = el.scrollHeight
+
+    if (wasAtBottomRef.current) {
+      el.scrollTop = nextScrollHeight
+    } else {
+      const delta = nextScrollHeight - prevScrollHeight
+      if (Number.isFinite(delta) && delta !== 0) {
+        el.scrollTop = prevScrollTop + delta
+      }
+    }
+
+    prevScrollTopRef.current = el.scrollTop
+    prevScrollHeightRef.current = el.scrollHeight
   }, [messages])
 
   return (
-    <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+    <div ref={scrollContainerRef} className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
       {messages.map((message) => (
+        message.type === "approval_request" ? null : (
         <div
           key={message.id}
           className={cn(
@@ -151,37 +249,31 @@ export function MessageList({
               <AnomalyCard anomalies={message.anomalies} />
             )}
 
-            {/* DecisionCard: show when analysis complete and decision not yet created (or no stepState = backward compat) */}
-            {message.suggestedDecision && (!stepState || (stepState.analysisComplete && !stepState.decisionCreated)) && (
-              <DecisionCard
-                decision={message.suggestedDecision}
-                onCreateDecision={() => onAction?.("confirm_decision")}
-                onDismiss={() => {}}
-              />
-            )}
-
-            {/* TaskListCard:
-                - On analysis messages: show only BEFORE decision is created (decision card is still active)
-                - On decision_created messages: show AFTER decision created but before tasks created
-                This prevents the card from appearing twice when both message types have recommendedTasks. */}
-            {message.recommendedTasks && message.recommendedTasks.length > 0 && (
-              (message.type === "decision_created" && (!stepState || (stepState.decisionCreated && !stepState.tasksCreated))) ||
-              (message.type !== "decision_created" && (!stepState || (stepState.decisionCreated && !stepState.tasksCreated)) && !stepState?.decisionCreated)
-            ) && (
-              <TaskListCard
-                tasks={message.recommendedTasks}
-                onCreateAll={() => onAction?.("create_tasks")}
-              />
-            )}
-
-            {/* MiroGenerateCard + DistributeMessageCard: only on decision_created message, after tasks created */}
-            {message.type === "decision_created" && message.recommendedTasks && message.recommendedTasks.length > 0 && (!stepState || stepState.tasksCreated) && (
-              <MiroGenerateCard onGenerate={() => onAction?.("generate_miro")} />
-            )}
-
-            {message.type === "decision_created" && message.recommendedTasks && message.recommendedTasks.length > 0 && (!stepState || stepState.tasksCreated) && (
-              <DistributeMessageCard onDistribute={() => onAction?.("distribute_message")} />
-            )}
+            {/* TaskListCard: primary review surface. Prefer rendering on analysis messages. */}
+            {message.recommendedTasks &&
+              message.recommendedTasks.length > 0 &&
+              (message.type === "analysis" || (!hasAnalysisTaskCard && message.type === "decision_created")) && (
+                <TaskListCard
+                  tasks={message.recommendedTasks}
+                  approvalRequired={approvalRequired}
+                  generatedTaskIndexes={generatedTaskIndexes}
+                  skippedTaskIndexes={skippedTaskIndexes}
+                  createdTaskIdByIndex={createdTaskIdByIndex}
+                  generating={Boolean(tasksApprovalGenerating) || Boolean(generatingTasks)}
+                  generationStatus={taskGenerationStatus}
+                  approvalMode={Boolean(pendingTaskApproval)}
+                  selectedIndexes={selectedTaskIndexes}
+                  onSelectedIndexesChange={onSelectedTaskIndexesChange}
+                  onCreateSelected={pendingTaskApproval ? onApproveSelectedTasks : undefined}
+                  onRejectApproval={pendingTaskApproval ? onRejectTasksApproval : undefined}
+                  createButtonDisabled={Boolean(approvalDisabled) || Boolean(tasksApprovalGenerating)}
+                  onCreateAll={
+                    !pendingTaskApproval && stepState?.decisionCreated && !stepState?.tasksCreated
+                      ? () => onAction?.("create_tasks")
+                      : undefined
+                  }
+                />
+              )}
 
             {showFollowUpToggle && message.id === latestAnalysisMessageId && (!stepState || stepState.tasksCreated) && (
               <FollowUpCard
@@ -191,7 +283,36 @@ export function MessageList({
             )}
           </div>
         </div>
+        )
       ))}
+
+      {/* Action cards shown at the bottom so they're immediately visible after task creation. */}
+      {latestAnalysisWithTasks &&
+        (Boolean(stepState?.tasksCreated) || Boolean(pendingTaskApproval) || taskGenerationStatus === "awaiting_approval") && (
+        <div className="space-y-3">
+          <MiroGenerateCard
+            onGenerate={() => onAction?.("generate_miro")}
+            disabled={!Boolean(stepState?.tasksCreated) && Boolean(approvalRequired)}
+            disabledHint={
+              !Boolean(stepState?.tasksCreated) && Boolean(approvalRequired)
+                ? "Approve task creation to enable Miro generation."
+                : undefined
+            }
+          />
+          <DistributeMessageCard onDistribute={() => onAction?.("distribute_message")} />
+        </div>
+      )}
+
+      {pendingMiroApproval && (
+        <RecommendedMiroBoardCard
+          pending={pendingMiroApproval}
+          disabled={Boolean(approvalDisabled)}
+          generating={Boolean(miroApprovalGenerating)}
+          onApprove={onApproveMiroApproval}
+          onReject={onRejectMiroApproval}
+        />
+      )}
+
       {stepState?.analysisComplete && (
         <div className="flex justify-center pt-2 pb-1">
           <Button
@@ -205,7 +326,6 @@ export function MessageList({
           </Button>
         </div>
       )}
-      <div ref={bottomRef} />
     </div>
   )
 }

--- a/frontend/src/components/agent/chat/MiroGenerateCard.tsx
+++ b/frontend/src/components/agent/chat/MiroGenerateCard.tsx
@@ -7,9 +7,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 
 interface MiroGenerateCardProps {
   onGenerate?: () => void
+  disabled?: boolean
+  disabledHint?: string
 }
 
-export function MiroGenerateCard({ onGenerate }: MiroGenerateCardProps) {
+export function MiroGenerateCard({ onGenerate, disabled = false, disabledHint }: MiroGenerateCardProps) {
   return (
     <Card className="bg-card border-border">
       <CardHeader className="pb-3 pt-4 px-4">
@@ -18,7 +20,7 @@ export function MiroGenerateCard({ onGenerate }: MiroGenerateCardProps) {
             <LayoutTemplate className="h-4 w-4 text-primary" />
           </div>
           <CardTitle className="text-sm font-semibold text-card-foreground">
-            Miro Board
+            Recommended Miro Board
           </CardTitle>
         </div>
       </CardHeader>
@@ -26,7 +28,12 @@ export function MiroGenerateCard({ onGenerate }: MiroGenerateCardProps) {
         <p className="text-sm text-foreground">
           Generate a Miro board from the current analysis, suggested decision, and recommended tasks.
         </p>
-        <Button size="sm" variant="outline" onClick={onGenerate}>
+        {disabled && disabledHint ? (
+          <p className="text-xs text-muted-foreground">
+            {disabledHint}
+          </p>
+        ) : null}
+        <Button size="sm" variant="outline" onClick={onGenerate} disabled={disabled}>
           Generate Miro
         </Button>
       </CardContent>

--- a/frontend/src/components/agent/chat/RecommendedMiroBoardCard.tsx
+++ b/frontend/src/components/agent/chat/RecommendedMiroBoardCard.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { LayoutTemplate, Loader2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type { PendingExternalApproval } from "./ExternalApprovalModal"
+
+type RecommendedMiroBoardCardProps = {
+  pending: PendingExternalApproval
+  disabled?: boolean
+  generating?: boolean
+  onApprove?: () => void
+  onReject?: () => void
+}
+
+export function RecommendedMiroBoardCard({
+  pending,
+  disabled,
+  generating,
+  onApprove,
+  onReject,
+}: RecommendedMiroBoardCardProps) {
+  return (
+    <Card className="bg-card border-border">
+      <CardHeader className="pb-3 pt-4 px-4">
+        <div className="flex items-center gap-3">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/20 shrink-0">
+            <LayoutTemplate className="h-4 w-4 text-primary" />
+          </div>
+          <div className="min-w-0">
+            <CardTitle className="text-sm font-semibold text-card-foreground truncate">
+              Recommended Miro Board
+            </CardTitle>
+            <p className="text-xs text-muted-foreground truncate">
+              Review destination and approve generation.
+            </p>
+          </div>
+          {generating && (
+            <span className="ml-auto inline-flex items-center text-muted-foreground" title="Generating Miro...">
+              <Loader2 className="h-4 w-4 animate-spin" />
+            </span>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="px-4 pb-4 pt-0 space-y-3">
+        <div className="flex items-center justify-end gap-2">
+          <Button type="button" variant="outline" size="sm" disabled={disabled || generating} onClick={() => onReject?.()}>
+            Reject
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            disabled={disabled || generating}
+            onClick={() => onApprove?.()}
+          >
+            Approve
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+

--- a/frontend/src/components/agent/chat/TaskListCard.tsx
+++ b/frontend/src/components/agent/chat/TaskListCard.tsx
@@ -1,8 +1,9 @@
 "use client"
 
+import { useMemo, useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { ListChecks } from "lucide-react"
+import { CheckCircle2, ChevronDown, ChevronRight, Clock, ListChecks, Loader2, AlertCircle, XCircle } from "lucide-react"
 import { cn } from "@/lib/utils"
 import type { RecommendedTask } from "@/types/agent"
 
@@ -12,13 +13,127 @@ const priorityColors = {
   LOW: { bg: "bg-green-500/20", text: "text-green-400" },
 } as const
 
+export type TaskGenerationStatus = "idle" | "generating" | "awaiting_approval" | "completed" | "error"
+
 interface TaskListCardProps {
   tasks: RecommendedTask[]
+  /** Legacy action (pre-approval selection): creates tasks for all recommendations. */
   onCreateAll?: () => void
+  approvalRequired?: boolean
+  /** Indexes of recommended tasks that have been created in the DB. */
+  generatedTaskIndexes?: number[]
+  /** Indexes of recommendations the user explicitly chose NOT to create (approval flow). */
+  skippedTaskIndexes?: number[]
+  /** Map from recommended task index -> created Task ID for deep-link navigation. */
+  createdTaskIdByIndex?: Record<number, number>
+  /** When true (approval off), but tasks not yet created, show a generating state. */
+  generating?: boolean
+  /** When true, render selection + destination + reject/create actions. */
+  approvalMode?: boolean
+  selectedIndexes?: number[]
+  onSelectedIndexesChange?: (next: number[]) => void
+  onCreateSelected?: (selectedIndexes: number[]) => void
+  onRejectApproval?: () => void
+  createButtonDisabled?: boolean
+  generationStatus?: TaskGenerationStatus
 }
 
-export function TaskListCard({ tasks, onCreateAll }: TaskListCardProps) {
+export function TaskListCard({
+  tasks,
+  onCreateAll,
+  approvalRequired,
+  generatedTaskIndexes,
+  skippedTaskIndexes,
+  createdTaskIdByIndex,
+  generating,
+  approvalMode,
+  selectedIndexes,
+  onSelectedIndexesChange,
+  onCreateSelected,
+  onRejectApproval,
+  createButtonDisabled,
+  generationStatus = "idle",
+}: TaskListCardProps) {
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null)
+
+  const generatedSet = useMemo(() => {
+    return new Set(Array.isArray(generatedTaskIndexes) ? generatedTaskIndexes : [])
+  }, [generatedTaskIndexes])
+
+  const skippedSet = useMemo(() => {
+    return new Set(Array.isArray(skippedTaskIndexes) ? skippedTaskIndexes : [])
+  }, [skippedTaskIndexes])
+
+  const selectedSet = useMemo(() => {
+    return new Set(Array.isArray(selectedIndexes) ? selectedIndexes : [])
+  }, [selectedIndexes])
+
+  const toggleSelected = (idx: number) => {
+    const next = new Set(selectedSet)
+    if (next.has(idx)) next.delete(idx)
+    else next.add(idx)
+    onSelectedIndexesChange?.(Array.from(next).sort((a, b) => a - b))
+  }
+
+  const canCreateSelected =
+    approvalMode &&
+    typeof onCreateSelected === "function" &&
+    selectedSet.size > 0 &&
+    !createButtonDisabled
+
+  // In approval mode, we still want the Create Tasks button visible while the user is
+  // deciding which tasks to create (even if the global status shows "Awaiting approval").
+  // Hide only once we're actively generating/creating tasks (or disabled).
+  const showCreateActions = approvalMode
+    ? generationStatus !== "generating" && !generating && !createButtonDisabled
+    : generationStatus === "idle" && !generating && !createButtonDisabled
+
+  const handleRowClick = (idx: number) => {
+    const taskId = createdTaskIdByIndex?.[idx]
+    if (taskId != null && Number.isFinite(taskId)) {
+      window.location.href = `/tasks/${taskId}`
+      return
+    }
+    setExpandedIndex((prev) => (prev === idx ? null : idx))
+  }
+
   if (!tasks.length) return null
+
+  const statusChip = (() => {
+    if (generationStatus === "generating") {
+      return (
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-muted/60 px-2 py-0.5 text-[11px] text-muted-foreground">
+          <Loader2 className="h-3 w-3 animate-spin" />
+          Generating…
+        </span>
+      )
+    }
+    if (generationStatus === "awaiting_approval") {
+      return (
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-muted/60 px-2 py-0.5 text-[11px] text-muted-foreground">
+          <Clock className="h-3 w-3" />
+          Awaiting approval
+        </span>
+      )
+    }
+    if (generationStatus === "completed") {
+      return (
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2 py-0.5 text-[11px] text-emerald-600">
+          <CheckCircle2 className="h-3 w-3" />
+          Generated
+        </span>
+      )
+    }
+    if (generationStatus === "error") {
+      return (
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-destructive/10 px-2 py-0.5 text-[11px] text-destructive">
+          <AlertCircle className="h-3 w-3" />
+          Failed
+        </span>
+      )
+    }
+    return null
+  })()
 
   return (
     <Card className="bg-card border-border">
@@ -27,32 +142,152 @@ export function TaskListCard({ tasks, onCreateAll }: TaskListCardProps) {
           <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/20 shrink-0">
             <ListChecks className="h-4 w-4 text-primary" />
           </div>
-          <CardTitle className="text-sm font-semibold text-card-foreground">
-            Recommended Tasks ({tasks.length})
-          </CardTitle>
+          <div className="min-w-0 flex-1">
+            <CardTitle className="text-sm font-semibold text-card-foreground">
+              Recommended Tasks ({tasks.length})
+            </CardTitle>
+          </div>
+          {statusChip ? <div className="shrink-0">{statusChip}</div> : null}
         </div>
       </CardHeader>
       <CardContent className="px-4 pb-4 pt-0 space-y-2">
         {tasks.map((task, i) => {
           const priority = priorityColors[task.priority] || priorityColors.MEDIUM
+          const isGenerated = generatedSet.has(i)
+          const isSelected = selectedSet.has(i)
+          const isSkipped = skippedSet.has(i)
+          const statusNode = (() => {
+            if (isGenerated) {
+              return (
+                <span
+                  className="inline-flex items-center text-emerald-600"
+                  title={`${task.summary} is generated`}
+                >
+                  <CheckCircle2 className="h-4 w-4" />
+                </span>
+              )
+            }
+            if (isSkipped) {
+              return (
+                <span
+                  className="inline-flex items-center text-destructive"
+                  title={`${task.summary} was not selected`}
+                >
+                  <XCircle className="h-4 w-4" />
+                </span>
+              )
+            }
+            if (generating || generationStatus === "generating") {
+              return (
+                <span
+                  className="inline-flex items-center text-muted-foreground"
+                  title="Generating tasks..."
+                >
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                </span>
+              )
+            }
+            if (approvalRequired) {
+              return (
+                <span
+                  className="inline-flex items-center text-muted-foreground"
+                  title="Waiting for approval"
+                >
+                  <Clock className="h-4 w-4" />
+                </span>
+              )
+            }
+            return null
+          })()
           return (
-            <div key={i} className="flex items-start gap-3 py-1.5">
-              <span className={cn("text-xs font-medium px-2 py-0.5 rounded-full shrink-0 mt-0.5", priority.bg, priority.text)}>
-                {task.priority}
-              </span>
-              <div className="flex-1 min-w-0">
-                <p className="text-sm text-foreground">{task.summary}</p>
-                <p className="text-xs text-muted-foreground capitalize">{task.type}</p>
-              </div>
+            <div
+              key={i}
+              className={cn(
+                "rounded-md hover:bg-muted/40 transition-colors",
+                approvalMode && isSelected && "bg-muted/40"
+              )}
+            >
+              <button
+                type="button"
+                className="w-full text-left flex items-start gap-3 py-2 px-2 rounded-md"
+                onClick={() => handleRowClick(i)}
+              >
+                {approvalMode && (
+                  <input
+                    type="checkbox"
+                    checked={isSelected}
+                    onChange={() => toggleSelected(i)}
+                    onClick={(e) => e.stopPropagation()}
+                    className="mt-1 h-4 w-4 shrink-0 rounded border border-input"
+                    disabled={createButtonDisabled || isGenerated}
+                    aria-label={`Select task ${i + 1}`}
+                  />
+                )}
+                <span
+                  className={cn(
+                    "text-xs font-medium px-2 py-0.5 rounded-full shrink-0 mt-0.5",
+                    priority.bg,
+                    priority.text
+                  )}
+                >
+                  {task.priority}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm text-foreground">{task.summary}</p>
+                  <p className="text-xs text-muted-foreground capitalize">{task.type}</p>
+                </div>
+                <div className="flex items-center gap-2 shrink-0 pt-0.5">
+                  {statusNode}
+                  {expandedIndex === i ? (
+                    <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                  ) : (
+                    <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                  )}
+                </div>
+              </button>
+              {expandedIndex === i && (
+                <div className={cn("px-2 pb-2", approvalMode ? "pl-[72px]" : "pl-[52px]")}>
+                  <p className="text-xs text-muted-foreground whitespace-pre-wrap">
+                    {task.description?.trim() ? task.description : "No description provided."}
+                  </p>
+                </div>
+              )}
             </div>
           )
         })}
 
-        <div className="pt-2">
-          <Button size="sm" onClick={onCreateAll}>
-            Create All Tasks
-          </Button>
-        </div>
+        {approvalMode && showCreateActions && onRejectApproval && onCreateSelected && (
+          <div className="pt-2 flex items-center justify-end gap-2">
+            <Button size="sm" variant="outline" onClick={onRejectApproval} disabled={createButtonDisabled}>
+              Reject
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => {
+                const selected = Array.from(selectedSet)
+                onSelectedIndexesChange?.([])
+                onCreateSelected(selected)
+              }}
+              disabled={!canCreateSelected}
+            >
+              Create Tasks
+            </Button>
+          </div>
+        )}
+
+        {onCreateAll && !approvalMode && showCreateActions && (
+          <div className="pt-2">
+            <Button
+              size="sm"
+              onClick={() => {
+                onSelectedIndexesChange?.([])
+                onCreateAll()
+              }}
+            >
+              Create Tasks
+            </Button>
+          </div>
+        )}
       </CardContent>
     </Card>
   )

--- a/frontend/src/components/agent/chat/WelcomeScreen.tsx
+++ b/frontend/src/components/agent/chat/WelcomeScreen.tsx
@@ -10,9 +10,11 @@ interface WelcomeScreenProps {
   onSend: (message: string) => void
   onFileUpload: (file: File) => void
   disabled?: boolean
+  /** When the parent renders its own composer, hide the built-in ChatInput. */
+  showComposer?: boolean
 }
 
-export function WelcomeScreen({ onSend, onFileUpload, disabled }: WelcomeScreenProps) {
+export function WelcomeScreen({ onSend, onFileUpload, disabled, showComposer = true }: WelcomeScreenProps) {
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const handleUploadClick = () => {
@@ -64,14 +66,16 @@ export function WelcomeScreen({ onSend, onFileUpload, disabled }: WelcomeScreenP
         </div>
       </div>
 
-      <div className="shrink-0">
-        <ChatInput
-          onSend={onSend}
-          onFileUpload={onFileUpload}
-          disabled={disabled}
-          placeholder="Or type your question..."
-        />
-      </div>
+      {showComposer ? (
+        <div className="shrink-0">
+          <ChatInput
+            onSend={onSend}
+            onFileUpload={onFileUpload}
+            disabled={disabled}
+            placeholder="Or type your question..."
+          />
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/frontend/src/components/agent/layout/LeftSidebar.tsx
+++ b/frontend/src/components/agent/layout/LeftSidebar.tsx
@@ -41,13 +41,14 @@ function formatTimeAgo(iso: string): string {
 }
 
 export function LeftSidebar() {
-  const { activeView, isViewReady, setActiveView, openFloatingChat, floatingChat, isInSnapZone } = useAgentLayout()
+  const { activeView, isViewReady, setActiveView, openFloatingChat, closeFloatingChat, floatingChat, isInSnapZone } = useAgentLayout()
   const [recentSessions, setRecentSessions] = useState<SessionItem[]>([])
   const [sessionsLoading, setSessionsLoading] = useState(true)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editTitle, setEditTitle] = useState("")
   const editInputRef = useRef<HTMLInputElement>(null)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [pendingDeleteSession, setPendingDeleteSession] = useState<SessionItem | null>(null)
 
   const loadSessions = async (showLoading = false) => {
     if (showLoading) {
@@ -107,10 +108,23 @@ export function LeftSidebar() {
     }
   }, [editingId])
 
-  const handleNewChat = (e: React.MouseEvent) => {
+  const handleNewChat = async (e: React.MouseEvent) => {
     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+
+    // Open immediately for responsiveness, then attach a real sessionId once created.
+    // The approval toggle only renders once sessionId exists.
     sessionStorage.removeItem("agent-session-id")
     openFloatingChat(null, rect)
+
+    try {
+      const session = await AgentAPI.createSession({})
+      const sid = String(session.id)
+      sessionStorage.setItem("agent-session-id", sid)
+      openFloatingChat(sid, rect)
+      window.dispatchEvent(new CustomEvent("agent:sessions-changed"))
+    } catch {
+      // Keep the welcome screen (no session yet) on failure.
+    }
   }
 
   const handleSelectSession = (sessionId: string, e: React.MouseEvent) => {
@@ -153,6 +167,24 @@ export function LeftSidebar() {
   const handleDeleteConfirm = async () => {
     setShowDeleteConfirm(false)
     await batch.deleteSelected()
+  }
+
+  const handleSingleDeleteConfirm = async () => {
+    const s = pendingDeleteSession
+    if (!s) return
+    setPendingDeleteSession(null)
+    try {
+      await AgentAPI.deleteSession(s.id)
+      setRecentSessions((prev) => prev.filter((x) => x.id !== s.id))
+      window.dispatchEvent(new CustomEvent("agent:sessions-changed"))
+      if (floatingChat.sessionId === s.id && floatingChat.mode !== "closed") {
+        closeFloatingChat()
+        sessionStorage.removeItem("agent-session-id")
+        window.dispatchEvent(new CustomEvent("agent:new-chat"))
+      }
+    } catch {
+      // ignore
+    }
   }
 
   return (
@@ -325,6 +357,17 @@ export function LeftSidebar() {
                     >
                       <Pencil className="w-3 h-3" />
                     </button>
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        setPendingDeleteSession(session)
+                      }}
+                      className="opacity-0 group-hover:opacity-100 text-muted-foreground/60 hover:text-red-500 shrink-0 transition-opacity"
+                      title="Delete"
+                      aria-label="Delete dialogue"
+                    >
+                      <X className="w-3.5 h-3.5" />
+                    </button>
                     <span className="text-[10px] text-muted-foreground/50 shrink-0">{session.time}</span>
                   </button>
                 )}
@@ -362,6 +405,21 @@ export function LeftSidebar() {
         cancelText="Cancel"
         onConfirm={handleDeleteConfirm}
         onCancel={() => setShowDeleteConfirm(false)}
+      />
+
+      <ConfirmDialog
+        isOpen={pendingDeleteSession != null}
+        title="Delete Dialogue"
+        message={
+          pendingDeleteSession
+            ? `Delete "${pendingDeleteSession.title}"? This action cannot be undone.`
+            : ""
+        }
+        type="danger"
+        confirmText="Delete"
+        cancelText="Cancel"
+        onConfirm={handleSingleDeleteConfirm}
+        onCancel={() => setPendingDeleteSession(null)}
       />
     </div>
   )

--- a/frontend/src/components/agent/layout/RightPanel.tsx
+++ b/frontend/src/components/agent/layout/RightPanel.tsx
@@ -7,6 +7,8 @@ import { AnomalyAlerts } from "../overview/AnomalyAlerts"
 import { RecentDecisions } from "../overview/RecentDecisions"
 import { AgentAPI } from "@/lib/api/agentApi"
 import { AgentDecisionListSkeleton } from "@/components/agent/skeletons/AgentSkeletons"
+import { Button } from "@/components/ui/button"
+import { CheckCircle2, X, XCircle } from "lucide-react"
 
 type TabValue = "alerts" | "decisions"
 
@@ -15,11 +17,21 @@ const tabs: { value: TabValue; label: string }[] = [
   { value: "decisions", label: "Decisions" },
 ]
 
+type MiroDialogState =
+  | null
+  | {
+      status: "success" | "failed"
+      boardId?: string
+      workflowRunId?: string
+      lastUpdatedAt: number
+    }
+
 export function RightPanel() {
   const { isRightPanelOpen, setActiveView, setPendingDecisionId } = useAgentLayout()
   const [activeTab, setActiveTab] = useState<TabValue>("alerts")
   const [anomalies, setAnomalies] = useState<{ type: string; severity: string; campaign: string; description: string; cost: number; roas?: number }[]>([])
   const [anomaliesLoading, setAnomaliesLoading] = useState(true)
+  const [miroDialog, setMiroDialog] = useState<MiroDialogState>(null)
 
   // Load latest anomalies from backend on mount
   useEffect(() => {
@@ -68,6 +80,24 @@ export function RightPanel() {
     return () => window.removeEventListener("agent:add-alert", handler)
   }, [])
 
+  // Listen for Miro generation completion events from chat.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail as
+        | { status?: "success" | "failed"; boardId?: string; workflowRunId?: string }
+        | undefined
+      if (!detail?.status) return
+      setMiroDialog({
+        status: detail.status,
+        boardId: detail.boardId,
+        workflowRunId: detail.workflowRunId,
+        lastUpdatedAt: Date.now(),
+      })
+    }
+    window.addEventListener("agent:miro-status", handler)
+    return () => window.removeEventListener("agent:miro-status", handler)
+  }, [])
+
   const handleDecisionSelect = (decisionId: number) => {
     setActiveView("decisions")
     setPendingDecisionId(decisionId)
@@ -104,6 +134,63 @@ export function RightPanel() {
         <div className="flex-1 overflow-y-auto">
           {/* Alerts Tab */}
           <div className={cn("p-3", activeTab !== "alerts" && "hidden")}>
+            {miroDialog && (
+              <div
+                className={cn(
+                  "mb-3 rounded-lg border px-3 py-2 text-sm",
+                  miroDialog.status === "success"
+                    ? "border-emerald-200 bg-emerald-50 text-emerald-900"
+                    : "border-destructive/20 bg-destructive/10 text-foreground"
+                )}
+              >
+                <div className="flex items-start gap-2">
+                  <div className="mt-0.5 shrink-0">
+                    {miroDialog.status === "success" ? (
+                      <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+                    ) : (
+                      <XCircle className="h-4 w-4 text-destructive" />
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <p className="font-medium">
+                          {miroDialog.status === "success"
+                            ? "Miro board generated successfully."
+                            : "Miro board generation failed."}
+                        </p>
+                        {miroDialog.status !== "success" && (
+                          <p className="text-xs text-muted-foreground mt-0.5">
+                            Please try again.
+                          </p>
+                        )}
+                      </div>
+                      <button
+                        type="button"
+                        className="shrink-0 rounded-md p-1 hover:bg-black/5"
+                        aria-label="Dismiss"
+                        onClick={() => setMiroDialog(null)}
+                      >
+                        <X className="h-4 w-4 text-muted-foreground" />
+                      </button>
+                    </div>
+                    {miroDialog.status === "success" && miroDialog.boardId && (
+                      <div className="mt-2">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => {
+                            window.location.href = `/miro/${miroDialog.boardId}`
+                          }}
+                        >
+                          Open Miro board
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
             <AnomalyAlerts anomalies={anomalies} loading={anomaliesLoading} compact />
           </div>
 

--- a/frontend/src/components/agent/taskboard/KanbanColumn.tsx
+++ b/frontend/src/components/agent/taskboard/KanbanColumn.tsx
@@ -13,6 +13,7 @@ interface KanbanColumnProps {
   exitingIds?: Set<string | number>
   onToggleSelect?: (id: string | number) => void
   onCardClick?: (task: Task) => void
+  onDeleteDraftTask?: (task: Task) => void
 }
 
 const statusLabels: Record<ColumnStatus, string> = {
@@ -22,9 +23,9 @@ const statusLabels: Record<ColumnStatus, string> = {
   APPROVED: "Approved",
 }
 
-export function KanbanColumn({ status, tasks, isManaging, selectedIds, exitingIds, onToggleSelect, onCardClick }: KanbanColumnProps) {
+export function KanbanColumn({ status, tasks, isManaging, selectedIds, exitingIds, onToggleSelect, onCardClick, onDeleteDraftTask }: KanbanColumnProps) {
   return (
-    <div className="flex min-w-[280px] flex-1 flex-col rounded-lg bg-card/50">
+    <div className="flex w-full flex-col rounded-lg bg-card/50 min-h-0">
       <div className="flex items-center justify-between p-3 border-b border-border">
         <h3 className="text-sm font-semibold text-foreground">
           {statusLabels[status]}
@@ -50,6 +51,7 @@ export function KanbanColumn({ status, tasks, isManaging, selectedIds, exitingId
                 isSelected={selectedIds?.has(task.id)}
                 onToggleSelect={() => onToggleSelect?.(task.id)}
                 onClick={() => onCardClick?.(task)}
+                onDeleteClick={() => onDeleteDraftTask?.(task)}
               />
             </div>
           ))}

--- a/frontend/src/components/agent/taskboard/TaskBoard.tsx
+++ b/frontend/src/components/agent/taskboard/TaskBoard.tsx
@@ -5,8 +5,7 @@ import { FilterBar } from "./FilterBar"
 import { KanbanColumn, type ColumnStatus } from "./KanbanColumn"
 import type { Task, TaskType, TaskPriority } from "./TaskCard"
 import { TaskAPI } from "@/lib/api/taskApi"
-// import { useBatchManage } from "@/hooks/useBatchManage"
-// import ConfirmDialog from "@/components/common/ConfirmDialog"
+import ConfirmDialog from "@/components/common/ConfirmDialog"
 import { TaskDetailModal } from "./TaskDetailModal"
 import { NewTaskModal } from "./NewTaskModal"
 // import toast from "react-hot-toast"
@@ -15,6 +14,14 @@ import { TaskFilterPanel } from "@/components/tasks/TaskFilterPanel"
 import { AgentTaskBoardSkeleton } from "@/components/agent/skeletons/AgentSkeletons"
 
 const columns: ColumnStatus[] = ["DRAFT", "SUBMITTED", "UNDER_REVIEW", "APPROVED"]
+const DEFAULT_COL_WIDTH = 320
+const MIN_COL_WIDTH = 240
+const MAX_COL_WIDTH = 640
+const COL_WIDTHS_STORAGE_KEY = "agent-taskboard:column-widths:v1"
+
+function clamp(n: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, n))
+}
 
 function getInitials(name: string): string {
   return name
@@ -40,11 +47,62 @@ export function TaskBoard() {
   const [typeFilter, setTypeFilter] = useState("all")
   const [priorityFilter, setPriorityFilter] = useState("all")
   const [ownerFilter, setOwnerFilter] = useState("all")
-  // const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [selectedTask, setSelectedTask] = useState<Task | null>(null)
   const [showNewTask, setShowNewTask] = useState(false)
+  const [pendingDeleteTask, setPendingDeleteTask] = useState<Task | null>(null)
+  const [deleting, setDeleting] = useState(false)
 
   const [filters, setFilters, clearFilters] = useTaskFilterParams()
+
+  const [columnWidths, setColumnWidths] = useState<Record<ColumnStatus, number>>(() => {
+    const defaults = Object.fromEntries(columns.map((c) => [c, DEFAULT_COL_WIDTH])) as Record<ColumnStatus, number>
+    if (typeof window === "undefined") return defaults
+    try {
+      const raw = window.localStorage.getItem(COL_WIDTHS_STORAGE_KEY)
+      if (!raw) return defaults
+      const parsed = JSON.parse(raw) as Record<string, unknown>
+      const out = { ...defaults }
+      for (const c of columns) {
+        const v = parsed?.[c]
+        if (typeof v === "number" && Number.isFinite(v)) {
+          out[c] = clamp(v, MIN_COL_WIDTH, MAX_COL_WIDTH)
+        }
+      }
+      return out
+    } catch {
+      return defaults
+    }
+  })
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(COL_WIDTHS_STORAGE_KEY, JSON.stringify(columnWidths))
+    } catch {
+      // ignore
+    }
+  }, [columnWidths])
+
+  const handleStartResize = useCallback((status: ColumnStatus, e: React.PointerEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    const startX = e.clientX
+    const startWidth = columnWidths[status] ?? DEFAULT_COL_WIDTH
+
+    const onMove = (ev: PointerEvent) => {
+      const dx = ev.clientX - startX
+      const next = clamp(startWidth + dx, MIN_COL_WIDTH, MAX_COL_WIDTH)
+      setColumnWidths((prev) => (prev[status] === next ? prev : { ...prev, [status]: next }))
+    }
+
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove)
+      window.removeEventListener("pointerup", onUp)
+    }
+
+    window.addEventListener("pointermove", onMove)
+    window.addEventListener("pointerup", onUp)
+  }, [columnWidths])
 
   const reload = useCallback(async () => {
     setLoading(true)
@@ -140,35 +198,72 @@ export function TaskBoard() {
         onNewTask={() => setShowNewTask(true)}
       />
 
-      <div className="flex gap-4 flex-1 overflow-hidden">
-        {columns.map((status) => (
-          <KanbanColumn
-            key={status}
-            status={status}
-            tasks={filteredTasks.filter((t) => t.status === status)}
-            onCardClick={(task) => setSelectedTask(task)}
-          />
-        ))}
+      {/* Horizontal scroll container so columns never push the page width */}
+      <div className="flex-1 min-h-0 overflow-x-auto overflow-y-hidden">
+        <div className="flex h-full w-max min-w-full gap-4 pr-1">
+          {columns.map((status, idx) => (
+            <div
+              key={status}
+              className="relative h-full shrink-0"
+              style={{ width: columnWidths[status] ?? DEFAULT_COL_WIDTH }}
+            >
+              <KanbanColumn
+                status={status}
+                tasks={filteredTasks.filter((t) => t.status === status)}
+                onCardClick={(task) => setSelectedTask(task)}
+                onDeleteDraftTask={(task) => setPendingDeleteTask(task)}
+              />
+
+              {/* Resize bar between column titles */}
+              {idx < columns.length - 1 && (
+                <div
+                  role="separator"
+                  aria-orientation="vertical"
+                  onPointerDown={(e) => handleStartResize(status, e)}
+                  className="group absolute right-[-10px] top-0 z-10 h-12 w-5 cursor-col-resize"
+                  title="Drag to resize column"
+                >
+                  {/* Keep hit-area wide, but only show a short bar on hover */}
+                  <div className="mx-auto mt-3 h-6 w-[3px] rounded-full bg-muted-foreground/40 opacity-0 transition-opacity duration-150 group-hover:opacity-100" />
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
       </div>
 
       <TaskDetailModal task={selectedTask} onClose={() => setSelectedTask(null)} />
       <NewTaskModal open={showNewTask} onClose={() => setShowNewTask(false)} onCreated={reload} />
 
-      {/* Manage batch delete confirm dialog removed
       <ConfirmDialog
-        isOpen={showDeleteConfirm}
-        title="Delete Tasks"
-        message={`Are you sure you want to delete ${batch.selectedCount} task${batch.selectedCount > 1 ? "s" : ""}? This action cannot be undone.`}
+        isOpen={pendingDeleteTask != null}
+        title="Delete Draft Task"
+        message={
+          pendingDeleteTask
+            ? `Delete "${pendingDeleteTask.summary}"? This action cannot be undone.`
+            : ""
+        }
         type="danger"
         confirmText="Delete"
         cancelText="Cancel"
-        onConfirm={() => {
-          setShowDeleteConfirm(false)
-          batch.deleteSelected()
+        onConfirm={async () => {
+          const t = pendingDeleteTask
+          if (!t || deleting) return
+          setDeleting(true)
+          try {
+            await TaskAPI.deleteTask(Number(t.id))
+            setTasks((prev) => prev.filter((x) => x.id !== t.id))
+            if (selectedTask?.id === t.id) setSelectedTask(null)
+            window.dispatchEvent(new CustomEvent("agent:tasks-changed"))
+          } catch {
+            // ignore
+          } finally {
+            setDeleting(false)
+            setPendingDeleteTask(null)
+          }
         }}
-        onCancel={() => setShowDeleteConfirm(false)}
+        onCancel={() => pendingDeleteTask && !deleting ? setPendingDeleteTask(null) : null}
       />
-      */}
     </div>
   )
 }

--- a/frontend/src/components/agent/taskboard/TaskCard.tsx
+++ b/frontend/src/components/agent/taskboard/TaskCard.tsx
@@ -1,6 +1,7 @@
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Checkbox } from "@/components/ui/checkbox"
 import { cn } from "@/lib/utils"
+import { X } from "lucide-react"
 
 export type TaskType =
   | "budget"
@@ -72,13 +73,15 @@ interface TaskCardProps {
   isSelected?: boolean
   onToggleSelect?: () => void
   onClick?: () => void
+  onDeleteClick?: () => void
 }
 
-export function TaskCard({ task, isManaging, isSelected, onToggleSelect, onClick }: TaskCardProps) {
+export function TaskCard({ task, isManaging, isSelected, onToggleSelect, onClick, onDeleteClick }: TaskCardProps) {
+  const showDelete = task.status === "DRAFT" && !isManaging && Boolean(onDeleteClick)
   return (
     <div
       className={cn(
-        "rounded-lg border bg-card p-3 shadow-sm transition-colors",
+        "rounded-lg border bg-card p-3 shadow-sm transition-colors group",
         isManaging && isSelected
           ? "border-blue-500/50 bg-blue-500/5"
           : "border-border hover:border-muted-foreground/30",
@@ -97,9 +100,25 @@ export function TaskCard({ task, isManaging, isSelected, onToggleSelect, onClick
           </div>
         )}
         <div className="flex flex-col gap-2 flex-1 min-w-0">
-          <p className="text-sm font-medium text-card-foreground line-clamp-1">
-            {task.summary}
-          </p>
+          <div className="flex items-start gap-2">
+            <p className="text-sm font-medium text-card-foreground line-clamp-1 flex-1 min-w-0">
+              {task.summary}
+            </p>
+            {showDelete && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onDeleteClick?.()
+                }}
+                className="opacity-0 group-hover:opacity-100 text-muted-foreground/60 hover:text-red-500 transition-opacity shrink-0"
+                title="Delete draft task"
+                aria-label="Delete draft task"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+          </div>
 
           <div className="flex items-center justify-between gap-2">
             <div className="flex items-center gap-2">

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -8,6 +8,7 @@ export interface AgentSession {
   created_by: number;
   title?: string | null;
   status?: string;
+  approval_required?: boolean;
   created_at: string;
   updated_at: string;
   message_count?: number;
@@ -21,10 +22,12 @@ export interface AgentSessionDetail extends AgentSession {
 
 export interface UpdateSessionRequest {
   title?: string;
+  approval_required?: boolean;
 }
 
 export interface CreateSessionRequest {
   project_id?: number;
+  approval_required?: boolean;
 }
 
 // ==================== Message Types ====================
@@ -45,11 +48,15 @@ export interface AgentMessageData {
   anomalies?: AnomalyItem[];
   decision_id?: number;
   task_ids?: number[];
+  created_tasks?: Array<{ index: number; task_id: number; summary: string }>;
   board_id?: string;
   event_type?: string;
   status?: string;
   suggested_decision?: SuggestedDecision;
   recommended_tasks?: RecommendedTask[];
+  approval_id?: string;
+  kind?: string;
+  draft?: Record<string, unknown>;
   file_id?: string;
   workflow_run_id?: string;
   session_id?: string;
@@ -68,6 +75,7 @@ export type SSEEventType =
   | 'text'
   | 'analysis'
   | 'confirmation_request'
+  | 'approval_request'
   | 'follow_up_prompt'
   | 'decision_draft'
   | 'task_created'
@@ -88,7 +96,16 @@ export interface SSEEvent {
 
 // ==================== Chat Request ====================
 
-export type AgentAction = 'analyze' | 'confirm_decision' | 'create_tasks' | 'generate_miro' | 'distribute_message' | 'start_follow_up' | 'cancel_follow_up' | 'confirm_columns';
+export type AgentAction =
+  | 'analyze'
+  | 'confirm_decision'
+  | 'create_tasks'
+  | 'generate_miro'
+  | 'distribute_message'
+  | 'start_follow_up'
+  | 'cancel_follow_up'
+  | 'confirm_columns'
+  | 'resolve_external_approval';
 
 export interface CalendarContextPayload {
   type: 'calendar' | 'event';
@@ -114,6 +131,9 @@ export interface AgentChatRequest {
   // User-approved column mapping for confirm_columns action.
   // Format: {original_header: canonical_name or "unknown"}
   column_mapping?: Record<string, string>;
+  approval_id?: string;
+  approval_decision?: 'approve' | 'reject';
+  approval_draft?: Record<string, unknown>;
 }
 
 // ==================== Analysis Types ====================
@@ -194,6 +214,7 @@ export interface DecisionOption {
 export interface RecommendedTask {
   type: string;
   summary: string;
+  description?: string;
   priority: 'HIGH' | 'MEDIUM' | 'LOW';
 }
 


### PR DESCRIPTION
Users can set approval requirements for specific agent workflows (or steps): some actions must get human approval before the Agent continues. 

When the approval requirement is triggered, Every outcome that the agent generates and affects outside the agent's environment (e.g., sending an email, generating a miro board, etc.) will be paused until the user approves the action. 

Workflow: 1. The user can toggle on/off the approval requirement for specific agent workflows in the agent chat interface. 2. When the approval requirement is triggered, everytime the agent generates an outcome that affects outside the agent's environment, a notification will be sent to the user for approval. The agent will pause until the user approves the action. 3. The user can view the pending approval in agent chatbox and approve or reject the action.