### PR TITLE
SMP-559: Fix budget API paths in budgetApi.ts

### DIFF
--- a/frontend/src/lib/api/budgetApi.ts
+++ b/frontend/src/lib/api/budgetApi.ts
@@ -1,8 +1,8 @@
 import api from "../api";
 
 /** Path prefix matches `backend/budget_approval/urls.py` included at `api/`. */
-const POOLS = "/api/task/budget-pools/";
-const TASKS = "/api/task/budget-tasks/";
+const POOLS = "/api/budgets/pools/";
+const TASKS = "/api/budgets/requests/";
 
 function listResults<T>(data: unknown): T[] {
   if (Array.isArray(data)) return data as T[];


### PR DESCRIPTION
Fix incorrect API paths in budgetApi.ts. Changed /api/task/budget-pools/ to /api/budgets/pools/ and /api/task/budget-tasks/ to /api/budgets/requests/.