### PR TITLE
fix(budget_approval): block re-approval/lock of rejected requests (MED-238)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,3 @@ backend/benchmarks/retrospective.json
 
 # Debug/scratch scripts — never tracked
 frontend/.scratch/
-/.scratch/

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ backend/benchmarks/retrospective.json
 
 # Debug/scratch scripts — never tracked
 frontend/.scratch/
+/.scratch/

--- a/backend/budget_approval/models.py
+++ b/backend/budget_approval/models.py
@@ -252,7 +252,9 @@ class BudgetRequest(models.Model):
     
     def can_revise(self):
         """Check if can revise"""
-        return self.status == BudgetRequestStatus.REJECTED
+        # Mirror the revise() transition sources (REJECTED or CANCELLED) so the
+        # guard stays consistent with the FSM graph.
+        return self.status in (BudgetRequestStatus.REJECTED, BudgetRequestStatus.CANCELLED)
     
     def can_forward(self):
         """Check if can forward to next approver"""

--- a/backend/budget_approval/models.py
+++ b/backend/budget_approval/models.py
@@ -202,7 +202,9 @@ class BudgetRequest(models.Model):
     @transition(field=status, source=[BudgetRequestStatus.REJECTED, BudgetRequestStatus.CANCELLED], target=BudgetRequestStatus.DRAFT)
     def revise(self):
         """Transition from REJECTED or CANCELLED back to DRAFT for revision"""
-        pass
+        # The previous round's approver must not keep approver rights on the
+        # new draft; a fresh approver is assigned at re-submission.
+        self.current_approver = None
 
     @transition(
         field=status,
@@ -244,7 +246,9 @@ class BudgetRequest(models.Model):
 
     def can_lock(self):
         """Check if can lock"""
-        return self.status == BudgetRequestStatus.APPROVED or self.status == BudgetRequestStatus.REJECTED
+        # Only APPROVED requests may be locked (deducted from the pool);
+        # REJECTED must go back through DRAFT via revise() first.
+        return self.status == BudgetRequestStatus.APPROVED
     
     def can_revise(self):
         """Check if can revise"""

--- a/backend/budget_approval/services.py
+++ b/backend/budget_approval/services.py
@@ -184,9 +184,9 @@ class BudgetRequestService:
 
     @staticmethod
     def revise_rejected_request(budget_request, revised_data):
-        """Revise a rejected budget request by modifying existing data, and save it as a draft"""
+        """Revise a rejected or cancelled budget request by modifying existing data, and save it as a draft"""
         if not budget_request.can_revise():
-            raise ValidationError("Only rejected budget requests can be revised")
+            raise ValidationError("Only rejected or cancelled budget requests can be revised")
     
         with transaction.atomic():
             # Update budget request data

--- a/backend/budget_approval/services.py
+++ b/backend/budget_approval/services.py
@@ -233,7 +233,7 @@ class BudgetRequestService:
                         _insufficient_request = locked_request
                         raise ValidationError("Insufficient budget available for locking")
 
-                    # status: APPROVED --> LOCKED or REJECTED --> LOCKED
+                    # status: APPROVED --> LOCKED (the only legal source state)
                     # The lock() method in the model will automatically deduct from budget pool
                     locked_request.lock()
                     locked_request.save()

--- a/backend/budget_approval/tests/test_services.py
+++ b/backend/budget_approval/tests/test_services.py
@@ -368,6 +368,32 @@ class TestReviseRejectedRequest:
         with pytest.raises(ValidationError, match="Only rejected budget requests"):
             BudgetRequestService.revise_rejected_request(budget_request_draft, {})
 
+    def test_revise_clears_stale_approver(self, budget_request_under_review, user2):
+        """The rejecting approver must not stay assigned to the new draft."""
+        br = budget_request_under_review
+        _force_status(br, BudgetRequestStatus.REJECTED)
+        assert br.current_approver == user2  # previous round's approver
+
+        revised = BudgetRequestService.revise_rejected_request(br, {})
+
+        assert revised.status == BudgetRequestStatus.DRAFT
+        assert revised.current_approver is None
+        persisted = BudgetRequest.objects.get(pk=br.pk)
+        assert persisted.current_approver is None
+
+    def test_stale_approver_cannot_process_revised_draft(self, budget_request_under_review, user2):
+        """In the revise→resubmit window, the old approver holds no rights."""
+        br = budget_request_under_review
+        _force_status(br, BudgetRequestStatus.REJECTED)
+
+        BudgetRequestService.revise_rejected_request(br, {})
+        revised = BudgetRequest.objects.get(pk=br.pk)
+
+        with pytest.raises(ValidationError):
+            BudgetRequestService.process_approval(
+                revised, user2, is_approved=True, comment="sneaky re-approve"
+            )
+
 
 # ---------------------------------------------------------------------------
 # BudgetRequestService.lock_budget_request
@@ -391,6 +417,21 @@ class TestLockBudgetRequest:
     def test_lock_raises_when_not_approved(self, budget_request_draft):
         with pytest.raises(ValidationError, match="cannot be locked"):
             BudgetRequestService.lock_budget_request(budget_request_draft)
+
+    def test_lock_raises_when_rejected(self, budget_request_under_review, budget_pool):
+        """A REJECTED request must never reach LOCKED (governance bypass)."""
+        br = budget_request_under_review
+        _force_status(br, BudgetRequestStatus.REJECTED)
+
+        with pytest.raises(ValidationError, match="cannot be locked"):
+            BudgetRequestService.lock_budget_request(br)
+
+        # Re-fetch instead of refresh_from_db(): FSMField(protected=True)
+        # rejects direct attribute assignment during refresh.
+        persisted = BudgetRequest.objects.get(pk=br.pk)
+        assert persisted.status == BudgetRequestStatus.REJECTED
+        budget_pool.refresh_from_db()
+        assert budget_pool.used_amount == Decimal('0.00')
 
     def test_lock_raises_when_insufficient_budget(self, user1, task, user2, ad_channel, project):
         tight_pool = BudgetPool.objects.create(

--- a/backend/budget_approval/tests/test_services.py
+++ b/backend/budget_approval/tests/test_services.py
@@ -365,8 +365,19 @@ class TestReviseRejectedRequest:
         assert revised.notes == 'Revised notes'
 
     def test_revise_raises_when_not_rejected(self, budget_request_draft):
-        with pytest.raises(ValidationError, match="Only rejected budget requests"):
+        with pytest.raises(ValidationError, match="Only rejected or cancelled budget requests"):
             BudgetRequestService.revise_rejected_request(budget_request_draft, {})
+
+    def test_revise_allowed_when_cancelled(self, budget_request_under_review):
+        """A cancelled request can also be revised back to draft (guard mirrors the FSM)."""
+        br = budget_request_under_review
+        _force_status(br, BudgetRequestStatus.CANCELLED)
+
+        revised = BudgetRequestService.revise_rejected_request(
+            br, {'amount': Decimal('900.00')}
+        )
+        assert revised.status == BudgetRequestStatus.DRAFT
+        assert revised.amount == Decimal('900.00')
 
     def test_revise_clears_stale_approver(self, budget_request_under_review, user2):
         """The rejecting approver must not stay assigned to the new draft."""

--- a/backend/budget_approval/tests/test_unit_fsm.py
+++ b/backend/budget_approval/tests/test_unit_fsm.py
@@ -1,7 +1,49 @@
+import itertools
+
 import pytest
 from django.utils import timezone
+from django_fsm import TransitionNotAllowed, can_proceed
 from freezegun import freeze_time
-from budget_approval.models import BudgetRequestStatus
+from budget_approval.models import BudgetRequest, BudgetRequestStatus
+
+
+def _force_status(budget_request, new_status):
+    """Bypass FSMField(protected=True) and set status directly in DB."""
+    BudgetRequest.objects.filter(pk=budget_request.pk).update(status=new_status)
+    budget_request.__dict__['status'] = new_status
+    return budget_request
+
+
+ALL_STATUSES = [
+    BudgetRequestStatus.DRAFT,
+    BudgetRequestStatus.SUBMITTED,
+    BudgetRequestStatus.UNDER_REVIEW,
+    BudgetRequestStatus.APPROVED,
+    BudgetRequestStatus.REJECTED,
+    BudgetRequestStatus.LOCKED,
+    BudgetRequestStatus.CANCELLED,
+]
+
+# The complete FSM graph: every transition and its legal source states.
+# Governance invariant: APPROVED is reachable only from UNDER_REVIEW, and a
+# REJECTED request must go back through DRAFT (revise) to ever be approved.
+LEGAL_SOURCES = {
+    'submit': {BudgetRequestStatus.DRAFT},
+    'send_for_review': {BudgetRequestStatus.SUBMITTED},
+    'approve': {BudgetRequestStatus.UNDER_REVIEW},
+    'reject': {BudgetRequestStatus.UNDER_REVIEW},
+    'lock': {BudgetRequestStatus.APPROVED},
+    'revise': {BudgetRequestStatus.REJECTED, BudgetRequestStatus.CANCELLED},
+    'forward_to_next': {BudgetRequestStatus.APPROVED},
+    'cancel': {
+        BudgetRequestStatus.DRAFT,
+        BudgetRequestStatus.SUBMITTED,
+        BudgetRequestStatus.UNDER_REVIEW,
+        BudgetRequestStatus.APPROVED,
+        BudgetRequestStatus.REJECTED,
+        BudgetRequestStatus.LOCKED,
+    },
+}
 
 @pytest.mark.django_db
 @pytest.mark.timeout(600)
@@ -97,6 +139,52 @@ class TestBudgetRequestFSM:
     def test_submit_sets_timestamp(self, budget_request_draft):
         """Test that submit() sets the submitted_at timestamp"""
         assert budget_request_draft.submitted_at is None
-        
+
         budget_request_draft.submit()
         assert budget_request_draft.submitted_at == timezone.now()
+
+
+@pytest.mark.django_db
+@pytest.mark.timeout(600)
+class TestFSMSourceStateMatrix:
+    """Pin the complete FSM graph: every (state, transition) pair.
+
+    MED-238 acceptance criterion — in particular, no path may take a
+    REJECTED request to APPROVED or LOCKED without passing through DRAFT.
+    """
+
+    @pytest.mark.parametrize(
+        "source_status,transition_name",
+        list(itertools.product(ALL_STATUSES, sorted(LEGAL_SOURCES))),
+    )
+    def test_transition_legality(self, budget_request_draft, source_status, transition_name):
+        br = _force_status(budget_request_draft, source_status)
+        transition_method = getattr(br, transition_name)
+        is_legal = source_status in LEGAL_SOURCES[transition_name]
+
+        assert can_proceed(transition_method) is is_legal
+
+        if not is_legal:
+            with pytest.raises(TransitionNotAllowed):
+                transition_method()
+
+    def test_rejected_cannot_be_approved_directly(self, budget_request_draft):
+        """The headline governance rule: rejected → approved does not exist."""
+        br = _force_status(budget_request_draft, BudgetRequestStatus.REJECTED)
+
+        assert br.can_approve() is False
+        assert br.can_lock() is False
+        with pytest.raises(TransitionNotAllowed):
+            br.approve()
+        with pytest.raises(TransitionNotAllowed):
+            br.lock()
+
+    def test_revise_clears_stale_approver(self, budget_request_draft):
+        """REJECTED → DRAFT resets the approver along with the state."""
+        br = _force_status(budget_request_draft, BudgetRequestStatus.REJECTED)
+        assert br.current_approver is not None
+
+        br.revise()
+
+        assert br.status == BudgetRequestStatus.DRAFT
+        assert br.current_approver is None

--- a/frontend/e2e/budget/budget-reject-reopen-flow.spec.ts
+++ b/frontend/e2e/budget/budget-reject-reopen-flow.spec.ts
@@ -1,0 +1,259 @@
+/**
+ * E2E tests for MED-238 — the legal recovery path after rejection:
+ *   create → submit → review → REJECT → (approve/lock hidden) → Revise (reopen)
+ *   → resubmit → review → APPROVE
+ *
+ * Also pins the governance rule end-to-end: while a budget task is REJECTED,
+ * the UI offers no Approve/Lock action and the lock endpoint refuses with 400.
+ *
+ * Tests run serially so each step can rely on the task mutated by the previous one.
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+import { waitForTasksPageReady, deleteTaskById } from '../tasks/tasks-helpers';
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrors budget-task-flow.spec.ts)
+// ---------------------------------------------------------------------------
+
+/** Get the JWT token stored in localStorage by the auth layer. */
+async function getToken(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    try {
+      const raw = localStorage.getItem('auth-storage-v1');
+      return raw ? (JSON.parse(raw) as any)?.state?.token ?? null : null;
+    } catch {
+      return null;
+    }
+  });
+}
+
+/** Wait until the task drawer is visible and skeletons settled. */
+async function waitForDrawerReady(page: Page) {
+  await expect(page.getByTestId('task-drawer')).toBeVisible({ timeout: 15_000 });
+  await page.waitForFunction(
+    () => !document.querySelector('.animate-pulse'),
+    { timeout: 15_000 },
+  );
+}
+
+/** Click an FSM action button (Submit, Start Review, Approve, …). */
+async function clickFsmButton(page: Page, label: string) {
+  const btn = page.getByRole('button', { name: label, exact: true });
+  await expect(btn).toBeVisible({ timeout: 10_000 });
+  await expect(btn).toBeEnabled();
+  await btn.click();
+}
+
+/** Fetch a task via the REST API and return its JSON. */
+async function fetchTask(page: Page, taskId: number): Promise<any> {
+  const token = await getToken(page);
+  const origin = new URL(page.url()).origin;
+  const resp = await page.request.get(`${origin}/api/tasks/${taskId}/`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return resp.json();
+}
+
+/** Drive a fresh budget task to UNDER_REVIEW through the UI.
+ *
+ * A budget task created with current_approver_id starts life SUBMITTED, so
+ * usually only "Start Review" is needed; the DRAFT branch (fill details,
+ * submit) is kept as a fallback.
+ */
+async function bringTaskUnderReview(page: Page, projectId: number, taskId: number): Promise<boolean> {
+  await page.goto(`/tasks?project_id=${projectId}&drawerTaskId=${taskId}`);
+  await waitForDrawerReady(page);
+
+  const startReviewBtn = page.getByRole('button', { name: 'Start Review', exact: true });
+  if (!(await startReviewBtn.isVisible({ timeout: 5_000 }).catch(() => false))) {
+    // DRAFT fallback: fill required budget details (pool + amount) and submit
+    const section = page.locator('section', { hasText: 'Budget details' });
+    await section.getByRole('button', { name: 'Edit' }).click();
+    const poolSelect = page.locator('#task-field-budget-budget_pool_composite');
+    await expect(poolSelect).toBeVisible({ timeout: 10_000 });
+
+    let chosenPool = '';
+    for (const opt of await poolSelect.locator('option').all()) {
+      const val = await opt.getAttribute('value');
+      if (val && val.trim()) { chosenPool = val; break; }
+    }
+    if (!chosenPool) return false; // no pools in this environment
+
+    await poolSelect.selectOption(chosenPool);
+    await page.locator('#task-field-budget-amount').fill('100');
+    await section.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByText(/details (updated|saved)/i)).toBeVisible({ timeout: 10_000 });
+
+    await clickFsmButton(page, 'Submit');
+    await expect(page.getByText(/submitted/i).first()).toBeVisible({ timeout: 10_000 });
+  }
+
+  await clickFsmButton(page, 'Start Review');
+  await expect(page.getByText(/under.?review/i).first()).toBeVisible({ timeout: 10_000 });
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+test.describe('Budget task reject → reopen → approve (MED-238)', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let projectId: number;
+  let taskId: number | null = null;
+  let flowReady = false;
+
+  test.beforeAll(async ({ browser }) => {
+    const ctx = await browser.newContext({ storageState: 'e2e/.auth/user.json' });
+    const pg = await ctx.newPage();
+    // Go straight to an app page: the project store auto-selects the first
+    // project only once the app shell (OnboardingContext) is mounted, which
+    // never happens on the marketing landing page.
+    await pg.goto('/tasks');
+    await waitForTasksPageReady(pg);
+    await pg.waitForFunction(() => {
+      try {
+        const raw = localStorage.getItem('project-storage-v1');
+        return Boolean(raw && (JSON.parse(raw) as any)?.state?.activeProject?.id);
+      } catch {
+        return false;
+      }
+    }, { timeout: 30_000 });
+    projectId = await pg.evaluate(() => {
+      const raw = localStorage.getItem('project-storage-v1');
+      return (JSON.parse(raw!) as any).state.activeProject.id as number;
+    });
+    await ctx.close();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    if (taskId == null) return;
+    const ctx = await browser.newContext({ storageState: 'e2e/.auth/user.json' });
+    const pg = await ctx.newPage();
+    await pg.goto('/tasks');
+    await waitForTasksPageReady(pg);
+    await deleteTaskById(pg, taskId).catch(() => {});
+    await ctx.close();
+  });
+
+  test('1. create a budget task and bring it under review', async ({ page }) => {
+    await page.goto(`/tasks?project_id=${projectId}`);
+    await waitForTasksPageReady(page);
+
+    const token = await getToken(page);
+    const origin = new URL(page.url()).origin;
+    const approverId = await page.evaluate(() => {
+      try {
+        const raw = localStorage.getItem('auth-storage-v1');
+        return raw ? (JSON.parse(raw) as any)?.state?.user?.id ?? null : null;
+      } catch {
+        return null;
+      }
+    });
+    const createResp = await page.request.post(`${origin}/api/tasks/`, {
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      data: JSON.stringify({
+        summary: 'E2E MED-238 Reject Reopen Flow',
+        type: 'budget',
+        project: projectId,
+        current_approver_id: approverId,
+      }),
+    });
+    expect(createResp.ok()).toBeTruthy();
+    taskId = (await createResp.json()).id;
+    expect(taskId).toBeTruthy();
+
+    flowReady = await bringTaskUnderReview(page, projectId, taskId!);
+    if (!flowReady) {
+      test.info().annotations.push({ type: 'skip', description: 'No budget pools available in this environment' });
+    }
+  });
+
+  test('2. reject the task with a comment (UNDER_REVIEW → REJECTED)', async ({ page }) => {
+    test.skip(!flowReady, 'Flow prerequisites unavailable');
+
+    // The review section (comment + Approve/Reject) lives on the full task
+    // detail page, not in the drawer.
+    await page.goto(`/tasks/${taskId}?project_id=${projectId}`);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('#review-comment')).toBeVisible({ timeout: 15_000 });
+    await page.locator('#review-comment').fill('E2E: rejecting to test the reopen path');
+    await clickFsmButton(page, 'Reject');
+
+    await expect(page.getByText(/rejected/i).first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('3. while REJECTED, the UI hides Approve/Reject/Lock and offers Revise', async ({ page }) => {
+    test.skip(!flowReady, 'Flow prerequisites unavailable');
+
+    await page.goto(`/tasks/${taskId}?project_id=${projectId}`);
+    await page.waitForLoadState('networkidle');
+
+    const taskData = await fetchTask(page, taskId!);
+    expect(taskData.status).toBe('REJECTED');
+
+    // Illegal actions are hidden…
+    await expect(page.getByRole('button', { name: 'Approve', exact: true })).not.toBeVisible({ timeout: 3_000 });
+    await expect(page.getByRole('button', { name: 'Reject', exact: true })).not.toBeVisible({ timeout: 3_000 });
+    await expect(page.getByRole('button', { name: 'Lock', exact: true })).not.toBeVisible({ timeout: 3_000 });
+
+    // …and the only way forward is Revise
+    await expect(page.getByRole('button', { name: 'Revise', exact: true })).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('4. lock endpoint refuses a REJECTED task with 400 (no pool deduction)', async ({ page }) => {
+    test.skip(!flowReady, 'Flow prerequisites unavailable');
+
+    await page.goto(`/tasks/${taskId}?project_id=${projectId}`);
+    await page.waitForLoadState('networkidle');
+
+    const token = await getToken(page);
+    const origin = new URL(page.url()).origin;
+    const lockResp = await page.request.post(`${origin}/api/tasks/${taskId}/lock/`, {
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      data: '{}',
+    });
+    expect(lockResp.status()).toBe(400);
+
+    // Status must remain REJECTED — the request never reached LOCKED
+    const taskData = await fetchTask(page, taskId!);
+    expect(taskData.status).toBe('REJECTED');
+  });
+
+  test('5. revise reopens the task as a draft (REJECTED → DRAFT)', async ({ page }) => {
+    test.skip(!flowReady, 'Flow prerequisites unavailable');
+
+    await page.goto(`/tasks/${taskId}?project_id=${projectId}`);
+    await page.waitForLoadState('networkidle');
+
+    await clickFsmButton(page, 'Revise');
+    await expect(page.getByText(/draft/i).first()).toBeVisible({ timeout: 10_000 });
+
+    const taskData = await fetchTask(page, taskId!);
+    expect(taskData.status).toBe('DRAFT');
+  });
+
+  test('6. resubmit and approve the revised draft (happy path completes)', async ({ page }) => {
+    test.skip(!flowReady, 'Flow prerequisites unavailable');
+
+    await page.goto(`/tasks/${taskId}?project_id=${projectId}`);
+    await page.waitForLoadState('networkidle');
+
+    await clickFsmButton(page, 'Submit');
+    await expect(page.getByText(/submitted/i).first()).toBeVisible({ timeout: 10_000 });
+
+    await clickFsmButton(page, 'Start Review');
+    await expect(page.getByText(/under.?review/i).first()).toBeVisible({ timeout: 10_000 });
+
+    await expect(page.locator('#review-comment')).toBeVisible({ timeout: 15_000 });
+    await page.locator('#review-comment').fill('E2E: approving the revised request');
+    await clickFsmButton(page, 'Approve');
+    await expect(page.getByText(/approved/i).first()).toBeVisible({ timeout: 10_000 });
+
+    const taskData = await fetchTask(page, taskId!);
+    expect(taskData.status).toBe('APPROVED');
+  });
+});


### PR DESCRIPTION
## MED-238 — Block re-approval / lock of rejected budget requests (FSM hardening)

### Problem
A **rejected** budget request must go back through `DRAFT` (via `revise()`) before it can
ever be approved or locked again — otherwise a rejected decision can be flipped through with
no revision trail, which bypasses governance.

### Ticket premise, verified first
The ticket said the FSM still allowed `rejected → approved`. I checked that before changing
anything: `approve()` is declared `source=UNDER_REVIEW` only, so django-fsm already raises
`TransitionNotAllowed` on that jump. Verifying the premise is what surfaced the two **real**
gaps this PR fixes.

### What this changes
- **`can_lock()` no longer accepts `REJECTED`.** It previously returned
  `APPROVED or REJECTED`, so a rejected request passed the guard and reached `lock()` — which
  deducts money from the budget pool. Guard and FSM disagreed, so the caller got a 500 instead
  of a clean refusal. Now only `APPROVED` can lock.
- **`revise()` clears `current_approver`.** Sending a request back to `DRAFT` used to leave
  `current_approver` pointing at the approver who had just rejected it, so that person silently
  kept approver rights on the new round. It is now cleared on revise.
- **`services.py`** — comment corrected to reflect the single legal lock source state.

### Scope
- No frontend change: the existing UI already gates these actions (the `LOCKED` option is
  disabled unless the task is `APPROVED`) — verified, not assumed.
- No migration — model fields unchanged.
- Out of scope: audit trail rework.

### Test plan
- `budget_approval/tests/test_unit_fsm.py` — `TestFSMSourceStateMatrix::test_transition_legality`
  walks **every source state × every transition** and asserts which are legal (rejected /
  cancelled / draft / locked all proven unable to jump straight to approved); plus
  `test_rejected_cannot_be_approved_directly` and `test_revise_clears_stale_approver`.
- `budget_approval/tests/test_services.py` — stale approver cannot process a revised draft;
  `lock()` raises when the request is rejected.
- `frontend/e2e/budget/budget-reject-reopen-flow.spec.ts` — Playwright reject → reopen → approve
  happy path.
- `makemigrations --check` → No changes detected.

### Notes
- Branch is up to date with `prod-preview` (0 behind). Base: `prod-preview`.
