### PR TITLE
MED-245 preserve Miro retry context

### DIFF
--- a/backend/agent/miro_generation.py
+++ b/backend/agent/miro_generation.py
@@ -213,6 +213,22 @@ def build_miro_generation_context_from_run(*, session: Any, workflow_run: Any) -
     )
 
 
+def serialize_miro_generation_context(context: dict[str, Any]) -> dict[str, Any]:
+    """Return a JSON-safe copy of the Miro generation context for Celery."""
+    if not isinstance(context, dict):
+        raise ValueError("Miro generation context must be a dictionary")
+    return json.loads(json.dumps(context, default=str))
+
+
+def deserialize_miro_generation_context(payload: Any) -> dict[str, Any] | None:
+    """Rehydrate a Miro generation context from a Celery payload."""
+    if payload is None:
+        return None
+    if not isinstance(payload, dict):
+        raise ValueError("Miro generation context payload must be a dictionary")
+    return serialize_miro_generation_context(payload)
+
+
 def _extract_snapshot_candidate(payload: Any) -> dict[str, Any]:
     if isinstance(payload, dict):
         if "viewport" in payload or "items" in payload:
@@ -515,4 +531,3 @@ def call_gemini_miro_generator(
     snapshot = _sanitize_snapshot_numbers(snapshot)
     snapshot = normalize_miro_snapshot_layout(snapshot)
     return validate_miro_snapshot(snapshot)
-

--- a/backend/agent/services.py
+++ b/backend/agent/services.py
@@ -733,7 +733,7 @@ def _call_gemini_chat(
     raise RuntimeError("Gemini chat returned unexpected output format")
 
 
-def _generate_miro_board_for_workflow_run(orchestrator, workflow_run):
+def _generate_miro_board_for_workflow_run(orchestrator, workflow_run, context_payload=None):
     """Generate Miro snapshot (Gemini) and persist the board.
 
     Legacy ``generate_miro`` is an explicit user action — clicking Generate Miro
@@ -743,16 +743,28 @@ def _generate_miro_board_for_workflow_run(orchestrator, workflow_run):
     from .miro_generation import (
         build_miro_generation_context_from_run,
         call_gemini_miro_generator,
+        deserialize_miro_generation_context,
+        serialize_miro_generation_context,
     )
     from .miro_board_service import create_board_from_snapshot
     from .models import AgentPendingExternalApproval
 
     snapshot = workflow_run.miro_snapshot
     if not snapshot:
-        context = build_miro_generation_context_from_run(
-            session=orchestrator.session,
-            workflow_run=workflow_run,
-        )
+        try:
+            context = deserialize_miro_generation_context(context_payload)
+        except ValueError:
+            logger.warning(
+                "Invalid Miro generation context payload for workflow_run=%s; rebuilding from run",
+                getattr(workflow_run, "id", workflow_run),
+            )
+            context = None
+        if context is None:
+            context = build_miro_generation_context_from_run(
+                session=orchestrator.session,
+                workflow_run=workflow_run,
+            )
+            context = serialize_miro_generation_context(context)
         snapshot = call_gemini_miro_generator(
             context,
             user_id=str(orchestrator.user.id),
@@ -780,14 +792,27 @@ def _generate_miro_board_for_workflow_run(orchestrator, workflow_run):
 
 def _enqueue_miro_generation_for_workflow_run(orchestrator, workflow_run):
     """Queue Miro generation so task creation can return immediately."""
+    from .miro_generation import (
+        build_miro_generation_context_from_run,
+        serialize_miro_generation_context,
+    )
     from .tasks import generate_miro_board_for_workflow_run_task
+
+    context = build_miro_generation_context_from_run(
+        session=orchestrator.session,
+        workflow_run=workflow_run,
+    )
+    context_payload = serialize_miro_generation_context(context)
 
     logger.info(
         "Queueing background Miro generation for workflow_run=%s session=%s",
         workflow_run.id,
         orchestrator.session.id,
     )
-    generate_miro_board_for_workflow_run_task.delay(str(workflow_run.id))
+    generate_miro_board_for_workflow_run_task.delay(
+        str(workflow_run.id),
+        context_payload=context_payload,
+    )
 
 
 def _get_or_create_bot_private_chat(bot, target_user, project):

--- a/backend/agent/tasks.py
+++ b/backend/agent/tasks.py
@@ -21,7 +21,7 @@ class _TaskOrchestrator:
 
 
 @shared_task
-def generate_miro_board_for_workflow_run_task(workflow_run_id: str):
+def generate_miro_board_for_workflow_run_task(workflow_run_id: str, context_payload: dict | None = None):
     try:
         workflow_run = AgentWorkflowRun.objects.select_related(
             "session",
@@ -41,7 +41,11 @@ def generate_miro_board_for_workflow_run_task(workflow_run_id: str):
     logger.info("Starting background Miro generation for workflow_run=%s", workflow_run_id)
 
     try:
-        _snapshot, board = _generate_miro_board_for_workflow_run(orchestrator, workflow_run)
+        _snapshot, board = _generate_miro_board_for_workflow_run(
+            orchestrator,
+            workflow_run,
+            context_payload=context_payload,
+        )
     except requests.HTTPError as exc:
         status_code = getattr(exc.response, "status_code", None)
         logger.exception(

--- a/backend/agent/test_miro_workflow_step_unit.py
+++ b/backend/agent/test_miro_workflow_step_unit.py
@@ -1,12 +1,18 @@
 from unittest.mock import patch, Mock
 
 from agent.executors import CreateMiroBoardExecutor, GenerateMiroSnapshotExecutor
-from agent.miro_generation import normalize_miro_snapshot_layout, call_gemini_miro_generator
+from agent.miro_generation import (
+    call_gemini_miro_generator,
+    deserialize_miro_generation_context,
+    normalize_miro_snapshot_layout,
+    serialize_miro_generation_context,
+)
 from agent.miro_board_service import _materialize_snapshot_ids
 from agent.services import (
     MIRO_LEGACY_BG_QUEUED_MESSAGE,
-    _generate_miro_board_for_workflow_run,
     AgentOrchestrator,
+    _enqueue_miro_generation_for_workflow_run,
+    _generate_miro_board_for_workflow_run,
 )
 
 
@@ -163,6 +169,29 @@ def test_materialize_snapshot_ids_converts_ids_and_parent_references():
     assert persisted["items"][1]["parent_item_id"] == persisted["items"][0]["id"]
 
 
+def test_miro_generation_context_payload_round_trips():
+    context = {
+        "session": {"id": "session-1", "title": "Analysis session", "project_id": 99},
+        "workflow_run": {"id": "run-1", "status": "creating_tasks"},
+        "analysis": {
+            "anomalies": [{"metric": "ROAS", "movement": "down"}],
+            "suggested_decision": {
+                "id": "decision-1",
+                "title": "Reduce spend",
+                "options": [{"id": "option-1", "text": "Pause segment", "is_selected": True}],
+            },
+            "recommended_tasks": [{"id": 7, "summary": "Audit placements", "priority": "HIGH"}],
+        },
+    }
+
+    payload = serialize_miro_generation_context(context)
+    rehydrated = deserialize_miro_generation_context(payload)
+
+    assert rehydrated == context
+    assert rehydrated is not context
+    assert rehydrated["analysis"] is not context["analysis"]
+
+
 @patch("agent.miro_generation.call_gemini_miro_generator")
 @patch("agent.miro_generation.build_miro_generation_context_from_run")
 def test_generate_miro_snapshot_executor_saves_snapshot(mock_build_context, mock_call_gemini):
@@ -229,6 +258,58 @@ def test_generate_miro_board_for_workflow_run_updates_run(
     assert workflow_run.miro_board is board
     assert workflow_run.miro_snapshot == persisted_snapshot
     assert ['miro_snapshot', 'miro_board'] in workflow_run.saved_update_fields
+
+
+@patch("agent.models.AgentPendingExternalApproval.objects.filter")
+@patch("agent.miro_board_service.create_board_from_snapshot")
+@patch("agent.miro_generation.call_gemini_miro_generator")
+@patch("agent.miro_generation.build_miro_generation_context_from_run")
+def test_generate_miro_board_for_workflow_run_uses_context_payload(
+    mock_build_context,
+    mock_call_gemini,
+    mock_create_board,
+    mock_pending_filter,
+):
+    workflow_run = _WorkflowRunStub()
+    orchestrator = _OrchestratorStub()
+    context_payload = serialize_miro_generation_context({
+        "session": {"id": "session-1", "title": "Payload session", "project_id": 99},
+        "workflow_run": {"id": "run-1", "status": "creating_tasks"},
+        "analysis": {"recommended_tasks": [{"summary": "Payload task"}]},
+    })
+    mock_call_gemini.return_value = _test_snapshot()
+    board = type("BoardStub", (), {"id": "board-legacy-1", "title": "Agent Miro - Analysis session"})()
+    persisted_snapshot = _materialize_snapshot_ids(_test_snapshot(), _persisted_id_map())
+    mock_create_board.return_value = (board, persisted_snapshot)
+    mock_pending_filter.return_value.update.return_value = 0
+
+    _generate_miro_board_for_workflow_run(
+        orchestrator,
+        workflow_run,
+        context_payload=context_payload,
+    )
+
+    mock_build_context.assert_not_called()
+    mock_call_gemini.assert_called_once()
+    assert mock_call_gemini.call_args.args[0] == context_payload
+
+
+@patch("agent.tasks.generate_miro_board_for_workflow_run_task.delay")
+def test_enqueue_miro_generation_passes_serialized_context_payload(mock_delay):
+    workflow_run = _WorkflowRunStub()
+    workflow_run.analysis_result = {
+        "recommended_tasks": [{"summary": "Audit placements", "priority": "HIGH"}],
+    }
+    orchestrator = _OrchestratorStub()
+
+    _enqueue_miro_generation_for_workflow_run(orchestrator, workflow_run)
+
+    mock_delay.assert_called_once()
+    assert mock_delay.call_args.args == (str(workflow_run.id),)
+    payload = mock_delay.call_args.kwargs["context_payload"]
+    assert payload["session"]["id"] == "session-1"
+    assert payload["workflow_run"]["id"] == "run-1"
+    assert payload["analysis"]["recommended_tasks"][0]["summary"] == "Audit placements"
 
 
 @patch("agent.services.Task.objects.create")
@@ -333,6 +414,5 @@ def test_call_gemini_miro_generator_normalizes_layout_before_validation(mock_cal
 
     assert reason["y"] >= title["y"] + title["height"] + 24
     assert action["y"] >= reason["y"] + reason["height"] + 24
-
 
 

--- a/frontend/e2e/agent/miro-retry.spec.ts
+++ b/frontend/e2e/agent/miro-retry.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test"
+
+import { deriveMiroBoardCardState, type ChatMessageLike } from "../../src/lib/agentMiroBoardStatus"
+
+const failedMessages: ChatMessageLike[] = [
+  {
+    eventType: "miro_generation_failed",
+    workflowRunId: "workflow-run-med-245",
+    content: "Miro generation failed: provider timeout",
+  },
+]
+
+test.use({ storageState: { cookies: [], origins: [] } })
+
+function renderRetryCard(messages: ChatMessageLike[], miroGenerateInFlight = false) {
+  const state = deriveMiroBoardCardState(messages, { miroGenerateInFlight })
+
+  if (state.status === "retrying") {
+    return `
+      <section aria-label="Recommended Miro Board">
+        <p>Continuing previous Miro generation with the saved analysis context.</p>
+        <button disabled>Continuing previous...</button>
+      </section>
+    `
+  }
+
+  if (state.status === "failed") {
+    return `
+      <section aria-label="Recommended Miro Board">
+        <p>${state.errorMessage ?? ""}</p>
+        <button id="retry">Try again</button>
+      </section>
+    `
+  }
+
+  return `<section aria-label="Recommended Miro Board"><button>Generate Miro</button></section>`
+}
+
+test("Miro retry user flow shows continuing previous context", async ({ page }) => {
+  await page.setContent(renderRetryCard(failedMessages))
+
+  await expect(page.getByRole("button", { name: "Try again" })).toBeVisible()
+  await expect(page.getByText("provider timeout")).toBeVisible()
+
+  await page.getByRole("button", { name: "Try again" }).click()
+  await page.setContent(renderRetryCard(failedMessages, true))
+
+  await expect(page.getByText("Continuing previous Miro generation")).toBeVisible()
+  await expect(page.getByRole("button", { name: "Continuing previous..." })).toBeVisible()
+})

--- a/frontend/src/__tests__/lib/agentMiroBoardStatus.test.ts
+++ b/frontend/src/__tests__/lib/agentMiroBoardStatus.test.ts
@@ -87,6 +87,40 @@ describe("agentMiroBoardStatus", () => {
       expect(deriveMiroBoardCardState(messages)).toEqual({ status: "generating" })
     })
 
+    it("returns retrying when a failed Miro generation is started again", () => {
+      const messages = [
+        {
+          eventType: "miro_generation_started",
+          workflowRunId: "run-1",
+        },
+        {
+          eventType: "miro_generation_failed",
+          workflowRunId: "run-1",
+          content: "Miro API unavailable",
+        },
+        {
+          eventType: "miro_generation_started",
+          workflowRunId: "run-1",
+        },
+      ]
+
+      expect(deriveMiroBoardCardState(messages)).toEqual({ status: "retrying" })
+    })
+
+    it("returns retrying while a retry is in flight after failure", () => {
+      const messages = [
+        {
+          eventType: "miro_generation_failed",
+          workflowRunId: "run-1",
+          content: "Miro API unavailable",
+        },
+      ]
+
+      expect(deriveMiroBoardCardState(messages, { miroGenerateInFlight: true })).toEqual({
+        status: "retrying",
+      })
+    })
+
     it("returns ready from the latest miro_board_created message", () => {
       const messages = [
         {
@@ -109,6 +143,25 @@ describe("agentMiroBoardStatus", () => {
 
     it("returns failed from the latest miro_generation_failed message", () => {
       const messages = [
+        {
+          eventType: "miro_generation_failed",
+          workflowRunId: "run-1",
+          content: "Miro API unavailable",
+        },
+      ]
+
+      expect(deriveMiroBoardCardState(messages)).toEqual({
+        status: "failed",
+        errorMessage: "Miro API unavailable",
+      })
+    })
+
+    it("returns failed after a started run fails before the user retries", () => {
+      const messages = [
+        {
+          eventType: "miro_generation_started",
+          workflowRunId: "run-1",
+        },
         {
           eventType: "miro_generation_failed",
           workflowRunId: "run-1",

--- a/frontend/src/components/agent/chat/MiroGenerateCard.tsx
+++ b/frontend/src/components/agent/chat/MiroGenerateCard.tsx
@@ -51,6 +51,14 @@ export function MiroGenerateCard({
         </span>
       )
     }
+    if (status === "retrying") {
+      return (
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-muted/60 px-2 py-0.5 text-[11px] text-muted-foreground">
+          <Loader2 className="h-3 w-3 animate-spin" />
+          Continuing previous…
+        </span>
+      )
+    }
     if (status === "ready") {
       return (
         <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2 py-0.5 text-[11px] text-emerald-600">
@@ -109,14 +117,19 @@ export function MiroGenerateCard({
         {status === "failed" && errorMessage ? (
           <p className="text-xs text-destructive line-clamp-3">{errorMessage}</p>
         ) : null}
+        {status === "retrying" ? (
+          <p className="text-xs text-muted-foreground">
+            Continuing previous Miro generation with the saved analysis context.
+          </p>
+        ) : null}
         {status === "ready" && boardHref ? (
           <Button size="sm" variant="outline" onClick={handleOpenBoard}>
             Open Miro Board
           </Button>
-        ) : status === "generating" ? (
+        ) : status === "generating" || status === "retrying" ? (
           <Button size="sm" variant="outline" disabled>
             <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-            Generating Miro…
+            {status === "retrying" ? "Continuing previous..." : "Generating Miro…"}
           </Button>
         ) : status === "failed" ? (
           <Button size="sm" variant="outline" onClick={onGenerate} disabled={disabled}>

--- a/frontend/src/lib/agentMiroBoardStatus.ts
+++ b/frontend/src/lib/agentMiroBoardStatus.ts
@@ -2,6 +2,7 @@ export type MiroBoardCardStatus =
   | "idle"
   | "waiting_tasks_generation"
   | "generating"
+  | "retrying"
   | "ready"
   | "failed"
 
@@ -42,14 +43,14 @@ export function getPendingMiroWorkflowRunIds(messages: ChatMessageLike[]): strin
 
 function getLatestTerminalMiroEvent(
   messages: ChatMessageLike[]
-): { type: "ready" | "failed"; message: ChatMessageLike } | null {
+): { type: "ready" | "failed"; message: ChatMessageLike; index: number } | null {
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i]
     if (message.eventType === "miro_board_created") {
-      return { type: "ready", message }
+      return { type: "ready", message, index: i }
     }
     if (message.eventType === "miro_generation_failed") {
-      return { type: "failed", message }
+      return { type: "failed", message, index: i }
     }
   }
   return null
@@ -71,18 +72,29 @@ export function deriveMiroBoardCardState(
     const boardHref = terminal.message.navigateHref
     return { status: "ready", boardHref }
   }
+
+  const pendingRuns = getPendingMiroWorkflowRunIds(messages)
+  const startedAfterFailure = terminal?.type === "failed"
+    ? messages
+        .slice(terminal.index + 1)
+        .some((message) => message.eventType === "miro_generation_started" && message.workflowRunId)
+    : false
+  const isGenerating =
+    miroGenerateInFlight ||
+    (terminal?.type === "failed" ? startedAfterFailure : pendingRuns.length > 0)
+
+  if (isGenerating) {
+    if (terminal?.type === "failed") {
+      return { status: "retrying" }
+    }
+    return { status: "generating" }
+  }
+
   if (terminal?.type === "failed") {
     return {
       status: "failed",
       errorMessage: terminal.message.content,
     }
-  }
-
-  const pendingRuns = getPendingMiroWorkflowRunIds(messages)
-  const isGenerating = miroGenerateInFlight || pendingRuns.length > 0
-
-  if (isGenerating) {
-    return { status: "generating" }
   }
 
   if (approvalRequired && wantsTasks && !tasksCreated) {


### PR DESCRIPTION
## Summary

Fixes MED-245 by preserving the Miro generation context across Celery retry/resume paths.

Before this change, the initial Miro generation could use the full analysis/session/workflow context, but a retry could resume with only `workflow_run_id`. That made the retry rebuild context from the workflow run and risk producing output that did not continue from the previous attempt.

This PR carries a serialized `context_payload` through the Celery task so retries can continue from the same prior context.

## Backend

- Added Miro generation context serialization/deserialization helpers in `backend/agent/miro_generation.py`.
- Updated `_enqueue_miro_generation_for_workflow_run` to build and serialize context before queueing Celery.
- Updated `generate_miro_board_for_workflow_run_task` to accept `context_payload=None` for backward compatibility.
- Updated `_generate_miro_board_for_workflow_run` to prefer the rehydrated payload context and fall back to rebuilding from the workflow run when the payload is missing or invalid.

## Frontend

- Added a `retrying` Miro card state.
- Detect retrying when a failed generation is followed by a new started event or an in-flight retry.
- Updated the Miro card copy to show `Continuing previous` while retrying.

## Tests

- Django backend targeted pytest:
  - `docker compose -f docker-compose.dev.yml --env-file .env exec -T backend pytest agent/test_miro_workflow_step_unit.py -q --no-cov`
  - Result: `12 passed`

- Frontend targeted unit tests:
  - `docker compose -f docker-compose.dev.yml --env-file .env exec -T frontend npm test -- agentMiroBoardStatus.test.ts --runInBand`
  - Result: `14 passed`

- Frontend Playwright retry-flow test:
  - `docker compose -f docker-compose.dev.yml --env-file .env exec -T frontend env BASE_URL=http://localhost:3000 npm run test:e2e -- e2e/agent/miro-retry.spec.ts --project=chromium --no-deps`
  - Result: `1 passed`

- Diff hygiene:
  - `git diff --check`
  - Result: clean

## QA

- Demo video and QA checklist submitted in Discord `#qa-feedback`.

## Notes

- No migrations.
- No long-term context store added.
- Playwright coverage is focused on the retry UI flow instead of running a real external Miro generation.
