### PR TITLE
Feat/agent anomaly confirmation

### DIFF
--- a/backend/agent/executors.py
+++ b/backend/agent/executors.py
@@ -145,6 +145,29 @@ class CreateTasksExecutor(BaseStepExecutor):
             return StepResult(success=False, error='No analysis_result in input')
 
         try:
+            # Gate: anomalies must be reviewed and confirmed before tasks.
+            if not analysis.get('anomalies_confirmed'):
+                return StepResult(
+                    success=False,
+                    error='Anomalies must be confirmed before creating tasks.',
+                )
+
+            # All-excluded: anomalies existed but none were included -> no-op
+            # success so the workflow completes cleanly. Zero-detected-anomaly
+            # runs are NOT skipped (existing behaviour preserved).
+            had_anomalies = bool(analysis.get('anomalies'))
+            reviewed = analysis.get('reviewed_anomalies') or []
+            included_anomalies = [a for a in reviewed if a.get('included', True)]
+            if had_anomalies and not included_anomalies:
+                return StepResult(
+                    success=True,
+                    output_data=input_data,
+                    sse_events=[{
+                        'type': 'text',
+                        'content': 'All anomalies were excluded; no tasks were created.',
+                    }],
+                )
+
             tasks_data = analysis.get('recommended_tasks', [])
             if not tasks_data:
                 return StepResult(success=False, error='No recommended_tasks in analysis.')
@@ -155,6 +178,8 @@ class CreateTasksExecutor(BaseStepExecutor):
                 'input_data': input_data,
                 'analysis_result': analysis,
                 'decision_id': decision.id if decision else None,
+                'included_anomalies': included_anomalies,
+                'reviewed_anomalies': reviewed,
             }
             gate = request_external_commit(
                 orchestrator=self.orchestrator,

--- a/backend/agent/executors.py
+++ b/backend/agent/executors.py
@@ -145,8 +145,10 @@ class CreateTasksExecutor(BaseStepExecutor):
             return StepResult(success=False, error='No analysis_result in input')
 
         try:
-            # Gate: anomalies must be reviewed and confirmed before tasks.
-            if not analysis.get('anomalies_confirmed'):
+            # Gate only applies when anomalies were detected: they must be
+            # reviewed + confirmed first. Zero-anomaly analyses proceed unchanged.
+            had_anomalies = bool(analysis.get('anomalies'))
+            if had_anomalies and not analysis.get('anomalies_confirmed'):
                 return StepResult(
                     success=False,
                     error='Anomalies must be confirmed before creating tasks.',
@@ -155,7 +157,6 @@ class CreateTasksExecutor(BaseStepExecutor):
             # All-excluded: anomalies existed but none were included -> no-op
             # success so the workflow completes cleanly. Zero-detected-anomaly
             # runs are NOT skipped (existing behaviour preserved).
-            had_anomalies = bool(analysis.get('anomalies'))
             reviewed = analysis.get('reviewed_anomalies') or []
             included_anomalies = [a for a in reviewed if a.get('included', True)]
             if had_anomalies and not included_anomalies:

--- a/backend/agent/serializers.py
+++ b/backend/agent/serializers.py
@@ -134,7 +134,7 @@ class ChatInputSerializer(serializers.Serializer):
         choices=[
             'analyze', 'create_tasks', 'generate_miro',
             'distribute_message', 'start_follow_up', 'cancel_follow_up',
-            'confirm_columns',
+            'confirm_columns', 'confirm_anomalies',
             'resolve_external_approval',
         ],
         required=False,
@@ -152,6 +152,9 @@ class ChatInputSerializer(serializers.Serializer):
     # User-approved column mapping for confirm_columns action.
     # Format: {original_header: canonical_name or "unknown"}
     column_mapping = serializers.JSONField(required=False, allow_null=True)
+    # Reviewed anomaly list for confirm_anomalies action.
+    # Format: [{id, included, severity, description}, ...] covering every anomaly.
+    reviewed_anomalies = serializers.JSONField(required=False, allow_null=True)
     user_context = serializers.CharField(
         required=False,
         allow_null=True,

--- a/backend/agent/services.py
+++ b/backend/agent/services.py
@@ -1601,8 +1601,10 @@ class AgentOrchestrator:
 
         analysis = self._workflow_run_analysis(workflow_run)
 
-        # Gate: anomalies must be reviewed and confirmed before tasks are created.
-        if not analysis.get('anomalies_confirmed'):
+        # Gate only applies when anomalies were actually detected: they must be
+        # reviewed + confirmed first. Zero-anomaly analyses proceed unchanged.
+        had_anomalies = bool(analysis.get('anomalies'))
+        if had_anomalies and not analysis.get('anomalies_confirmed'):
             yield {
                 "type": "error",
                 "content": "Anomalies must be confirmed before creating tasks.",
@@ -1611,7 +1613,6 @@ class AgentOrchestrator:
 
         # All-excluded: anomalies were detected but the user included none ->
         # skip task creation. Zero-detected-anomaly runs are NOT skipped.
-        had_anomalies = bool(analysis.get('anomalies'))
         reviewed = analysis.get('reviewed_anomalies') or []
         included_anomalies = [a for a in reviewed if a.get('included', True)]
         if had_anomalies and not included_anomalies:

--- a/backend/agent/services.py
+++ b/backend/agent/services.py
@@ -266,6 +266,32 @@ def _call_gemini_analysis(spreadsheet_data, user_id=None, success_criteria=None,
     )
 
 
+def _assign_anomaly_ids(analysis):
+    """Assign a stable id to every anomaly so the frontend can reference them
+    across the review/confirmation round-trip.
+
+    - Idempotent: anomalies that already carry an ``id`` are left untouched, so
+      re-analysis or session restore never reshuffles ids.
+    - Zero-anomaly datasets are marked ``anomalies_confirmed=True`` so they do
+      not block the workflow waiting for a confirmation that has no card. This
+      preserves the existing downstream behaviour (tasks still flow from
+      ``recommended_tasks``); task creation is only skipped when anomalies were
+      detected and the user excluded all of them.
+    """
+    if not isinstance(analysis, dict):
+        return analysis
+
+    anomalies = analysis.get('anomalies') or []
+    for i, anomaly in enumerate(anomalies):
+        if isinstance(anomaly, dict) and not anomaly.get('id'):
+            anomaly['id'] = f"anom_{i}"
+
+    if not anomalies:
+        analysis['anomalies_confirmed'] = True
+
+    return analysis
+
+
 def _run_analysis(spreadsheet_data, user_id=None, success_criteria=None, user_context=None):
     """Run analysis using Gemini, with Claude as fallback.
 
@@ -275,11 +301,11 @@ def _run_analysis(spreadsheet_data, user_id=None, success_criteria=None, user_co
     from .gemini_client import _get_api_key as _gemini_key
     if _gemini_key():
         try:
-            return _call_gemini_analysis(
+            return _assign_anomaly_ids(_call_gemini_analysis(
                 spreadsheet_data, user_id,
                 success_criteria=success_criteria,
                 user_context=user_context,
-            )
+            ))
         except Exception as e:
             logger.error(f"Gemini analysis failed, falling back to Claude: {e}")
 
@@ -287,7 +313,7 @@ def _run_analysis(spreadsheet_data, user_id=None, success_criteria=None, user_co
     client = _get_llm_client()
     if client:
         try:
-            return _call_llm(client, spreadsheet_data)
+            return _assign_anomaly_ids(_call_llm(client, spreadsheet_data))
         except Exception as e:
             logger.error(f"LLM call failed: {e}")
 
@@ -740,11 +766,20 @@ class AgentOrchestrator:
                        action=None, file_id=None, calendar_context=None,
                        workflow_id=None, column_mapping=None,
                        approval_id=None, approval_decision=None,
-                       approval_draft=None, user_context=None):
+                       approval_draft=None, user_context=None,
+                       reviewed_anomalies=None):
         """Main entry point. Routes calendar context first, then workflow engine or legacy logic.
 
         Yields SSE chunks as dicts.
         """
+        if action == 'confirm_anomalies':
+            latest_run = self.session.workflow_runs.filter(
+                is_deleted=False
+            ).order_by('-created_at').first()
+            yield from self.confirm_anomalies(latest_run, reviewed_anomalies)
+            yield {"type": "done"}
+            return
+
         if action == 'resolve_external_approval':
             if not approval_id or not approval_decision:
                 yield {'type': 'error', 'content': 'approval_id and approval_decision are required.'}
@@ -1443,6 +1478,110 @@ class AgentOrchestrator:
 
         return analysis if isinstance(analysis, dict) else {}
 
+    def confirm_anomalies(self, workflow_run, reviewed_anomalies):
+        """Persist the user's reviewed anomaly list and unlock task creation.
+
+        Guard order is deliberate: the already-confirmed no-op runs BEFORE any
+        payload validation so a reload/retry that sends a partial or stale
+        payload no-ops cleanly instead of raising a validation error.
+        """
+        # 1. Missing run/analysis.
+        analysis = self._workflow_run_analysis(workflow_run) if workflow_run else {}
+        if not workflow_run or not isinstance(analysis, dict) or not analysis:
+            yield {"type": "error", "content": "No analysis to confirm."}
+            return
+
+        # 2. Already confirmed -> safe idempotent no-op (before validation).
+        if analysis.get('anomalies_confirmed'):
+            yield {
+                "type": "anomalies_confirmed",
+                "content": "Anomalies already confirmed.",
+                "data": analysis,
+                "already_confirmed": True,
+            }
+            return
+
+        stored = analysis.get('anomalies') or []
+        existing_by_id = {a.get('id'): a for a in stored if isinstance(a, dict)}
+
+        payload = reviewed_anomalies if isinstance(reviewed_anomalies, list) else []
+        payload_ids = [
+            entry.get('id') for entry in payload if isinstance(entry, dict)
+        ]
+
+        # 3. Completeness check (atomic): payload ids must exactly equal the
+        #    stored anomaly id set -- reject on unknown / missing / duplicate.
+        stored_ids = set(existing_by_id.keys())
+        payload_id_set = set(payload_ids)
+        unknown = sorted(i for i in payload_id_set if i not in stored_ids)
+        missing = sorted(i for i in stored_ids if i not in payload_id_set)
+        duplicate = sorted({i for i in payload_ids if payload_ids.count(i) > 1})
+        if unknown or missing or duplicate:
+            yield {
+                "type": "error",
+                "content": (
+                    f"Anomaly review incomplete: unknown={unknown}, "
+                    f"missing={missing}, duplicate={duplicate}"
+                ),
+            }
+            return
+
+        # 4. Validate + merge each entry onto the full stored anomaly object.
+        valid_severities = {'critical', 'warning', 'info'}
+        merged = []
+        for entry in payload:
+            anomaly_id = entry.get('id')
+            base = dict(existing_by_id[anomaly_id])
+            severity = entry.get('severity')
+            if severity is not None:
+                if severity not in valid_severities:
+                    yield {
+                        "type": "error",
+                        "content": f"Invalid severity '{severity}' for {anomaly_id}.",
+                    }
+                    return
+                base['severity'] = severity
+            description = entry.get('description')
+            if description is not None:
+                if not isinstance(description, str):
+                    yield {
+                        "type": "error",
+                        "content": f"Invalid description for {anomaly_id}.",
+                    }
+                    return
+                base['description'] = description.strip()[:1000]
+            base['included'] = bool(entry.get('included', True))
+            merged.append(base)
+
+        # 5. Persist reviewed list + confirmation flag (keep original anomalies).
+        analysis['reviewed_anomalies'] = merged
+        analysis['anomalies_confirmed'] = True
+        workflow_run.analysis_result = analysis
+        workflow_run.save(update_fields=['analysis_result', 'updated_at'])
+
+        # Update the stored analysis message so a reload restores the same card
+        # in its locked, reviewed state (rather than an editable duplicate).
+        analysis_message = (
+            AgentMessage.objects
+            .filter(session=self.session, role='assistant', metadata__has_key='anomalies')
+            .order_by('-created_at')
+            .first()
+        )
+        if analysis_message:
+            meta = analysis_message.metadata or {}
+            meta['anomalies_confirmed'] = True
+            meta['reviewed_anomalies'] = merged
+            analysis_message.metadata = meta
+            analysis_message.save(update_fields=['metadata'])
+
+        included_count = sum(1 for a in merged if a.get('included'))
+        # 6. Emit confirmation with full merged objects so the UI can re-render.
+        yield {
+            "type": "anomalies_confirmed",
+            "content": f"Anomalies confirmed ({included_count} included).",
+            "data": analysis,
+        }
+
     def create_tasks_from_analysis(self, workflow_run):
         """Create Tasks directly from analysis results, optionally linking to Decision if it exists."""
         yield {"type": "text", "content": "Creating tasks..."}
@@ -1461,6 +1600,27 @@ class AgentOrchestrator:
             return
 
         analysis = self._workflow_run_analysis(workflow_run)
+
+        # Gate: anomalies must be reviewed and confirmed before tasks are created.
+        if not analysis.get('anomalies_confirmed'):
+            yield {
+                "type": "error",
+                "content": "Anomalies must be confirmed before creating tasks.",
+            }
+            return
+
+        # All-excluded: anomalies were detected but the user included none ->
+        # skip task creation. Zero-detected-anomaly runs are NOT skipped.
+        had_anomalies = bool(analysis.get('anomalies'))
+        reviewed = analysis.get('reviewed_anomalies') or []
+        included_anomalies = [a for a in reviewed if a.get('included', True)]
+        if had_anomalies and not included_anomalies:
+            yield {
+                "type": "text",
+                "content": "All anomalies were excluded; no tasks were created.",
+            }
+            return
+
         recommended_tasks = analysis.get("recommended_tasks", [])
         if not recommended_tasks:
             yield {"type": "error", "content": "No recommended tasks found in analysis."}
@@ -1474,6 +1634,8 @@ class AgentOrchestrator:
             'input_data': {'analysis_result': analysis},
             'analysis_result': analysis,
             'decision_id': decision.id if decision else None,
+            'included_anomalies': included_anomalies,
+            'reviewed_anomalies': reviewed,
         }
         gate = request_external_commit(
             orchestrator=self,

--- a/backend/agent/tests.py
+++ b/backend/agent/tests.py
@@ -881,12 +881,11 @@ class AnomalyConfirmationTests(TestCase):
 
     def test_zero_anomalies_preserves_task_creation(self):
         from task.models import Task
-        # Clean dataset: no anomalies, auto-confirmed, tasks still flow.
+        # Clean dataset: no anomalies key at all and no confirmation flag — the
+        # gate must NOT block; tasks still flow (existing behaviour preserved).
         run = AgentWorkflowRun.objects.create(
             session=self.session, status='awaiting_confirmation',
             analysis_result={
-                "anomalies": [],
-                "anomalies_confirmed": True,
                 "recommended_tasks": [
                     {"type": "optimization", "summary": "Monitor", "priority": "LOW"},
                 ],

--- a/backend/agent/tests.py
+++ b/backend/agent/tests.py
@@ -14,25 +14,42 @@ from .models import (
 from .services import AgentOrchestrator, _forward_to_users
 
 
-def _test_analysis_data():
-    """Minimal valid analysis structure for tests."""
-    return {
-        "anomalies": [
-            {
-                "metric": "ROAS",
-                "movement": "SHARP_DECREASE",
-                "scope_type": "CAMPAIGN",
-                "scope_value": "Test Campaign",
-                "delta_value": -20.0,
-                "delta_unit": "PERCENT",
-                "period": "LAST_7_DAYS",
-                "description": "Test Campaign ROAS dropped 20%",
-            },
-        ],
+def _test_anomaly(**overrides):
+    """A single anomaly dict (with a stable id) for tests."""
+    anomaly = {
+        "id": "anom_0",
+        "metric": "ROAS",
+        "movement": "SHARP_DECREASE",
+        "scope_type": "CAMPAIGN",
+        "scope_value": "Test Campaign",
+        "delta_value": -20.0,
+        "delta_unit": "PERCENT",
+        "period": "LAST_7_DAYS",
+        "severity": "critical",
+        "description": "Test Campaign ROAS dropped 20%",
+    }
+    anomaly.update(overrides)
+    return anomaly
+
+
+def _test_analysis_data(confirmed=True):
+    """Minimal valid analysis structure for tests.
+
+    Defaults to an already-confirmed analysis (anomalies reviewed and included)
+    so the existing task-creation tests exercise the post-confirmation path.
+    Pass ``confirmed=False`` for tests that need the pre-confirmation state.
+    """
+    anomaly = _test_anomaly()
+    analysis = {
+        "anomalies": [dict(anomaly)],
         "recommended_tasks": [
             {"type": "optimization", "summary": "Test task", "priority": "MEDIUM"},
         ],
     }
+    if confirmed:
+        analysis["reviewed_anomalies"] = [dict(anomaly, included=True)]
+        analysis["anomalies_confirmed"] = True
+    return analysis
 
 
 class AgentModelTests(TestCase):
@@ -669,6 +686,238 @@ class OrchestratorTests(TestCase):
         self.assertTrue(participant.is_active)
         self.assertEqual(results[0]['status'], 'sent')
         mock_notify_delay.assert_called_once()
+
+
+class AnomalyIdAssignmentTests(TestCase):
+    """_assign_anomaly_ids: stable ids + zero-anomaly auto-confirm."""
+
+    def test_assigns_sequential_ids(self):
+        from agent.services import _assign_anomaly_ids
+        analysis = {"anomalies": [{"metric": "ROAS"}, {"metric": "CPA"}]}
+        result = _assign_anomaly_ids(analysis)
+        self.assertEqual(result["anomalies"][0]["id"], "anom_0")
+        self.assertEqual(result["anomalies"][1]["id"], "anom_1")
+
+    def test_idempotent_existing_ids_untouched(self):
+        from agent.services import _assign_anomaly_ids
+        analysis = {"anomalies": [{"id": "keep_me", "metric": "ROAS"}]}
+        result = _assign_anomaly_ids(analysis)
+        self.assertEqual(result["anomalies"][0]["id"], "keep_me")
+
+    def test_zero_anomalies_auto_confirmed(self):
+        from agent.services import _assign_anomaly_ids
+        analysis = {"anomalies": [], "recommended_tasks": [{"summary": "x"}]}
+        result = _assign_anomaly_ids(analysis)
+        self.assertTrue(result["anomalies_confirmed"])
+
+    def test_nonempty_anomalies_not_auto_confirmed(self):
+        from agent.services import _assign_anomaly_ids
+        analysis = {"anomalies": [{"metric": "ROAS"}]}
+        result = _assign_anomaly_ids(analysis)
+        self.assertNotIn("anomalies_confirmed", result)
+
+
+class AnomalyConfirmationTests(TestCase):
+    """confirm_anomalies action + task-creation gate."""
+
+    def setUp(self):
+        self.org = Organization.objects.create(name='Org Anom', slug='org-anom')
+        self.user = CustomUser.objects.create_user(
+            email='anom@test.com', username='anomuser', password='testpass123',
+        )
+        self.user.organization = self.org
+        self.user.save()
+        self.project = Project.objects.create(
+            name='Project Anom', organization=self.org, owner=self.user,
+        )
+        ProjectMember.objects.create(
+            user=self.user, project=self.project, role='owner', is_active=True,
+        )
+        self.session = AgentSession.objects.create(user=self.user, project=self.project)
+        self.orch = AgentOrchestrator(self.user, self.project, self.session)
+
+    def _unconfirmed_run(self):
+        return AgentWorkflowRun.objects.create(
+            session=self.session,
+            status='awaiting_confirmation',
+            analysis_result=_test_analysis_data(confirmed=False),
+        )
+
+    def _full_payload(self, included=True, **overrides):
+        entry = {"id": "anom_0", "included": included,
+                 "severity": "critical", "description": "edited desc"}
+        entry.update(overrides)
+        return [entry]
+
+    # --- confirm_anomalies ------------------------------------------------
+
+    def test_confirm_persists_reviewed_list_full_objects(self):
+        run = self._unconfirmed_run()
+        chunks = list(self.orch.confirm_anomalies(run, self._full_payload()))
+        types = [c['type'] for c in chunks]
+        self.assertIn('anomalies_confirmed', types)
+        run.refresh_from_db()
+        ar = run.analysis_result
+        self.assertTrue(ar['anomalies_confirmed'])
+        reviewed = ar['reviewed_anomalies']
+        self.assertEqual(len(reviewed), 1)
+        # full merged object retains original display fields
+        self.assertEqual(reviewed[0]['metric'], 'ROAS')
+        self.assertEqual(reviewed[0]['period'], 'LAST_7_DAYS')
+        self.assertTrue(reviewed[0]['included'])
+        # original anomalies untouched
+        self.assertNotIn('included', ar['anomalies'][0])
+
+    def test_confirm_merges_severity_and_description_edits(self):
+        run = self._unconfirmed_run()
+        list(self.orch.confirm_anomalies(
+            run, self._full_payload(severity='info', description='new text')))
+        run.refresh_from_db()
+        reviewed = run.analysis_result['reviewed_anomalies'][0]
+        self.assertEqual(reviewed['severity'], 'info')
+        self.assertEqual(reviewed['description'], 'new text')
+
+    def test_confirm_unknown_id_rejected_atomically(self):
+        run = self._unconfirmed_run()
+        payload = [{"id": "anom_0", "included": True},
+                   {"id": "ghost", "included": True}]
+        chunks = list(self.orch.confirm_anomalies(run, payload))
+        self.assertEqual(chunks[0]['type'], 'error')
+        run.refresh_from_db()
+        self.assertNotIn('anomalies_confirmed', run.analysis_result)
+
+    def test_confirm_missing_id_rejected_atomically(self):
+        run = AgentWorkflowRun.objects.create(
+            session=self.session, status='awaiting_confirmation',
+            analysis_result={
+                "anomalies": [_test_anomaly(id="anom_0"), _test_anomaly(id="anom_1")],
+                "recommended_tasks": [{"summary": "x"}],
+            },
+        )
+        payload = [{"id": "anom_0", "included": True}]  # missing anom_1
+        chunks = list(self.orch.confirm_anomalies(run, payload))
+        self.assertEqual(chunks[0]['type'], 'error')
+        run.refresh_from_db()
+        self.assertNotIn('anomalies_confirmed', run.analysis_result)
+
+    def test_confirm_duplicate_id_rejected_atomically(self):
+        run = self._unconfirmed_run()
+        payload = [{"id": "anom_0", "included": True},
+                   {"id": "anom_0", "included": False}]
+        chunks = list(self.orch.confirm_anomalies(run, payload))
+        self.assertEqual(chunks[0]['type'], 'error')
+        run.refresh_from_db()
+        self.assertNotIn('anomalies_confirmed', run.analysis_result)
+
+    def test_confirm_invalid_severity_rejected(self):
+        run = self._unconfirmed_run()
+        chunks = list(self.orch.confirm_anomalies(
+            run, self._full_payload(severity='nope')))
+        self.assertEqual(chunks[0]['type'], 'error')
+        run.refresh_from_db()
+        self.assertNotIn('anomalies_confirmed', run.analysis_result)
+
+    def test_already_confirmed_is_safe_noop_on_partial_payload(self):
+        run = AgentWorkflowRun.objects.create(
+            session=self.session, status='awaiting_confirmation',
+            analysis_result=_test_analysis_data(confirmed=True),
+        )
+        # Partial/stale payload (missing ids) must NOT error -> no-op.
+        chunks = list(self.orch.confirm_anomalies(run, []))
+        self.assertEqual(chunks[0]['type'], 'anomalies_confirmed')
+        self.assertTrue(chunks[0].get('already_confirmed'))
+
+    def test_confirm_no_run_errors(self):
+        chunks = list(self.orch.confirm_anomalies(None, self._full_payload()))
+        self.assertEqual(chunks[0]['type'], 'error')
+
+    def test_confirm_updates_stored_analysis_message_for_restore(self):
+        run = self._unconfirmed_run()
+        # Simulate the persisted analysis message the SSE stream would have saved.
+        msg = AgentMessage.objects.create(
+            session=self.session,
+            role='assistant',
+            content='Found 1 anomalies.',
+            message_type='analysis',
+            metadata={'anomalies': [_test_anomaly()]},
+        )
+        list(self.orch.confirm_anomalies(run, self._full_payload(included=False)))
+        msg.refresh_from_db()
+        self.assertTrue(msg.metadata['anomalies_confirmed'])
+        self.assertEqual(len(msg.metadata['reviewed_anomalies']), 1)
+        self.assertFalse(msg.metadata['reviewed_anomalies'][0]['included'])
+
+    # --- task-creation gate ----------------------------------------------
+
+    def test_create_tasks_blocked_before_confirmation(self):
+        from task.models import Task
+        run = self._unconfirmed_run()
+        chunks = list(self.orch.create_tasks_from_analysis(run))
+        types = [c['type'] for c in chunks]
+        self.assertIn('error', types)
+        self.assertNotIn('task_created', types)
+        self.assertFalse(Task.objects.filter(project=self.project).exists())
+
+    def test_create_tasks_allowed_after_confirmation(self):
+        from task.models import Task
+        run = self._unconfirmed_run()
+        list(self.orch.confirm_anomalies(run, self._full_payload(included=True)))
+        run.refresh_from_db()
+        chunks = list(self.orch.create_tasks_from_analysis(run))
+        types = [c['type'] for c in chunks]
+        self.assertIn('task_created', types)
+        self.assertTrue(Task.objects.filter(project=self.project).exists())
+
+    def test_all_excluded_confirms_but_creates_no_tasks(self):
+        from task.models import Task
+        run = self._unconfirmed_run()
+        list(self.orch.confirm_anomalies(run, self._full_payload(included=False)))
+        run.refresh_from_db()
+        self.assertTrue(run.analysis_result['anomalies_confirmed'])
+        chunks = list(self.orch.create_tasks_from_analysis(run))
+        types = [c['type'] for c in chunks]
+        self.assertNotIn('task_created', types)
+        self.assertFalse(Task.objects.filter(project=self.project).exists())
+
+    def test_zero_anomalies_preserves_task_creation(self):
+        from task.models import Task
+        # Clean dataset: no anomalies, auto-confirmed, tasks still flow.
+        run = AgentWorkflowRun.objects.create(
+            session=self.session, status='awaiting_confirmation',
+            analysis_result={
+                "anomalies": [],
+                "anomalies_confirmed": True,
+                "recommended_tasks": [
+                    {"type": "optimization", "summary": "Monitor", "priority": "LOW"},
+                ],
+            },
+        )
+        chunks = list(self.orch.create_tasks_from_analysis(run))
+        types = [c['type'] for c in chunks]
+        self.assertIn('task_created', types)
+        self.assertTrue(Task.objects.filter(project=self.project).exists())
+
+    def test_included_anomalies_attached_to_commit_context(self):
+        captured = {}
+        run = self._unconfirmed_run()
+        list(self.orch.confirm_anomalies(run, self._full_payload(included=True)))
+        run.refresh_from_db()
+
+        from agent import approval_gate
+
+        real = approval_gate.request_external_commit
+
+        def _spy(*args, **kwargs):
+            captured['commit_context'] = kwargs.get('commit_context')
+            return real(*args, **kwargs)
+
+        with patch('agent.approval_gate.request_external_commit', side_effect=_spy):
+            list(self.orch.create_tasks_from_analysis(run))
+
+        self.assertIn('commit_context', captured)
+        included = captured['commit_context'].get('included_anomalies')
+        self.assertEqual(len(included), 1)
+        self.assertEqual(included[0]['id'], 'anom_0')
 
 
 class CalendarAgentTests(TestCase):

--- a/backend/agent/views.py
+++ b/backend/agent/views.py
@@ -154,11 +154,12 @@ class ChatView(EnglishResponseMixin, APIView):
         approval_id = serializer.validated_data.get('approval_id')
         approval_decision = serializer.validated_data.get('approval_decision')
         approval_draft = serializer.validated_data.get('approval_draft')
+        reviewed_anomalies = serializer.validated_data.get('reviewed_anomalies')
 
         should_persist_user_message = action not in {
             'start_follow_up', 'cancel_follow_up',
             'create_tasks', 'generate_miro',
-            'distribute_message', 'confirm_columns',
+            'distribute_message', 'confirm_columns', 'confirm_anomalies',
             'resolve_external_approval',
         }
 
@@ -220,6 +221,7 @@ class ChatView(EnglishResponseMixin, APIView):
                     approval_decision=approval_decision,
                     approval_draft=approval_draft,
                     user_context=user_context,
+                    reviewed_anomalies=reviewed_anomalies,
                 ):
                     chunk_type = chunk.get('type', 'text')
                     content = chunk.get('content', '')
@@ -263,8 +265,11 @@ class ChatView(EnglishResponseMixin, APIView):
                         yield f"data: {sse_data}\n\n"
                         continue
 
-                    # Skip internal signalling events from content accumulation
-                    if chunk_type not in ('done', 'calendar_updated'):
+                    # Skip internal signalling events from content accumulation.
+                    # 'anomalies_confirmed' updates the existing analysis message
+                    # in-place (see confirm_anomalies), so it must not be persisted
+                    # as a second anomaly card here.
+                    if chunk_type not in ('done', 'calendar_updated', 'anomalies_confirmed'):
                         if content:
                             assistant_content_parts.append(content)
                         last_message_type = chunk_type

--- a/frontend/src/__tests__/components/agent/chat/AnomalyCard.test.tsx
+++ b/frontend/src/__tests__/components/agent/chat/AnomalyCard.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { AnomalyCard } from '@/components/agent/chat/AnomalyCard'
+import type { AnomalyItem } from '@/types/agent'
+
+// Render agent copy synchronously (bypass the typing-animation queue).
+jest.mock('@/components/agent/chat/AgentMessageBoardText', () => ({
+  AgentMessageBoardText: ({ target }: { target: string }) => <span>{target}</span>,
+}))
+
+function anomaly(overrides: Partial<AnomalyItem> = {}): AnomalyItem {
+  return {
+    id: 'anom_0',
+    metric: 'ROAS',
+    movement: 'SHARP_DECREASE',
+    severity: 'critical',
+    current_value: 1,
+    previous_value: 2,
+    change_percent: -50,
+    description: 'ROAS dropped',
+    ...overrides,
+  }
+}
+
+describe('AnomalyCard — interactive review', () => {
+  it('renders an include checkbox and severity select per anomaly', () => {
+    render(<AnomalyCard anomalies={[anomaly()]} onConfirm={jest.fn()} />)
+    expect(screen.getByLabelText(/include ROAS/i)).toBeChecked()
+    expect(screen.getByLabelText(/severity for ROAS/i)).toBeInTheDocument()
+  })
+
+  it('excluding an anomaly mutes its row (line-through title)', () => {
+    render(<AnomalyCard anomalies={[anomaly()]} onConfirm={jest.fn()} />)
+    const checkbox = screen.getByLabelText(/include ROAS/i)
+    fireEvent.click(checkbox)
+    expect(checkbox).not.toBeChecked()
+    // The title wrapper carries the line-through class when excluded.
+    expect(screen.getByText('ROAS').closest('.line-through')).toBeInTheDocument()
+  })
+
+  it('changing severity moves a row between Alerts and Signals', () => {
+    render(<AnomalyCard anomalies={[anomaly()]} onConfirm={jest.fn()} />)
+    // Starts as critical -> in Alerts section.
+    expect(screen.getByText(/Alerts \(1\)/)).toBeInTheDocument()
+    expect(screen.queryByText(/Signals \(/)).not.toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText(/severity for ROAS/i), { target: { value: 'info' } })
+    expect(screen.getByText(/Signals \(1\)/)).toBeInTheDocument()
+    expect(screen.queryByText(/Alerts \(/)).not.toBeInTheDocument()
+  })
+
+  it('Confirm sends every anomaly exactly once with edits applied', () => {
+    const onConfirm = jest.fn()
+    render(
+      <AnomalyCard
+        anomalies={[anomaly({ id: 'anom_0' }), anomaly({ id: 'anom_1', metric: 'CPA', severity: 'info' })]}
+        onConfirm={onConfirm}
+      />
+    )
+    // Exclude the first one.
+    fireEvent.click(screen.getByLabelText(/include ROAS/i))
+    fireEvent.click(screen.getByRole('button', { name: /confirm anomalies/i }))
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    const payload = onConfirm.mock.calls[0][0]
+    expect(payload).toHaveLength(2)
+    expect(payload.map((p: any) => p.id).sort()).toEqual(['anom_0', 'anom_1'])
+    const first = payload.find((p: any) => p.id === 'anom_0')
+    expect(first.included).toBe(false)
+  })
+
+  it('locks controls read-only once confirmed', () => {
+    render(<AnomalyCard anomalies={[anomaly()]} confirmed onConfirm={jest.fn()} />)
+    expect(screen.getByText(/review locked/i)).toBeInTheDocument()
+    // Checkbox remains visible but disabled; severity select is replaced by a label.
+    expect(screen.getByLabelText(/include ROAS/i)).toBeDisabled()
+    expect(screen.queryByLabelText(/severity for ROAS/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /confirm anomalies/i })).not.toBeInTheDocument()
+  })
+
+  it('shows the pre-confirm lock warning', () => {
+    render(<AnomalyCard anomalies={[anomaly()]} onConfirm={jest.fn()} />)
+    expect(screen.getByText(/once confirmed, this review is locked/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/agent/chat/AgentChatPage.tsx
+++ b/frontend/src/components/agent/chat/AgentChatPage.tsx
@@ -102,7 +102,11 @@ function restoreMessage(m: AgentMessage): ChatMessage {
     content: m.content,
     type,
     isFollowUpPrompt,
-    anomalies: m.data?.anomalies,
+    // Prefer the reviewed list so a restored, confirmed card shows the user's
+    // include/exclude + edits; fall back to the raw anomalies pre-confirmation.
+    anomalies: m.data?.reviewed_anomalies ?? m.data?.anomalies,
+    anomaliesConfirmed:
+      Boolean(m.data?.anomalies_confirmed) || (m.data?.anomalies?.length ?? 0) === 0,
     recommendedTasks: m.data?.recommended_tasks,
     navigateTo,
     navigateLabel,
@@ -250,6 +254,7 @@ export function AgentChatPage({ embeddedInFloating = false }: AgentChatPageProps
   const [stepProgress, setStepProgress] = useState<StepProgressItem[]>([])
   const [stepState, setStepState] = useState<WorkflowStepState>({
     analysisComplete: false,
+    anomaliesConfirmed: false,
     tasksCreated: false,
   })
   const [followUpAvailable, setFollowUpAvailable] = useState(false)
@@ -352,14 +357,44 @@ export function AgentChatPage({ embeddedInFloating = false }: AgentChatPageProps
     }
   }, [])
 
-  const queueAutoExternalActionsAfterAnalysis = useCallback((options?: { approvalRequired?: boolean }) => {
-    const requiresApproval = options?.approvalRequired ?? approvalRequiredRef.current
+  // Low-level: queue and run the downstream external actions (create tasks,
+  // generate miro). Runs at most once per analysis cycle.
+  const triggerExternalActions = useCallback((requiresApprovalArg?: boolean) => {
     if (autoExternalActionsTriggeredRef.current) return
     autoExternalActionsTriggeredRef.current = true
+    const requiresApproval = requiresApprovalArg ?? approvalRequiredRef.current
     autoActionQueueRef.current = requiresApproval ? ["create_tasks"] : ["create_tasks", "generate_miro"]
     setTaskGenerationStatus("generating")
     tryRunNextAutoAction()
   }, [tryRunNextAutoAction])
+
+  // After analysis: only auto-run downstream actions when there are no anomalies
+  // to review (clean dataset / already confirmed). When anomalies are present,
+  // defer until the user confirms them via confirm_anomalies.
+  const queueAutoExternalActionsAfterAnalysis = useCallback(
+    (options?: { approvalRequired?: boolean; analysis?: AnalysisResult | null }) => {
+      if (options && 'analysis' in options) {
+        const anomalies = options.analysis?.anomalies ?? []
+        const alreadyConfirmed =
+          Boolean(options.analysis?.anomalies_confirmed) || anomalies.length === 0
+        if (anomalies.length > 0 && !alreadyConfirmed) {
+          return // wait for the user to confirm anomalies
+        }
+      }
+      triggerExternalActions(options?.approvalRequired)
+    },
+    [triggerExternalActions]
+  )
+
+  // After the user confirms anomalies: run downstream actions only if at least
+  // one anomaly was included. All-excluded => no tasks.
+  const runPostConfirmActions = useCallback(
+    (hasIncluded: boolean) => {
+      if (!hasIncluded) return
+      triggerExternalActions()
+    },
+    [triggerExternalActions]
+  )
 
   const setSessionId = useCallback((id: string | null) => {
     sessionIdRef.current = id
@@ -463,12 +498,17 @@ export function AgentChatPage({ embeddedInFloating = false }: AgentChatPageProps
     // task/decision data from a *previous* upload cycle does not carry over.
     const restoredStepState: WorkflowStepState = {
       analysisComplete: false,
+      anomaliesConfirmed: false,
       tasksCreated: false,
     }
     for (const m of session.messages) {
       if (m.data?.anomalies) {
         restoredStepState.analysisComplete = true
         restoredStepState.tasksCreated = false
+        // A fresh analysis resets confirmation; clean datasets (no anomalies)
+        // and already-confirmed analyses are treated as confirmed.
+        restoredStepState.anomaliesConfirmed =
+          Boolean(m.data?.anomalies_confirmed) || m.data.anomalies.length === 0
       }
       if (m.message_type === "task_created" || m.data?.task_ids) restoredStepState.tasksCreated = true
     }
@@ -505,6 +545,7 @@ export function AgentChatPage({ embeddedInFloating = false }: AgentChatPageProps
     const recommendedTaskCount = latestRecommendedTasksRef.current?.length ?? 0
     if (
       restoredStepState.analysisComplete &&
+      restoredStepState.anomaliesConfirmed &&
       !restoredStepState.tasksCreated &&
       recommendedTaskCount > 0 &&
       !pendingTaskApprovalFromMessages
@@ -721,7 +762,7 @@ export function AgentChatPage({ embeddedInFloating = false }: AgentChatPageProps
       setFollowUpStarted(false)
       setSessionTitle("Chat")
       setApprovalRequired(getApprovalPref())
-      setStepState({ analysisComplete: false, tasksCreated: false })
+      setStepState({ analysisComplete: false, anomaliesConfirmed: false, tasksCreated: false })
       setGeneratedTaskIndexes([])
       setSkippedTaskIndexes([])
       setCreatedTaskIdByIndex({})
@@ -755,7 +796,7 @@ export function AgentChatPage({ embeddedInFloating = false }: AgentChatPageProps
       setFollowUpStarted(false)
       setSessionTitle("Chat")
       setApprovalRequired(false)
-      setStepState({ analysisComplete: false, tasksCreated: false })
+      setStepState({ analysisComplete: false, anomaliesConfirmed: false, tasksCreated: false })
     }
 
     const handleLoadSession = (e: Event) => {
@@ -789,7 +830,7 @@ export function AgentChatPage({ embeddedInFloating = false }: AgentChatPageProps
   const handleFileUpload = useCallback(async (file: File, userContext?: string) => {
     setHasStarted(true)
     // Reset workflow state so a new upload always starts from analysis
-    setStepState({ analysisComplete: false, tasksCreated: false })
+    setStepState({ analysisComplete: false, anomaliesConfirmed: false, tasksCreated: false })
     setGeneratedTaskIndexes([])
     setSkippedTaskIndexes([])
     setCreatedTaskIdByIndex({})
@@ -903,20 +944,30 @@ export function AgentChatPage({ embeddedInFloating = false }: AgentChatPageProps
           latestRecommendedTasksRef.current = analysisData?.recommended_tasks || null
           setFollowUpAvailable(true)
           setFollowUpStarted(false)
-          setStepState((prev) => ({ ...prev, analysisComplete: true }))
-          setGeneratedTaskIndexes([])
-          setSkippedTaskIndexes([])
-          setCreatedTaskIdByIndex({})
-          updateMessage(aiMsgId, {
-            content: contentParts.join("\n"),
-            type: "analysis",
-            anomalies: analysisData?.anomalies,
-            recommendedTasks: analysisData?.recommended_tasks,
-          })
-          selectAllRecommendedTasks(analysisData?.recommended_tasks?.length ?? 0)
-          queueAutoExternalActionsAfterAnalysis()
-          // Individual anomalies are added to the right panel via the
-          // AnomalyCard "+ Add" button — no auto-broadcast on new analysis.
+          {
+            const anomConfirmed =
+              Boolean(analysisData?.anomalies_confirmed) ||
+              (analysisData?.anomalies?.length ?? 0) === 0
+            setStepState((prev) => ({
+              ...prev,
+              analysisComplete: true,
+              anomaliesConfirmed: anomConfirmed,
+            }))
+            setGeneratedTaskIndexes([])
+            setSkippedTaskIndexes([])
+            setCreatedTaskIdByIndex({})
+            updateMessage(aiMsgId, {
+              content: contentParts.join("\n"),
+              type: "analysis",
+              anomalies: analysisData?.anomalies,
+              anomaliesConfirmed: anomConfirmed,
+              recommendedTasks: analysisData?.recommended_tasks,
+            })
+            selectAllRecommendedTasks(analysisData?.recommended_tasks?.length ?? 0)
+            // Defer downstream actions until anomalies are confirmed; clean
+            // datasets (no anomalies) proceed immediately.
+            queueAutoExternalActionsAfterAnalysis({ analysis: analysisData })
+          }
         } else if (event.type === "confirmation_request") {
           // If column mapping already shown, don't overwrite the card — just
           // silently wait for user confirmation via ColumnMappingCard buttons.
@@ -1080,17 +1131,24 @@ export function AgentChatPage({ embeddedInFloating = false }: AgentChatPageProps
           latestRecommendedTasksRef.current = data.recommended_tasks || null
           setFollowUpAvailable(true)
           setFollowUpStarted(false)
-          setStepState((prev) => ({ ...prev, analysisComplete: true }))
+          const anomConfirmed =
+            Boolean(data.anomalies_confirmed) || (data.anomalies?.length ?? 0) === 0
+          setStepState((prev) => ({
+            ...prev,
+            analysisComplete: true,
+            anomaliesConfirmed: anomConfirmed,
+          }))
           setGeneratedTaskIndexes([])
           setSkippedTaskIndexes([])
           setCreatedTaskIdByIndex({})
           updateMessage(aiMsgId, {
             type: "analysis",
             anomalies: data.anomalies,
+            anomaliesConfirmed: anomConfirmed,
             recommendedTasks: data.recommended_tasks,
           })
           selectAllRecommendedTasks(data.recommended_tasks?.length ?? 0)
-          queueAutoExternalActionsAfterAnalysis()
+          queueAutoExternalActionsAfterAnalysis({ analysis: data })
         }
         if (event.type === "approval_request" && event.data) {
           const d = event.data as Record<string, unknown>
@@ -1176,6 +1234,47 @@ export function AgentChatPage({ embeddedInFloating = false }: AgentChatPageProps
   // Keep ref in sync so handleFileUpload's done handler can call the latest version
   handleConfirmColumnsRef.current = handleConfirmColumns
 
+  /**
+   * Confirm the user's anomaly review. Persists the reviewed list, locks the
+   * card read-only, and (only if anomalies were included) runs the downstream
+   * task/miro actions. All-excluded confirms but creates nothing.
+   */
+  const handleConfirmAnomalies = useCallback(
+    (messageId: string, reviewed: import("@/types/agent").ReviewedAnomaly[]) => {
+      const sid = sessionIdRef.current
+      if (!sid) return
+      const requestSessionId = String(sid)
+
+      AgentAPI.sendMessage(
+        sid,
+        { message: "confirm_anomalies", action: "confirm_anomalies", reviewed_anomalies: reviewed },
+        (event: SSEEvent) => {
+          if (String(sessionIdRef.current) !== requestSessionId) return
+          if (event.type === "anomalies_confirmed") {
+            const data = (event.data as unknown as AnalysisResult) || null
+            const reviewedList = data?.reviewed_anomalies ?? []
+            const includedCount = reviewedList.filter((a) => a.included !== false).length
+            setStepState((prev) => ({ ...prev, anomaliesConfirmed: true }))
+            updateMessage(messageId, {
+              anomaliesConfirmed: true,
+              ...(reviewedList.length > 0 ? { anomalies: reviewedList } : {}),
+            })
+            runPostConfirmActions(includedCount > 0)
+          } else if (event.type === "error") {
+            // Leave the card editable for retry; surface the error inline.
+            addMessage({
+              id: `ai-anom-err-${Date.now()}`,
+              role: "assistant",
+              content: event.content || "Failed to confirm anomalies.",
+              type: "error",
+            })
+          }
+        }
+      )
+    },
+    [addMessage, updateMessage, runPostConfirmActions]
+  )
+
   /** Re-upload: reset to welcome screen so the user can upload a different file */
   const handleReupload = useCallback(() => {
     sessionIdRef.current = null
@@ -1187,7 +1286,7 @@ export function AgentChatPage({ embeddedInFloating = false }: AgentChatPageProps
     setFollowUpAvailable(false)
     setFollowUpStarted(false)
     setStepProgress([])
-    setStepState({ analysisComplete: false, tasksCreated: false })
+    setStepState({ analysisComplete: false, anomaliesConfirmed: false, tasksCreated: false })
     setGeneratedTaskIndexes([])
     setSkippedTaskIndexes([])
     latestRecommendedTasksRef.current = null
@@ -1357,19 +1456,24 @@ export function AgentChatPage({ embeddedInFloating = false }: AgentChatPageProps
           latestRecommendedTasksRef.current = data.recommended_tasks || null
           setFollowUpAvailable(true)
           setFollowUpStarted(false)
-          setStepState((prev) => ({ ...prev, analysisComplete: true }))
+          const anomConfirmed =
+            Boolean(data.anomalies_confirmed) || (data.anomalies?.length ?? 0) === 0
+          setStepState((prev) => ({
+            ...prev,
+            analysisComplete: true,
+            anomaliesConfirmed: anomConfirmed,
+          }))
           setGeneratedTaskIndexes([])
           setSkippedTaskIndexes([])
           setCreatedTaskIdByIndex({})
           updateMessage(aiMsgId, {
             type: "analysis",
             anomalies: data.anomalies,
+            anomaliesConfirmed: anomConfirmed,
             recommendedTasks: data.recommended_tasks,
           })
           selectAllRecommendedTasks(data.recommended_tasks?.length ?? 0)
-          // Individual anomalies are added to the right panel via the
-          // AnomalyCard "+ Add" button — no auto-broadcast on new analysis.
-          queueAutoExternalActionsAfterAnalysis()
+          queueAutoExternalActionsAfterAnalysis({ analysis: data })
         }
         if (event.type === "task_created" && event.data) {
           setStepState((prev) => ({ ...prev, tasksCreated: true }))
@@ -1663,6 +1767,8 @@ export function AgentChatPage({ embeddedInFloating = false }: AgentChatPageProps
     if (isStreamingRef.current || !sessionIdRef.current) return
     if (approvalRequiredRef.current) return
     if (!stepState.analysisComplete || stepState.tasksCreated) return
+    // Do not auto-run downstream actions until anomalies are confirmed.
+    if (!stepState.anomaliesConfirmed) return
     if (pendingTaskApproval) return
     if ((latestRecommendedTasksRef.current?.length ?? 0) === 0) return
     if (autoExternalActionsTriggeredRef.current) return
@@ -1672,6 +1778,7 @@ export function AgentChatPage({ embeddedInFloating = false }: AgentChatPageProps
     isStreaming,
     approvalRequired,
     stepState.analysisComplete,
+    stepState.anomaliesConfirmed,
     stepState.tasksCreated,
     pendingTaskApproval,
     queueAutoExternalActionsAfterAnalysis,
@@ -1856,6 +1963,7 @@ export function AgentChatPage({ embeddedInFloating = false }: AgentChatPageProps
           onRejectMiroApproval: handleRejectMiroApproval,
           onAction: handleAction,
           onConfirmColumns: handleConfirmColumns,
+          onConfirmAnomalies: handleConfirmAnomalies,
           onReupload: handleReupload,
           latestAnalysisMessageId,
           showFollowUpToggle: followUpAvailable || followUpStarted,

--- a/frontend/src/components/agent/chat/AnomalyCard.tsx
+++ b/frontend/src/components/agent/chat/AnomalyCard.tsx
@@ -3,9 +3,9 @@
 import { useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { AlertTriangle, TrendingDown, Info, ChevronDown, ChevronRight, Plus } from "lucide-react"
+import { AlertTriangle, TrendingDown, Info, ChevronDown, ChevronRight, Lock } from "lucide-react"
 import { cn } from "@/lib/utils"
-import type { AnomalyItem } from "@/types/agent"
+import type { AnomalyItem, AnomalySeverity, ReviewedAnomaly } from "@/types/agent"
 import { AgentMessageBoardText } from "./AgentMessageBoardText"
 
 const severityConfig = {
@@ -14,16 +14,14 @@ const severityConfig = {
   info: { icon: Info, color: "text-green-400", bg: "bg-green-500/20", label: "Info" },
 } as const
 
-function getSeverity(anomaly: AnomalyItem): keyof typeof severityConfig {
+const SEVERITY_OPTIONS: AnomalySeverity[] = ["critical", "warning", "info"]
+
+function getSeverity(anomaly: AnomalyItem): AnomalySeverity {
   if (anomaly.severity) return anomaly.severity
   const movement = anomaly.movement || ""
   if (movement.includes("SHARP")) return "critical"
   if (movement.includes("MODERATE")) return "warning"
   return "info"
-}
-
-function handleAddToPanel(anomaly: AnomalyItem) {
-  window.dispatchEvent(new CustomEvent("agent:add-alert", { detail: anomaly }))
 }
 
 function buildAnomalyTitle(anomaly: AnomalyItem): string {
@@ -33,31 +31,58 @@ function buildAnomalyTitle(anomaly: AnomalyItem): string {
   return title
 }
 
+/** Per-anomaly review state held locally until the user confirms. */
+interface ReviewState {
+  id: string
+  included: boolean
+  severity: AnomalySeverity
+  description: string
+}
+
 function AnomalyItemRow({
   anomaly,
+  review,
+  readOnly,
+  onChange,
   messageId,
   blockId,
   index,
 }: {
   anomaly: AnomalyItem
+  review: ReviewState
+  readOnly: boolean
+  onChange: (patch: Partial<ReviewState>) => void
   messageId?: string
   blockId?: string
   index: number
 }) {
-  const severity = getSeverity(anomaly)
-  const config = severityConfig[severity]
+  const config = severityConfig[review.severity]
   const Icon = config.icon
   const title = buildAnomalyTitle(anomaly)
+  const excluded = !review.included
 
   return (
-    <Card className="bg-card border-border">
+    <Card className={cn("bg-card border-border transition-opacity", excluded && "opacity-50")}>
       <CardHeader className="pb-2 pt-3 px-4">
         <div className="flex items-center gap-3">
+          <input
+            type="checkbox"
+            checked={review.included}
+            disabled={readOnly}
+            onChange={(e) => onChange({ included: e.target.checked })}
+            aria-label={`Include ${title}`}
+            className="h-4 w-4 shrink-0 accent-primary disabled:cursor-not-allowed"
+          />
           <div className={cn("flex h-8 w-8 items-center justify-center rounded-lg shrink-0", config.bg)}>
             <Icon className={cn("h-4 w-4", config.color)} />
           </div>
           <div className="flex-1 min-w-0">
-            <CardTitle className="text-sm font-semibold text-card-foreground truncate">
+            <CardTitle
+              className={cn(
+                "text-sm font-semibold text-card-foreground truncate",
+                excluded && "line-through"
+              )}
+            >
               <AgentMessageBoardText
                 target={title}
                 partId={`${messageId ?? "anomaly"}-${index}-title`}
@@ -65,36 +90,50 @@ function AnomalyItemRow({
               />
             </CardTitle>
           </div>
-          <span className={cn("text-xs font-medium px-2 py-0.5 rounded-full shrink-0", config.bg, config.color)}>
-            <AgentMessageBoardText
-              target={config.label}
-              partId={`${messageId ?? "anomaly"}-${index}-severity`}
-              blockId={blockId}
-            />
-          </span>
-          <Button
-            size="sm"
-            variant="ghost"
-            className="h-6 px-1.5 text-xs text-muted-foreground hover:text-foreground"
-            onClick={() => handleAddToPanel(anomaly)}
-          >
-            <Plus className="h-3 w-3 mr-0.5" />
-            <AgentMessageBoardText
-              target="Add"
-              partId={`${messageId ?? "anomaly"}-${index}-add`}
-              blockId={blockId}
-            />
-          </Button>
+          {readOnly ? (
+            <span
+              className={cn(
+                "text-xs font-medium px-2 py-0.5 rounded-full shrink-0",
+                config.bg,
+                config.color
+              )}
+            >
+              {config.label}
+            </span>
+          ) : (
+            <select
+              value={review.severity}
+              onChange={(e) => onChange({ severity: e.target.value as AnomalySeverity })}
+              aria-label={`Severity for ${title}`}
+              className="shrink-0 rounded-md border border-border bg-background px-2 py-1 text-xs"
+            >
+              {SEVERITY_OPTIONS.map((sev) => (
+                <option key={sev} value={sev}>
+                  {severityConfig[sev].label}
+                </option>
+              ))}
+            </select>
+          )}
         </div>
       </CardHeader>
       <CardContent className="px-4 pb-3 pt-0">
-        <p className="text-sm text-muted-foreground">
-          <AgentMessageBoardText
-            target={anomaly.description}
-            partId={`${messageId ?? "anomaly"}-${index}-desc`}
-            blockId={blockId}
+        {readOnly ? (
+          <p className={cn("text-sm text-muted-foreground", excluded && "line-through")}>
+            <AgentMessageBoardText
+              target={review.description}
+              partId={`${messageId ?? "anomaly"}-${index}-desc`}
+              blockId={blockId}
+            />
+          </p>
+        ) : (
+          <textarea
+            value={review.description}
+            onChange={(e) => onChange({ description: e.target.value })}
+            aria-label={`Description for ${title}`}
+            rows={2}
+            className="w-full resize-y rounded-md border border-border bg-background px-2 py-1 text-sm text-muted-foreground"
           />
-        </p>
+        )}
       </CardContent>
     </Card>
   )
@@ -150,16 +189,79 @@ interface AnomalyCardProps {
   anomalies: AnomalyItem[]
   messageId?: string
   blockId?: string
+  /** When true the card is locked read-only (already confirmed). */
+  confirmed?: boolean
+  /** Disable interaction (e.g. while the agent is streaming). */
+  disabled?: boolean
+  onConfirm?: (reviewed: ReviewedAnomaly[]) => void
 }
 
-export function AnomalyCard({ anomalies, messageId, blockId }: AnomalyCardProps) {
+export function AnomalyCard({
+  anomalies,
+  messageId,
+  blockId,
+  confirmed = false,
+  disabled = false,
+  onConfirm,
+}: AnomalyCardProps) {
+  // Initialise the editable review state once from the incoming anomalies.
+  const [reviewMap, setReviewMap] = useState<Record<string, ReviewState>>(() => {
+    const initial: Record<string, ReviewState> = {}
+    for (const a of anomalies) {
+      initial[a.id] = {
+        id: a.id,
+        included: a.included ?? true,
+        severity: getSeverity(a),
+        description: a.description,
+      }
+    }
+    return initial
+  })
+
   if (!anomalies.length) return null
 
-  const alerts = anomalies.filter((a) => {
-    const sev = getSeverity(a)
-    return sev === "critical" || sev === "warning"
-  })
-  const signals = anomalies.filter((a) => getSeverity(a) === "info")
+  const readOnly = confirmed || disabled
+  const interactive = Boolean(onConfirm) && !confirmed
+
+  const updateReview = (id: string, patch: Partial<ReviewState>) => {
+    setReviewMap((prev) => ({ ...prev, [id]: { ...prev[id], ...patch } }))
+  }
+
+  // Group by the CURRENT (possibly edited) severity so edits re-group live.
+  const ordered = anomalies
+    .map((a) => ({ anomaly: a, review: reviewMap[a.id] }))
+    .filter((x) => x.review)
+  const alerts = ordered.filter(
+    (x) => x.review.severity === "critical" || x.review.severity === "warning"
+  )
+  const signals = ordered.filter((x) => x.review.severity === "info")
+
+  const renderRow = (anomaly: AnomalyItem, idx: number) => (
+    <AnomalyItemRow
+      key={anomaly.id}
+      anomaly={anomaly}
+      review={reviewMap[anomaly.id]}
+      readOnly={readOnly}
+      onChange={(patch) => updateReview(anomaly.id, patch)}
+      messageId={messageId}
+      blockId={blockId}
+      index={idx}
+    />
+  )
+
+  const handleConfirm = () => {
+    if (!onConfirm) return
+    const reviewed: ReviewedAnomaly[] = anomalies.map((a) => {
+      const r = reviewMap[a.id]
+      return {
+        id: a.id,
+        included: r.included,
+        severity: r.severity,
+        description: r.description,
+      }
+    })
+    onConfirm(reviewed)
+  }
 
   return (
     <div className="flex flex-col gap-3">
@@ -172,15 +274,7 @@ export function AnomalyCard({ anomalies, messageId, blockId }: AnomalyCardProps)
           blockId={blockId}
           partId="anomaly-alerts-header"
         >
-          {alerts.map((anomaly, i) => (
-            <AnomalyItemRow
-              key={`alert-${i}`}
-              anomaly={anomaly}
-              messageId={messageId}
-              blockId={blockId}
-              index={i}
-            />
-          ))}
+          {alerts.map((x, i) => renderRow(x.anomaly, i))}
         </CollapsibleSection>
       )}
       {signals.length > 0 && (
@@ -192,16 +286,27 @@ export function AnomalyCard({ anomalies, messageId, blockId }: AnomalyCardProps)
           blockId={blockId}
           partId="anomaly-signals-header"
         >
-          {signals.map((anomaly, i) => (
-            <AnomalyItemRow
-              key={`signal-${i}`}
-              anomaly={anomaly}
-              messageId={messageId}
-              blockId={blockId}
-              index={alerts.length + i}
-            />
-          ))}
+          {signals.map((x, i) => renderRow(x.anomaly, alerts.length + i))}
         </CollapsibleSection>
+      )}
+
+      {confirmed ? (
+        <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+          <Lock className="h-3.5 w-3.5" />
+          <span>Anomalies confirmed — review locked</span>
+        </div>
+      ) : (
+        interactive && (
+          <div className="flex flex-col gap-2">
+            <p className="text-xs text-muted-foreground">
+              Review each anomaly, then confirm. Once confirmed, this review is locked and
+              cannot be edited.
+            </p>
+            <Button size="sm" onClick={handleConfirm} disabled={disabled} className="self-start">
+              Confirm Anomalies
+            </Button>
+          </div>
+        )
       )}
     </div>
   )

--- a/frontend/src/components/agent/chat/MessageList.tsx
+++ b/frontend/src/components/agent/chat/MessageList.tsx
@@ -12,7 +12,7 @@ import { MiroGenerateCard } from "./MiroGenerateCard"
 import { DistributeMessageCard } from "./DistributeMessageCard"
 import { TaskListCard } from "./TaskListCard"
 import { RecommendedMiroBoardCard } from "./RecommendedMiroBoardCard"
-import type { AnomalyItem, RecommendedTask, WorkflowStepState, ColumnDetectionData } from "@/types/agent"
+import type { AnomalyItem, RecommendedTask, ReviewedAnomaly, WorkflowStepState, ColumnDetectionData } from "@/types/agent"
 import { StepProgress, type StepProgressItem } from "./StepProgress"
 import type { PendingExternalApproval } from "./ExternalApprovalModal"
 import type { TaskGenerationStatus } from "./TaskListCard"
@@ -45,6 +45,7 @@ export interface ChatMessage {
   type?: ChatMessageType
   isFollowUpPrompt?: boolean
   anomalies?: AnomalyItem[]
+  anomaliesConfirmed?: boolean
   recommendedTasks?: RecommendedTask[]
   columnMappingData?: ColumnDetectionData
   fileName?: string
@@ -63,6 +64,7 @@ export interface MessageListProps {
   onAction?: (action: string) => void
   onNavigate?: (view: string, message?: ChatMessage) => void
   onConfirmColumns?: (mapping: Record<string, string>) => void
+  onConfirmAnomalies?: (messageId: string, reviewed: ReviewedAnomaly[]) => void
   onReupload?: () => void
   sessionId?: string | null
   approvalDisabled?: boolean
@@ -96,6 +98,7 @@ export function MessageList({
   onAction,
   onNavigate,
   onConfirmColumns,
+  onConfirmAnomalies,
   onReupload,
   sessionId,
   approvalDisabled,
@@ -349,6 +352,13 @@ export function MessageList({
                     anomalies={message.anomalies}
                     messageId={message.id}
                     blockId={`${message.id}-anomalies`}
+                    confirmed={Boolean(message.anomaliesConfirmed)}
+                    disabled={isStreaming}
+                    onConfirm={
+                      onConfirmAnomalies
+                        ? (reviewed) => onConfirmAnomalies(message.id, reviewed)
+                        : undefined
+                    }
                   />
                 </AgentMessageBoardBlock>
               )}

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -53,6 +53,8 @@ export interface AgentMessage {
 
 export interface AgentMessageData {
   anomalies?: AnomalyItem[];
+  reviewed_anomalies?: AnomalyItem[];
+  anomalies_confirmed?: boolean;
   decision_id?: number;
   task_ids?: number[];
   created_tasks?: Array<{ index: number; task_id: number; summary: string }>;
@@ -92,6 +94,7 @@ export type SSEEventType =
   | 'calendar_updated'
   | 'step_progress'
   | 'column_mapping'
+  | 'anomalies_confirmed'
   | 'done'
   | 'error';
 
@@ -111,6 +114,7 @@ export type AgentAction =
   | 'start_follow_up'
   | 'cancel_follow_up'
   | 'confirm_columns'
+  | 'confirm_anomalies'
   | 'resolve_external_approval';
 
 export interface CalendarContextPayload {
@@ -139,6 +143,7 @@ export interface AgentChatRequest {
   approval_decision?: 'approve' | 'reject';
   approval_draft?: Record<string, unknown>;
   user_context?: string;
+  reviewed_anomalies?: ReviewedAnomaly[];
 }
 
 // ==================== Analysis Types ====================
@@ -146,6 +151,7 @@ export interface AgentChatRequest {
 export type AnomalySeverity = 'critical' | 'warning' | 'info';
 
 export interface AnomalyItem {
+  id: string;
   metric: string;
   movement: string;
   severity: AnomalySeverity;
@@ -154,6 +160,16 @@ export interface AnomalyItem {
   change_percent: number;
   campaign?: string | null;
   ad_set?: string | null;
+  description: string;
+  /** Present on reviewed anomalies after confirmation. */
+  included?: boolean;
+}
+
+/** Per-anomaly review decision sent to the backend on confirm_anomalies. */
+export interface ReviewedAnomaly {
+  id: string;
+  included: boolean;
+  severity: AnomalySeverity;
   description: string;
 }
 
@@ -198,6 +214,8 @@ export interface ImportedCSVFile {
 
 export interface AnalysisResult {
   anomalies: AnomalyItem[];
+  reviewed_anomalies?: AnomalyItem[];
+  anomalies_confirmed?: boolean;
   recommended_tasks?: RecommendedTask[];
 }
 
@@ -212,6 +230,7 @@ export interface RecommendedTask {
 
 export interface WorkflowStepState {
   analysisComplete: boolean;
+  anomaliesConfirmed: boolean;
   tasksCreated: boolean;
 }
 


### PR DESCRIPTION
## Summary

- Add an **Anomaly Review & Confirmation** step after analysis and before task creation — anomalies are now interactive cards instead of read-only, so false positives no longer auto-flow into task creation
- Each anomaly supports **include/exclude**, **severity editing**, and **inline description editing**; excluded anomalies stay visible but muted (greyed + strikethrough) and are preserved for audit
- The user must explicitly click **Confirm Anomalies** before any tasks are created; confirmation is **one-way** (the card locks read-only afterward)
- **Scope note:** the codebase does not create real Decision records — the actionable downstream is task creation, which is what this gate controls (`create_decision` is a dead no-op)

## What Changed

### Backend
- `services.py`: `_assign_anomaly_ids()` assigns stable ids at the `_run_analysis` chokepoint (idempotent; zero-anomaly datasets auto-confirm to preserve existing behaviour). New `confirm_anomalies()` action — already-confirmed safe no-op (before validation), **atomic completeness check** (rejects unknown/missing/duplicate ids so every anomaly is explicitly included/excluded), merges edits onto full anomaly objects, persists `reviewed_anomalies` + `anomalies_confirmed`, and updates the stored analysis message for faithful restore
- `services.py` / `executors.py`: `create_tasks_from_analysis` and `CreateTasksExecutor` **gate task creation** on `anomalies_confirmed`; tasks are skipped only when anomalies existed and the user excluded all of them; included anomalies attached to `commit_context` for audit
- `serializers.py`: `confirm_anomalies` action choice + `reviewed_anomalies` field
- `views.py`: chat endpoint forwards `reviewed_anomalies`; confirmation event isn't re-persisted as a duplicate card
- No migration — confirmation state lives in the existing `analysis_result` JSONField

### Frontend
- `AnomalyCard.tsx`: now interactive — include/exclude checkbox, severity dropdown, editable description, live Alerts/Signals re-grouping on severity change, pre-confirm lock warning, and one-way lock after confirm
- `AgentChatPage.tsx`: defers downstream actions until anomalies are confirmed; `handleConfirmAnomalies` + `runPostConfirmActions` (skips tasks when none included); session-restore mapper reflects reviewed/confirmed state
- `MessageList.tsx` / `agent.ts`: thread the confirm callback + `anomaliesConfirmed`; add `AnomalyItem.id`, `ReviewedAnomaly`, `WorkflowStepState.anomaliesConfirmed`, and the `anomalies_confirmed` SSE/action types

## Test plan
- [ ] Analyze a file → anomaly cards are interactive; exclude one (greys + strikethrough), change a severity (row moves Alerts↔Signals), edit a description
- [ ] No tasks created until **Confirm Anomalies** is clicked (verify in DevTools → Network: `create_tasks` only fires after `confirm_anomalies`)
- [ ] After confirm, the card is locked read-only; reload keeps it locked and does not duplicate tasks
- [ ] Exclude **all** anomalies → confirm succeeds but **no tasks created** ("All anomalies were excluded")
- [ ] Zero-anomaly dataset → no card, tasks still created (existing behaviour preserved)
- [ ] Approval **ON** → confirm routes to the task-approval step instead of auto-creating
- [ ] Backend unit tests: `python manage.py test agent`

## Linear
[agent-16](https://linear.app/mediajira/issue/MED-160/agent-16-post-analysis-anomaly-review-and-editing)
