### PR TITLE
feat(agent): integrate draft context into Agent chat 

### DIFF
--- a/backend/agent/serializers.py
+++ b/backend/agent/serializers.py
@@ -149,6 +149,9 @@ class ChatInputSerializer(serializers.Serializer):
     )
     approval_draft = serializers.JSONField(required=False, allow_null=True)
     calendar_context = serializers.JSONField(required=False, allow_null=True)
+    # Draft → Agent context (read-only). Format: {"draftId": <pk|slug>, ...}.
+    # The Agent reads the draft via notion_editor's existing API/permissions.
+    draft_context = serializers.JSONField(required=False, allow_null=True)
     workflow_id = serializers.UUIDField(required=False, allow_null=True)
     # User-approved column mapping for confirm_columns action.
     # Format: {original_header: canonical_name or "unknown"}

--- a/backend/agent/services.py
+++ b/backend/agent/services.py
@@ -997,6 +997,7 @@ class AgentOrchestrator:
 
     def handle_message(self, message, spreadsheet_id=None, csv_filename=None,
                        action=None, file_id=None, calendar_context=None,
+                       draft_context=None,
                        workflow_id=None, column_mapping=None,
                        approval_id=None, approval_decision=None,
                        approval_draft=None, generation_outputs=None, user_context=None,
@@ -1029,6 +1030,12 @@ class AgentOrchestrator:
         # --- Calendar context takes priority over all other routing ---
         if calendar_context:
             yield from self.answer_calendar_question(message, calendar_context)
+            yield {"type": "done"}
+            return
+
+        # --- Draft context: answer using the draft's real content (read-only) ---
+        if draft_context:
+            yield from self.answer_draft_question(message, draft_context)
             yield {"type": "done"}
             return
 
@@ -1292,6 +1299,109 @@ class AgentOrchestrator:
         except Exception as e:
             logger.error(f"Failed to create calendar event: {e}")
             return None
+
+    # Cap on the draft text inlined into the LLM context (chars).
+    _DRAFT_PAYLOAD_MAX_CHARS = 12000
+
+    def answer_draft_question(self, message, draft_context):
+        """Answer a question using a draft's real content (AGENT-7, read-only).
+
+        The Agent reuses notion_editor's existing logic in-process — never
+        reimplementing it:
+          * permissions: DraftViewSet.get_queryset() is the single source of
+            truth for which drafts this user may see, and
+          * rendering: notion_editor's _html_to_plain_text extracts block text.
+        notion_editor's source files are unchanged, and the Agent holds no
+        draft/block/permission logic of its own.
+
+        TODO(AGENT-7 write direction): if Agent → Draft (create/update) becomes
+        in scope, drive it through notion_editor's existing DraftViewSet
+        create/update flow (no duplicate draft/block logic) and surface a
+        confirmation card linking back into the Notion module.
+        """
+        from types import SimpleNamespace
+        from notion_editor.views import DraftViewSet
+        from notion_editor.services import _html_to_plain_text
+        from .gemini_client import call_gemini, _get_api_key as _gemini_key
+
+        draft_ref = None
+        if isinstance(draft_context, dict):
+            draft_ref = draft_context.get('draftId') or draft_context.get('draft_id')
+        if not draft_ref:
+            yield {"type": "error", "content": "No draft was specified."}
+            return
+
+        # Permissions come entirely from DraftViewSet.get_queryset(), which
+        # only reads request.user — so a minimal stub request is enough. The
+        # Agent never reimplements the user/is_deleted access filter.
+        view = DraftViewSet()
+        view.request = SimpleNamespace(user=self.user)
+        accessible = view.get_queryset()
+
+        # Identify the draft within the already permission-scoped queryset
+        # (slug is the public identifier; fall back to a legacy numeric pk).
+        draft_ref = str(draft_ref)
+        draft = accessible.filter(slug=draft_ref).first()
+        if draft is None and draft_ref.isdigit():
+            draft = accessible.filter(pk=int(draft_ref)).first()
+        if draft is None:
+            yield {
+                "type": "error",
+                "content": "That draft could not be found or you do not have access to it.",
+            }
+            return
+
+        if not _gemini_key():
+            yield {"type": "error", "content": "Agent AI is not configured. Please set GEMINI_API_KEY."}
+            return
+
+        # Render blocks to text by reusing notion_editor's HTML extractor; the
+        # Agent does not parse or re-model blocks itself.
+        parts = []
+        title = (draft.title or '').strip()
+        if title:
+            parts.append(f"# {title}")
+        blocks = draft.content_blocks if isinstance(draft.content_blocks, list) else []
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+            content = block.get('content') or {}
+            html = ''
+            if isinstance(content, dict):
+                html = content.get('html') or content.get('text') or ''
+            text = _html_to_plain_text(html).strip()
+            if text:
+                parts.append(text)
+        draft_text = "\n\n".join(parts)
+        if len(draft_text) > self._DRAFT_PAYLOAD_MAX_CHARS:
+            draft_text = draft_text[:self._DRAFT_PAYLOAD_MAX_CHARS].rstrip() + "\n\n[... draft truncated for length ...]"
+
+        system_prompt = (
+            "You are a helpful writing assistant embedded in a Notion-style draft editor. "
+            "You help the user understand, summarize, expand, and answer questions about THIS draft. "
+            "Use only the provided draft content as ground truth; if the answer is not in the draft, "
+            "say so plainly. Respond in clear plain text (no JSON, no markdown code fences)."
+        )
+        user_prompt = (
+            f"Draft title: {draft.title}\n\n"
+            f'Draft content:\n"""\n{draft_text}\n"""\n\n'
+            f"User question: {message}"
+        )
+
+        try:
+            answer = call_gemini(
+                system_prompt=system_prompt,
+                user_prompt=user_prompt,
+                temperature=0.3,
+                timeout=90,
+            )
+        except Exception as e:
+            logger.error(f"Gemini draft Q&A error: {e}")
+            yield {"type": "error", "content": "Failed to get AI response. Please try again."}
+            return
+
+        answer_text = (answer or "").strip() or "I couldn't generate a response for that draft."
+        yield {"type": "text", "content": answer_text}
 
     def answer_calendar_question(self, message, calendar_context):
         """Answer calendar-related questions using real event data via Dify AI."""

--- a/backend/agent/test_draft_context.py
+++ b/backend/agent/test_draft_context.py
@@ -1,0 +1,110 @@
+"""Tests for Draft -> Agent context (AGENT-7, read-only).
+
+The Agent reads a draft by reusing notion_editor's DraftViewSet.get_queryset()
+in-process (its user-scoped permissions) and _html_to_plain_text for rendering.
+These tests use the real ORM (Django TestCase) and only mock the LLM call, so
+the permission boundary is exercised for real. The critical guarantee is that
+the LLM is never called when the user may not access the draft.
+"""
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from core.models import Organization, Project
+from agent.models import AgentSession
+from agent.services import AgentOrchestrator
+from notion_editor.models import Draft
+
+User = get_user_model()
+
+
+def _draft(user, title, html="Some content."):
+    return Draft.objects.create(
+        user=user,
+        title=title,
+        content_blocks=[{"type": "rich_text", "content": {"html": html}}],
+    )
+
+
+class AnswerDraftQuestionTest(TestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(name='Draft Org')
+        self.user = User.objects.create_user(
+            email='draft@test.com', username='draftuser', password='pw',
+        )
+        self.user.organization = self.org
+        self.user.save()
+        self.other = User.objects.create_user(
+            email='other-draft@test.com', username='otherdraft', password='pw',
+        )
+        self.project = Project.objects.create(
+            name='Draft Project', organization=self.org, owner=self.user,
+        )
+        self.session = AgentSession.objects.create(user=self.user, project=self.project)
+        self.orch = AgentOrchestrator(self.user, self.project, self.session)
+        self.draft = _draft(self.user, "Q3 Campaign Plan", "Target EU region, raise ROAS.")
+
+    @patch('agent.gemini_client._get_api_key', return_value='key')
+    @patch('agent.gemini_client.call_gemini')
+    def test_user_can_read_own_draft(self, mock_gemini, _mock_key):
+        mock_gemini.return_value = "Your draft focuses on the EU region."
+        chunks = list(self.orch.answer_draft_question(
+            "What is this draft about?", {"draftId": self.draft.slug},
+        ))
+        self.assertIn('text', [c['type'] for c in chunks])
+        self.assertNotIn('error', [c['type'] for c in chunks])
+        # Real draft content (rendered via notion_editor) reached the LLM prompt.
+        user_prompt = mock_gemini.call_args.kwargs['user_prompt']
+        self.assertIn("Target EU region", user_prompt)
+        self.assertIn("Q3 Campaign Plan", user_prompt)
+
+    @patch('agent.gemini_client._get_api_key', return_value='key')
+    @patch('agent.gemini_client.call_gemini')
+    def test_resolves_draft_by_numeric_pk(self, mock_gemini, _mock_key):
+        mock_gemini.return_value = "ok"
+        chunks = list(self.orch.answer_draft_question(
+            "Summarize", {"draftId": str(self.draft.pk)},
+        ))
+        self.assertIn('text', [c['type'] for c in chunks])
+
+    @patch('agent.gemini_client.call_gemini')
+    def test_cannot_read_other_users_draft_and_llm_never_called(self, mock_gemini):
+        # Owned by another user -> DraftViewSet.get_queryset() excludes it.
+        foreign = _draft(self.other, "Secret", "top secret content")
+        chunks = list(self.orch.answer_draft_question(
+            "Read it", {"draftId": foreign.slug},
+        ))
+        self.assertEqual(chunks[0]['type'], 'error')
+        mock_gemini.assert_not_called()
+
+    @patch('agent.gemini_client.call_gemini')
+    def test_soft_deleted_draft_is_inaccessible(self, mock_gemini):
+        self.draft.is_deleted = True
+        self.draft.save(update_fields=['is_deleted'])
+        chunks = list(self.orch.answer_draft_question("read it", {"draftId": self.draft.slug}))
+        self.assertEqual(chunks[0]['type'], 'error')
+        mock_gemini.assert_not_called()
+
+    @patch('agent.gemini_client.call_gemini')
+    def test_nonexistent_slug_yields_clean_error(self, mock_gemini):
+        chunks = list(self.orch.answer_draft_question("read it", {"draftId": "does-not-exist"}))
+        self.assertEqual(chunks[0]['type'], 'error')
+        mock_gemini.assert_not_called()
+
+    @patch('agent.gemini_client.call_gemini')
+    def test_missing_draft_ref_yields_error(self, mock_gemini):
+        chunks = list(self.orch.answer_draft_question("hi", {}))
+        self.assertEqual(chunks[0]['type'], 'error')
+        mock_gemini.assert_not_called()
+
+    @patch('agent.gemini_client._get_api_key', return_value='key')
+    @patch('agent.gemini_client.call_gemini')
+    def test_handle_message_routes_draft_context(self, mock_gemini, _mock_key):
+        mock_gemini.return_value = "answer"
+        chunks = list(self.orch.handle_message(
+            "What's here?", draft_context={"draftId": self.draft.slug},
+        ))
+        types = [c['type'] for c in chunks]
+        self.assertIn('text', types)
+        self.assertIn('done', types)

--- a/backend/agent/views.py
+++ b/backend/agent/views.py
@@ -162,6 +162,7 @@ class ChatView(EnglishResponseMixin, APIView):
         file_id = serializer.validated_data.get('file_id')
         action = serializer.validated_data.get('action')
         calendar_context = serializer.validated_data.get('calendar_context')
+        draft_context = serializer.validated_data.get('draft_context')
         workflow_id = serializer.validated_data.get('workflow_id')
         column_mapping = serializer.validated_data.get('column_mapping')
         user_context = serializer.validated_data.get('user_context') or None
@@ -249,6 +250,7 @@ class ChatView(EnglishResponseMixin, APIView):
                     action=action,
                     file_id=file_id,
                     calendar_context=calendar_context,
+                    draft_context=draft_context,
                     workflow_id=workflow_id,
                     column_mapping=column_mapping,
                     approval_id=approval_id,

--- a/frontend/src/__tests__/lib/agentLaunchContext.test.ts
+++ b/frontend/src/__tests__/lib/agentLaunchContext.test.ts
@@ -2,7 +2,10 @@ import {
   AGENT_CALENDAR_CONTEXT_KEY,
   AGENT_SESSION_ID_KEY,
   consumeCalendarPreload,
+  consumeDraftPreload,
   readStoredAgentSessionId,
+  shouldAutoSendDraftPreload,
+  stageDraftContext,
 } from '@/lib/agentLaunchContext';
 
 describe('agentLaunchContext', () => {
@@ -51,5 +54,48 @@ describe('agentLaunchContext', () => {
   it('reads stored agent session id', () => {
     sessionStorage.setItem(AGENT_SESSION_ID_KEY, '  session-42  ');
     expect(readStoredAgentSessionId()).toBe('session-42');
+  });
+});
+
+describe('agentLaunchContext — draft entry points', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('"Ask Agent" (list) stages an auto-send "Summarize this draft." message', () => {
+    stageDraftContext({ draftId: 'q3-plan', title: 'Q3 Plan', autoSend: true });
+    const preload = consumeDraftPreload();
+    expect(preload).not.toBeNull();
+    expect(preload?.autoSend).toBe(true);
+    expect(preload?.message).toBe('Summarize this draft.');
+    expect(preload?.context.draftId).toBe('q3-plan');
+    expect(shouldAutoSendDraftPreload(preload)).toBe(true);
+  });
+
+  it('"Open in Agent" (editor) attaches context but does NOT auto-send', () => {
+    stageDraftContext({ draftId: 'q3-plan', title: 'Q3 Plan', autoSend: false });
+    const preload = consumeDraftPreload();
+    expect(preload).not.toBeNull();
+    expect(preload?.autoSend).toBe(false);
+    expect(preload?.message).toBe('');
+    // The agent must stay silent (no LLM call) until the user sends a message.
+    expect(shouldAutoSendDraftPreload(preload)).toBe(false);
+    // ...but the draft is still attached for whatever the user sends next.
+    expect(preload?.context.draftId).toBe('q3-plan');
+  });
+
+  it('defaults to auto-send when the flag is omitted', () => {
+    stageDraftContext({ draftId: 'x' });
+    expect(consumeDraftPreload()?.autoSend).toBe(true);
+  });
+
+  it('consuming clears the staged draft context', () => {
+    stageDraftContext({ draftId: 'x', autoSend: false });
+    expect(consumeDraftPreload()).not.toBeNull();
+    expect(consumeDraftPreload()).toBeNull();
+  });
+
+  it('shouldAutoSendDraftPreload is false for null', () => {
+    expect(shouldAutoSendDraftPreload(null)).toBe(false);
   });
 });

--- a/frontend/src/app/(project)/notion/[draftId]/page.tsx
+++ b/frontend/src/app/(project)/notion/[draftId]/page.tsx
@@ -12,6 +12,7 @@ import {
   ChevronDown,
   MoreHorizontal,
   Trash2,
+  Sparkles,
   X,
 } from 'lucide-react';
 import { toast } from 'react-hot-toast';
@@ -40,6 +41,8 @@ import {
 import { NotionDraftAPI } from '@/lib/api/notionDraftApi';
 import { GoogleDocListItem, googleDocsApi } from '@/lib/api/googleDocsApi';
 import { notionIntegrationApi } from '@/lib/api/notionIntegrationApi';
+import { stageDraftContext } from '@/lib/agentLaunchContext';
+import { openAgentSidePanel } from '@/lib/agentSidePanelStore';
 import type {
   DraftStatus,
   EditorBlock,
@@ -683,6 +686,22 @@ function NotionV2DetailContent() {
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
+            <button
+              type="button"
+              onClick={() => {
+                if (!draftId) return;
+                // "Open in Agent": attach the draft as context but don't ask
+                // anything yet — the user types their own first question.
+                stageDraftContext({ draftId, title, autoSend: false });
+                openAgentSidePanel();
+              }}
+              disabled={!draftId}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md border border-violet-200 bg-violet-50 text-violet-800 hover:bg-violet-100 transition disabled:opacity-50 disabled:cursor-not-allowed"
+              title="Open this draft in the Agent"
+            >
+              <Sparkles className="w-4 h-4" />
+              Open in Agent
+            </button>
             <button
               type="button"
               onClick={handleSave}

--- a/frontend/src/components/agent/chat/AgentChatPage.tsx
+++ b/frontend/src/components/agent/chat/AgentChatPage.tsx
@@ -37,7 +37,10 @@ import type { DecisionGenerationStatus } from "./DecisionTreeListCard"
 import {
   AGENT_PANEL_OPENED_EVENT,
   consumeCalendarPreload,
+  consumeDraftPreload,
+  shouldAutoSendDraftPreload,
   type CalendarPreload,
+  type DraftPreload,
 } from "@/lib/agentLaunchContext"
 import { getPendingMiroWorkflowRunIds } from "@/lib/agentMiroBoardStatus"
 import { agentMiroBoardHref } from "@/lib/agentMiroBoardHref"
@@ -314,6 +317,8 @@ function appendMiroResultMessage(prev: ChatMessage[], event: SSEEvent): ChatMess
 
 // Reset when new calendar context is consumed so auto-send fires once per launch.
 let _calendarAutoSendFired = false
+// Same one-shot guard for a staged draft context (Draft → Agent).
+let _draftAutoSendFired = false
 
 type AgentChatPageProps = {
   /** Hide title + approval row; used when the floating window title bar shows them. */
@@ -437,6 +442,24 @@ export function AgentChatPage({ embeddedInFloating = false }: AgentChatPageProps
       sessionStorage.setItem("agent-session-calendar-context", JSON.stringify(sessionCalendarContext))
     }
   }, [sessionCalendarContext])
+
+  // Draft → Agent: staged draft context (read-only). Mirrors the calendar flow.
+  const [pendingDraftPreload, setPendingDraftPreload] = useState<DraftPreload | null>(() => {
+    const preload = consumeDraftPreload()
+    if (preload) {
+      _draftAutoSendFired = false
+    }
+    return preload
+  })
+  // Persist for the session lifetime so follow-up questions stay in draft context.
+  const [sessionDraftContext, setSessionDraftContext] = useState<Record<string, unknown> | null>(
+    pendingDraftPreload ? pendingDraftPreload.context : null
+  )
+  useEffect(() => {
+    if (sessionDraftContext) {
+      sessionStorage.setItem("agent-session-draft-context", JSON.stringify(sessionDraftContext))
+    }
+  }, [sessionDraftContext])
 
   const handleSendMessageRef = useRef<typeof handleSendMessage | null>(null)
   const isAwaitingFollowUp = followUpStarted && !isStreaming
@@ -1012,8 +1035,35 @@ setStepState({
       _calendarAutoSendFired = false
     }
 
-    window.addEventListener(AGENT_PANEL_OPENED_EVENT, onPanelOpened)
-    return () => window.removeEventListener(AGENT_PANEL_OPENED_EVENT, onPanelOpened)
+    // Draft → Agent (Open in Agent / Ask Agent from a draft).
+    const onPanelOpenedDraft = () => {
+      const preload = consumeDraftPreload()
+      if (!preload) {
+        return
+      }
+      sessionLoadRequestRef.current += 1
+      invalidateActiveStreams()
+      resetTransientChatUiState()
+      setSessionId(null)
+      sessionStorage.removeItem("agent-session-draft-context")
+      setMessages([])
+      setHasStarted(false)
+      setFollowUpAvailable(false)
+      setFollowUpStarted(false)
+      setSessionTitle("Chat")
+      setApprovalRequired(getApprovalPref())
+      setSessionDraftContext(preload.context)
+      setPendingDraftPreload(preload)
+      _draftAutoSendFired = false
+    }
+
+    const onPanelOpenedHandler = () => {
+      onPanelOpened()
+      onPanelOpenedDraft()
+    }
+
+    window.addEventListener(AGENT_PANEL_OPENED_EVENT, onPanelOpenedHandler)
+    return () => window.removeEventListener(AGENT_PANEL_OPENED_EVENT, onPanelOpenedHandler)
   }, [
     getApprovalPref,
     invalidateActiveStreams,
@@ -1030,8 +1080,11 @@ setStepState({
       setSessionId(null)
       setProjectId(null)
       sessionStorage.removeItem("agent-session-calendar-context")
+      sessionStorage.removeItem("agent-session-draft-context")
       setMessages([])
       setSessionCalendarContext(null)
+      setSessionDraftContext(null)
+      setPendingDraftPreload(null)
       setHasStarted(false)
       setFollowUpAvailable(false)
       setFollowUpStarted(false)
@@ -1706,6 +1759,7 @@ setStepState({
         ...(workflowId ? { workflow_id: workflowId } : {}),
         ...(action ? { action } : {}),
         ...(effectiveCalendarContext ? { calendar_context: effectiveCalendarContext as any } : {}),
+        ...(sessionDraftContext ? { draft_context: sessionDraftContext as any } : {}),
         user_context: userContext || undefined,
       },
       (event: SSEEvent) => {
@@ -1961,7 +2015,7 @@ setStepState({
         }
       }
     )
-  }, [sessionId, sessionCalendarContext, addMessage, updateMessage, setMessages, setSessionId, refreshFollowUpState, refreshSession, getApprovalPref, embeddedInFloating, queueAutoExternalActionsAfterAnalysis])
+  }, [sessionId, sessionCalendarContext, sessionDraftContext, addMessage, updateMessage, setMessages, setSessionId, refreshFollowUpState, refreshSession, getApprovalPref, embeddedInFloating, queueAutoExternalActionsAfterAnalysis])
 
   // Keep ref always pointing to the latest handleSendMessage
   handleSendMessageRef.current = handleSendMessage
@@ -2362,6 +2416,19 @@ setStepState({
     _calendarAutoSendFired = true
     handleSendMessageRef.current?.(pendingCalendarPreload.message, pendingCalendarPreload.context)
   }, [pendingCalendarPreload, hasStarted])
+
+  // Auto-send the initial draft question once — ONLY for "Ask Agent"
+  // (autoSend). "Open in Agent" (autoSend=false) just attaches the draft as
+  // context and waits for the user to type; sessionDraftContext is already set,
+  // so whichever message the user sends first still carries draft_context.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (!pendingDraftPreload || hasStarted) return
+    if (_draftAutoSendFired) return
+    if (!shouldAutoSendDraftPreload(pendingDraftPreload)) return
+    _draftAutoSendFired = true
+    handleSendMessageRef.current?.(pendingDraftPreload.message)
+  }, [pendingDraftPreload, hasStarted])
 
   return (
     <div className="flex h-full flex-col">

--- a/frontend/src/components/notion/NotionDraftCard.tsx
+++ b/frontend/src/components/notion/NotionDraftCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import { FileText, MoreHorizontal, Copy, Download, Trash2 } from 'lucide-react';
+import { FileText, MoreHorizontal, Copy, Download, Trash2, Sparkles } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -11,6 +11,8 @@ import {
 } from '@/components/ui/dropdown-menu';
 import NotionStatusPill from './NotionStatusPill';
 import type { DraftSummary } from '@/types/notion';
+import { stageDraftContext } from '@/lib/agentLaunchContext';
+import { openAgentSidePanel } from '@/lib/agentSidePanelStore';
 
 const formatTimestamp = (value: string) => {
   try {
@@ -106,6 +108,15 @@ export default function NotionDraftCard({
             data-prevent-open
             onClick={(event) => event.stopPropagation()}
           >
+            <DropdownMenuItem
+              onSelect={() => {
+                // "Ask Agent": auto-sends "Summarize this draft." on open.
+                stageDraftContext({ draftId: draftKey, title: draft.title, autoSend: true });
+                openAgentSidePanel();
+              }}
+            >
+              <Sparkles className="w-4 h-4 mr-2" /> Ask Agent
+            </DropdownMenuItem>
             <DropdownMenuItem onSelect={() => onDuplicate(draftKey)}>
               <Copy className="w-4 h-4 mr-2" /> Duplicate
             </DropdownMenuItem>

--- a/frontend/src/lib/agentLaunchContext.ts
+++ b/frontend/src/lib/agentLaunchContext.ts
@@ -1,6 +1,7 @@
 /** SessionStorage keys and launch helpers for Dashboard Agent side panel. */
 
 export const AGENT_CALENDAR_CONTEXT_KEY = 'agent-calendar-context';
+export const AGENT_DRAFT_CONTEXT_KEY = 'agent-draft-context';
 export const AGENT_SESSION_ID_KEY = 'agent-session-id';
 export const AGENT_PANEL_OPENED_EVENT = 'agent:panel-opened';
 
@@ -55,4 +56,82 @@ export function readStoredAgentSessionId(): string | null {
   }
   const stored = sessionStorage.getItem(AGENT_SESSION_ID_KEY);
   return stored?.trim() || null;
+}
+
+/**
+ * Context staged by a draft's entry point.
+ * - "Ask Agent" (autoSend=true): the Agent auto-sends `message` on open.
+ * - "Open in Agent" (autoSend=false): the draft is attached as context and the
+ *   cursor lands in the input; nothing is sent until the user types a message.
+ */
+export type DraftPreload = {
+  message: string;
+  autoSend: boolean;
+  context: Record<string, unknown>;
+};
+
+/**
+ * Stage a draft as Agent context (Draft → Agent). Stores a `{message, autoSend,
+ * context}` payload that the Agent side panel consumes on open. `context.draftId`
+ * is the draft's slug or pk; the Agent reads the draft via the existing Notion
+ * API. The draft context is threaded onto every subsequent send for the session,
+ * so follow-up messages keep the draft attached regardless of `autoSend`.
+ */
+export function stageDraftContext(args: {
+  draftId: string | number;
+  title?: string;
+  /** true = "Ask Agent" (auto-send); false = "Open in Agent" (wait for user). */
+  autoSend?: boolean;
+}): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const autoSend = args.autoSend !== false; // default: Ask Agent
+  const title = (args.title || '').trim();
+  const context: Record<string, unknown> = {
+    type: 'draft',
+    draftId: String(args.draftId),
+    title,
+  };
+  // Only "Ask Agent" carries an auto-message; "Open in Agent" stays silent.
+  const message = autoSend ? 'Summarize this draft.' : '';
+  sessionStorage.setItem(
+    AGENT_DRAFT_CONTEXT_KEY,
+    JSON.stringify({ message, autoSend, context })
+  );
+  // A fresh draft context starts a new conversation thread.
+  sessionStorage.removeItem(AGENT_SESSION_ID_KEY);
+}
+
+/**
+ * Whether a staged draft preload should auto-send its initial message.
+ * "Ask Agent" → true (sends immediately); "Open in Agent" → false (the Agent
+ * waits for the user, so no LLM call happens until they type a message).
+ */
+export function shouldAutoSendDraftPreload(preload: DraftPreload | null): boolean {
+  return Boolean(preload?.autoSend);
+}
+
+/**
+ * Read and remove draft context staged by a draft entry point.
+ * Returns null when no draft context is pending.
+ */
+export function consumeDraftPreload(): DraftPreload | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  const raw = sessionStorage.getItem(AGENT_DRAFT_CONTEXT_KEY);
+  if (!raw) {
+    return null;
+  }
+  sessionStorage.removeItem(AGENT_DRAFT_CONTEXT_KEY);
+  try {
+    const parsed = JSON.parse(raw) as DraftPreload;
+    if (!parsed || typeof parsed.message !== 'string' || typeof parsed.context !== 'object') {
+      return null;
+    }
+    return { ...parsed, autoSend: parsed.autoSend !== false };
+  } catch {
+    return null;
+  }
 }

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -165,6 +165,8 @@ export interface AgentChatRequest {
   csv_filename?: string;
   action?: AgentAction;
   calendar_context?: CalendarContextPayload;
+  /** Draft → Agent context (read-only): { draftId, title, ... }. */
+  draft_context?: Record<string, unknown>;
   workflow_id?: string;
   column_mapping?: Record<string, string>;
   approval_id?: string;


### PR DESCRIPTION
Implements AGENT-7 (Draft → Agent): users can launch the Agent from the draft list with "Ask Agent" (auto-asks for a summary) or from the draft editor with "Open in Agent" (attaches the draft as context, user types their own first question). The attached draft context is threaded on every subsequent message.

Backend
- agent/serializers.py: accept draft_context on ChatInputSerializer.
- agent/views.py: route draft_context into the orchestrator.
- agent/services.py: new answer_draft_question() reads the draft in-process by reusing notion_editor's DraftViewSet.get_queryset() for permissions and _html_to_plain_text for block rendering, then sends the draft text to the LLM. No ORM/permission/block logic is duplicated in the Agent.

Frontend
- lib/agentLaunchContext.ts: stageDraftContext / consumeDraftPreload with an autoSend boolean; shouldAutoSendDraftPreload predicate makes the "Open in Agent doesn't auto-send" rule explicit and testable.
- AgentChatPage: consumes the preload, threads draft_context on every send, gates auto-send via shouldAutoSendDraftPreload.
- NotionDraftCard: "Ask Agent" entry (autoSend: true).
- notion/[draftId]/page.tsx: "Open in Agent" entry (autoSend: false).

Constraints
- notion_editor module unchanged (verified clean).
- Permissions enforced by reusing DraftViewSet.get_queryset() in-process; the Agent has no access logic of its own.
- Read-only: Agent never creates or updates drafts. The write direction is left as a follow-up (TODO marker in answer_draft_question).

Tests
- agent/test_draft_context.py: real-ORM tests covering own-draft read, another user's draft (LLM never called), soft-deleted and nonexistent-slug errors, and handle_message routing.
- frontend launch-context tests: 5 tests covering both entry points, autoSend gating, and context persistence.

Linear
https://linear.app/mediajira/issue/MED-146/agent-7-notion-drafts-agent-integration