### PR TITLE
MED-233 Reject unsupported MIME types on attachment upload

### DIFF
--- a/backend/chat/services.py
+++ b/backend/chat/services.py
@@ -15,6 +15,38 @@ from core.models import ProjectMember
 User = get_user_model()
 logger = logging.getLogger(__name__)
 
+ALLOWED_ATTACHMENT_IMAGE_MIME_PREFIX = "image/"
+ALLOWED_ATTACHMENT_MIME_TYPES = frozenset({
+    "application/pdf",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.ms-powerpoint",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+})
+
+class UnsupportedAttachmentMimeType(ValueError):
+    """Raised when an uploaded attachment MIME type is not allowed."""
+
+
+def is_allowed_attachment_mime_type(mime_type: str) -> bool:
+    normalized_mime_type = (mime_type or "").strip().lower()
+    return (
+        normalized_mime_type.startswith(ALLOWED_ATTACHMENT_IMAGE_MIME_PREFIX)
+        or normalized_mime_type in ALLOWED_ATTACHMENT_MIME_TYPES
+    )
+
+
+def validate_attachment_mime_type(mime_type: str) -> None:
+    """
+    Raise UnsupportedAttachmentMimeType if MIME type is not allowed.
+    """
+    if not is_allowed_attachment_mime_type(mime_type):
+        raise UnsupportedAttachmentMimeType(
+            f'Unsupported MIME type: {mime_type or "<empty>"}'
+        )
+
 
 def extract_message_plain_text(rich_body) -> str:
     """Extract searchable plain text from a Tiptap JSON document."""
@@ -801,7 +833,6 @@ class ChatStarService:
             if s.position != idx:
                 s.position = idx
                 s.save(update_fields=['position', 'updated_at'])
-
 
 
 class MessageService:

--- a/backend/chat/tests/test_services.py
+++ b/backend/chat/tests/test_services.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from core.models import Organization, Project, ProjectMember
 from chat.models import Chat, ChatParticipant, ChatType
 from chat.serializers import ChatCreateSerializer
-from chat.services import ChatService, OnlineStatusService
+from chat.services import ChatService, OnlineStatusService, UnsupportedAttachmentMimeType, validate_attachment_mime_type
 
 User = get_user_model()
 
@@ -307,3 +307,37 @@ class PresenceRecipientCacheInvalidationTest(TestCase):
             cache.get(OnlineStatusService._presence_recipients_key(self.user_a.id)),
             [self.user_b.id],
         )
+
+class AttachmentMimeValidationTest(TestCase):
+    def test_allows_supported_mime_types(self):
+        allowed_types = [
+            "image/png",
+            "image/jpeg",
+            "image/svg+xml",
+            "application/pdf",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        ]
+
+        for mime_type in allowed_types:
+            with self.subTest(mime_type=mime_type):
+                validate_attachment_mime_type(mime_type)
+
+    def test_rejects_unsupported_mime_types(self):
+        rejected_types = [
+            "video/mp4",
+            "audio/webm",
+            "text/plain",
+            "text/csv",
+            "application/x-msdownload",
+            "application/x-sh",
+            "application/zip",
+            "text/html",
+            "",
+        ]
+
+        for mime_type in rejected_types:
+            with self.subTest(mime_type=mime_type):
+                with self.assertRaises(UnsupportedAttachmentMimeType):
+                    validate_attachment_mime_type(mime_type)

--- a/backend/chat/tests/test_views.py
+++ b/backend/chat/tests/test_views.py
@@ -1207,19 +1207,40 @@ class AttachmentAPITest(TestCase):
         from django.core.files.uploadedfile import SimpleUploadedFile
         
         test_file = SimpleUploadedFile(
-            'test.txt',
-            b'Test file content',
-            content_type='text/plain'
+            'test.pdf',
+            b'%PDF-1.4 test content',
+            content_type='application/pdf'
         )
         
         url = reverse('attachment-list')
         response = self.client.post(url, {'file': test_file}, format='multipart')
         
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data['original_filename'], 'test.txt')
+        self.assertEqual(response.data['original_filename'], 'test.pdf')
         self.assertEqual(response.data['file_type'], 'document')
         self.assertIn('file_url', response.data)
         self.assertIn('file_size_display', response.data)
+
+    def test_rejects_unsupported_mime_before_attachment_save(self):
+        """Unsupported MIME types return 415 and do not create an attachment row."""
+        from django.core.files.uploadedfile import SimpleUploadedFile
+        from chat.models import MessageAttachment
+
+        initial_count = MessageAttachment.objects.count()
+        test_file = SimpleUploadedFile(
+            'archive.zip',
+            b'PK\x03\x04',
+            content_type='application/zip'
+        )
+
+        url = reverse('attachment-list')
+        response = self.client.post(url, {'file': test_file}, format='multipart')
+
+        self.assertEqual(response.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
+        self.assertEqual(response.data['code'], 'unsupported_mime_type')
+        self.assertEqual(response.data['mime_type'], 'application/zip')
+        self.assertIn('Unsupported MIME type', response.data['error'])
+        self.assertEqual(MessageAttachment.objects.count(), initial_count)
     
     def test_upload_image(self):
         """Test uploading an image attachment"""

--- a/backend/chat/views.py
+++ b/backend/chat/views.py
@@ -44,7 +44,14 @@ from .serializers import (
     ScheduledMessageSerializer,
     ScheduledMessageCreateSerializer,
 )
-from .services import ChatService, ChatStarService, MessageService, OnlineStatusService
+from .services import (
+    ChatService,
+    ChatStarService,
+    MessageService,
+    OnlineStatusService,
+    UnsupportedAttachmentMimeType,
+    validate_attachment_mime_type,
+)
 from .tasks import notify_message_recipients, notify_new_message, send_scheduled_message
 from core.models import ProjectMember
 
@@ -319,7 +326,6 @@ class ChatViewSet(viewsets.ModelViewSet):
         
         except Exception as e:
             logger.error(f"Failed to notify participants about new chat: {e}")
-    
     def retrieve(self, request, *args, **kwargs):
         """Get chat details"""
         chat = self.get_object()
@@ -1602,6 +1608,22 @@ class AttachmentViewSet(viewsets.GenericViewSet):
         The attachment is initially unlinked (message=null).
         When sending a message, include the attachment IDs to link them.
         """
+
+        uploaded_file = request.FILES.get("file")
+
+        if uploaded_file:
+            try:
+                validate_attachment_mime_type(uploaded_file.content_type)
+            except UnsupportedAttachmentMimeType as e:
+                return Response(
+                    {
+                        "code": "unsupported_mime_type",
+                        "error": str(e),
+                        "mime_type": uploaded_file.content_type,
+                    },
+                    status=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+                )
+
         serializer = AttachmentUploadSerializer(
             data=request.data, 
             context={'request': request}

--- a/frontend/e2e/messages/messages-message-actions.spec.ts
+++ b/frontend/e2e/messages/messages-message-actions.spec.ts
@@ -21,6 +21,9 @@ const CHAT_ID = 9901;
 const CREATED_AT = '2026-05-28T10:00:00.000Z';
 
 type MockMessage = Record<string, any>;
+type SetupMessagesPageOptions = {
+	attachmentUploadHandler?: (requestIndex: number) => Promise<Record<string, any>>;
+};
 
 function buildChat() {
 	return {
@@ -86,7 +89,7 @@ function buildMessage(overrides: Record<string, any>): MockMessage {
 	};
 }
 
-async function setupMessagesPage(page: Page) {
+async function setupMessagesPage(page: Page, options: SetupMessagesPageOptions = {}) {
 	const chat = buildChat();
 	const messagesStore = [
 		buildMessage({
@@ -319,6 +322,42 @@ async function setupMessagesPage(page: Page) {
 		await route.fallback();
 	});
 
+	let attachmentUploadRequestCount = 0;
+	await page.route('**/api/chat/attachments/**', async (route) => {
+		const req = route.request();
+		const pathname = new URL(req.url()).pathname.replace(/\/+$/, '');
+
+		if (pathname === '/api/chat/attachments' && req.method() === 'POST') {
+			attachmentUploadRequestCount += 1;
+			const attachment = options.attachmentUploadHandler
+				? await options.attachmentUploadHandler(attachmentUploadRequestCount)
+				: {
+					id: 7000 + attachmentUploadRequestCount,
+					message: null,
+					file_type: 'document',
+					file_url: `/media/e2e-upload-${attachmentUploadRequestCount}.pdf`,
+					thumbnail_url: null,
+					file_size: 20,
+					file_size_display: '20 B',
+					original_filename: `e2e-upload-${attachmentUploadRequestCount}.pdf`,
+					mime_type: 'application/pdf',
+				};
+			await route.fulfill({
+				status: 201,
+				contentType: 'application/json',
+				body: JSON.stringify(attachment),
+			});
+			return;
+		}
+
+		if (/\/api\/chat\/attachments\/\d+$/.test(pathname) && req.method() === 'DELETE') {
+			await route.fulfill({ status: 204, body: '' });
+			return;
+		}
+
+		await route.fallback();
+	});
+
 	await page.goto(`/messages?projectId=${PROJECT.id}&chatId=${CHAT_ID}`);
 	await waitForLayoutMain(page);
 	await expect(page.getByTestId('messages-chat-window')).toBeVisible({ timeout: 15_000 });
@@ -353,6 +392,37 @@ test.describe('Message timeline actions', () => {
 		await page.getByRole('button', { name: 'Hide formatting' }).click();
 		await expect(page.getByRole('button', { name: 'Show formatting' })).toBeVisible();
 		await expect(page.getByRole('button', { name: /Bold/ })).not.toBeVisible();
+	});
+
+	test('attachment picker rejects unsupported MIME inline and retry with valid file succeeds', async ({ page }) => {
+		await setupMessagesPage(page);
+
+		const fileInput = page.locator('input[type="file"][accept*=".pdf"]').first();
+		await fileInput.setInputFiles({
+			name: 'bad.zip',
+			mimeType: 'application/zip',
+			buffer: Buffer.from('zip-content'),
+		});
+
+		await expect(page.getByText('bad.zip')).toBeVisible();
+		await expect(
+			page
+			.getByTestId('messages-chat-window')
+			.getByText('Unsupported file type "application/zip"')
+		).toBeVisible();
+
+		await page.getByRole('button', { name: 'Remove attachment' }).click();
+		await expect(page.getByText('bad.zip')).not.toBeVisible();
+
+		await fileInput.setInputFiles({
+			name: 'approved.pdf',
+			mimeType: 'application/pdf',
+			buffer: Buffer.from('%PDF-1.4 valid'),
+		});
+
+		const approvedAttachment = page.locator('div').filter({ hasText: 'approved.pdf' }).first();
+		await expect(approvedAttachment).toContainText('approved.pdf');
+		await expect(approvedAttachment).toContainText('✓');
 	});
 
 	test('hover toolbar can edit an own message and delete it into a tombstone', async ({ page }) => {

--- a/frontend/src/components/chat/ChatComposer.tsx
+++ b/frontend/src/components/chat/ChatComposer.tsx
@@ -80,6 +80,8 @@ import {
   validateFile,
   getFileTypeFromMime,
   formatFileSize,
+  CHAT_ATTACHMENT_INPUT_ACCEPT,
+  getAttachmentUploadErrorMessage,
 } from '@/lib/api/attachmentApi';
 import {
   createChatEditorExtensions,
@@ -1290,10 +1292,10 @@ export default function ChatComposer({
 
   const uploadFiles = useCallback(async (files: File[]) => {
     const newAttachments: PendingAttachment[] = [];
+    const uploadQueue: PendingAttachment[] = [];
     for (let i = 0; i < files.length; i++) {
       const file = files[i];
       const { isValid, error } = validateFile(file);
-      if (!isValid) { toast.error(error || `Invalid file: ${file.name}`); continue; }
       const preview = (
         file.type.startsWith('image/') ||
         file.type.startsWith('video/') ||
@@ -1301,21 +1303,35 @@ export default function ChatComposer({
       )
         ? URL.createObjectURL(file)
         : undefined;
-      newAttachments.push({ id: `tmp-${Date.now()}-${i}`, file, preview, progress: 0, uploading: true });
+      const attachment: PendingAttachment = {
+        id: `tmp-${Date.now()}-${i}`,
+        file,
+        preview,
+        progress: 0,
+        uploading: isValid,
+        error: isValid ? undefined : (error || `Invalid file: ${file.name}`),
+      };
+      newAttachments.push(attachment);
+      if (!isValid) {
+        toast.error(attachment.error || `Invalid file: ${file.name}`);
+        continue;
+      }
+      uploadQueue.push(attachment);
     }
     if (newAttachments.length === 0) return;
     setPendingAttachments((prev) => [...prev, ...newAttachments]);
+    if (uploadQueue.length === 0) return;
     setIsUploading(true);
-    for (const att of newAttachments) {
+    for (const att of uploadQueue) {
       try {
         const uploaded = await uploadAttachment(att.file, (progress) => {
           setPendingAttachments((prev) => prev.map((a) => a.id === att.id ? { ...a, progress } : a));
         });
         setPendingAttachments((prev) => prev.map((a) => a.id === att.id ? { ...a, uploading: false, uploaded } : a));
       } catch (err: unknown) {
-        const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error || 'Upload failed';
+        const msg = getAttachmentUploadErrorMessage(err, att.file.type);
         setPendingAttachments((prev) => prev.map((a) => a.id === att.id ? { ...a, uploading: false, error: msg } : a));
-        toast.error(`Failed to upload ${att.file.name}`);
+        toast.error(msg);
       }
     }
     setIsUploading(false);
@@ -2043,7 +2059,11 @@ export default function ChatComposer({
                     <span className="text-xs text-[#3CCED7]">{att.progress}%</span>
                   </div>
                 )}
-                {att.error && <span className="text-xs text-red-600">Failed</span>}
+                {att.error && (
+                  <p className="max-w-[200px] truncate text-xs text-red-600" title={att.error}>
+                    {att.error}
+                  </p>
+                )}
                 {att.uploaded && !att.uploading && <span className="text-xs text-green-600">✓</span>}
                 <button
                   type="button"
@@ -2135,7 +2155,7 @@ export default function ChatComposer({
             ref={fileInputRef}
             type="file"
             multiple
-            accept="image/*,video/*,audio/*,.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.txt,.csv"
+            accept={CHAT_ATTACHMENT_INPUT_ACCEPT}
             onChange={handleFileSelect}
             className="hidden"
           />

--- a/frontend/src/lib/api/attachmentApi.ts
+++ b/frontend/src/lib/api/attachmentApi.ts
@@ -12,9 +12,15 @@ export const FILE_SIZE_LIMITS = {
   document: 20 * 1024 * 1024, // 20 MB
 };
 
+export const CHAT_ATTACHMENT_INPUT_ACCEPT =
+  'image/*,.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx';
+
+export const SUPPORTED_ATTACHMENT_DOCUMENT_LABEL =
+  'images, PDF, Word, Excel, and PowerPoint files';
+
 // Allowed MIME types
 export const ALLOWED_MIME_TYPES = {
-  image: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
+  imagePrefix: 'image/',
   video: ['video/mp4', 'video/webm', 'video/quicktime', 'video/x-msvideo'],
   document: [
     'application/pdf',
@@ -24,13 +30,6 @@ export const ALLOWED_MIME_TYPES = {
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     'application/vnd.ms-powerpoint',
     'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-    'audio/mp4',
-    'audio/mpeg',
-    'audio/ogg',
-    'audio/wav',
-    'audio/webm',
-    'text/plain',
-    'text/csv',
   ],
 };
 
@@ -38,19 +37,39 @@ export const ALLOWED_MIME_TYPES = {
  * Get file type from MIME type
  */
 export function getFileTypeFromMime(mimeType: string): 'image' | 'video' | 'document' {
-  if (mimeType.startsWith('image/')) return 'image';
+  if (mimeType.startsWith(ALLOWED_MIME_TYPES.imagePrefix)) return 'image';
   if (mimeType.startsWith('video/')) return 'video';
   return 'document';
+}
+
+export function isAllowedAttachmentMimeType(mimeType: string): boolean {
+  const normalizedMimeType = mimeType.trim().toLowerCase();
+  return (
+    normalizedMimeType.startsWith(ALLOWED_MIME_TYPES.imagePrefix) ||
+    ALLOWED_MIME_TYPES.document.includes(normalizedMimeType)
+  );
+}
+
+export function buildUnsupportedAttachmentMessage(mimeType: string): string {
+  const normalizedMimeType = mimeType.trim() || 'unknown';
+  return `Unsupported file type "${normalizedMimeType}". Accepted formats: ${SUPPORTED_ATTACHMENT_DOCUMENT_LABEL}.`;
 }
 
 /**
  * Validate file before upload
  */
 export function validateFile(file: File): { isValid: boolean; error?: string } {
-  const fileType = getFileTypeFromMime(file.type);
+  const mimeType = file.type.trim().toLowerCase();
+  if (!isAllowedAttachmentMimeType(mimeType)) {
+    return {
+      isValid: false,
+      error: buildUnsupportedAttachmentMessage(mimeType),
+    };
+  }
+
+  const fileType = getFileTypeFromMime(mimeType);
   const maxSize = FILE_SIZE_LIMITS[fileType];
-  
-  // Check file size
+
   if (file.size > maxSize) {
     const maxMB = maxSize / (1024 * 1024);
     return {
@@ -58,22 +77,33 @@ export function validateFile(file: File): { isValid: boolean; error?: string } {
       error: `File too large. Maximum size for ${fileType} is ${maxMB} MB`,
     };
   }
-  
-  // Check MIME type
-  const allowedTypes = [
-    ...ALLOWED_MIME_TYPES.image,
-    ...ALLOWED_MIME_TYPES.video,
-    ...ALLOWED_MIME_TYPES.document,
-  ];
-  
-  if (!allowedTypes.includes(file.type)) {
-    return {
-      isValid: false,
-      error: `File type "${file.type}" is not allowed`,
-    };
-  }
-  
+
   return { isValid: true };
+}
+
+export function getAttachmentUploadErrorMessage(error: unknown, fallbackMimeType?: string): string {
+  const responseData = (error as { response?: { data?: Record<string, unknown> } })?.response?.data;
+  const mimeType = typeof responseData?.mime_type === 'string'
+    ? responseData.mime_type
+    : fallbackMimeType;
+
+  if (responseData?.code === 'unsupported_mime_type' && mimeType) {
+    return buildUnsupportedAttachmentMessage(mimeType);
+  }
+
+  if (typeof responseData?.error === 'string' && responseData.error.trim()) {
+    return responseData.error;
+  }
+
+  if ((error as Error)?.message) {
+    return (error as Error).message;
+  }
+
+  if (mimeType) {
+    return buildUnsupportedAttachmentMessage(mimeType);
+  }
+
+  return 'Failed to upload attachment';
 }
 
 /**
@@ -83,6 +113,11 @@ export async function uploadAttachment(
   file: File,
   onProgress?: (progress: number) => void
 ): Promise<MessageAttachment> {
+  const validation = validateFile(file);
+  if (!validation.isValid) {
+    throw new Error(validation.error || 'Unsupported file type');
+  }
+
   const formData = new FormData();
   formData.append('file', file);
   
@@ -165,7 +200,7 @@ export function getFileIconType(mimeType: string): FileIconType {
   return 'file';
 }
 
-export default {
+const attachmentApi = {
   uploadAttachment,
   getAttachment,
   deleteAttachment,
@@ -175,3 +210,5 @@ export default {
   formatFileSize,
   getFileIconType,
 };
+
+export default attachmentApi;


### PR DESCRIPTION
## Summary

- Add a centralized MIME allowlist for chat attachment uploads.
- Reject unsupported MIME types before storage with HTTP 415 and structured errors.
- Add frontend validation and inline rejection UX in the chat attachment picker.
- Add backend and Playwright coverage for unsupported upload + retry flow.

## Test plan
- Backend:
  - test_services.py
  - test_views.py
- Frontend:
  - Playwright: attachment picker rejects unsupported MIME inline and retry with valid file succeeds
 
## Docs

Linear: https://linear.app/mediajira/issue/MED-233/chat-reject-unsupported-mime-types-on-attachment-upload

Ticket: MED-233