### PR TITLE
fix(meta_ads): re-anchor insights sync window across UTC rollover (MED-246)

### DIFF
--- a/backend/meta_ads/management/commands/seed_med246_qa_mock_data.py
+++ b/backend/meta_ads/management/commands/seed_med246_qa_mock_data.py
@@ -1,0 +1,105 @@
+"""Seed schema-aligned Meta ads mock data for MED-246 QA.
+
+Usage (Docker):
+
+  docker compose -p mediajira-v2 -f docker-compose.dev.yml exec backend \\
+    python manage.py seed_med246_qa_mock_data
+
+  docker compose -p mediajira-v2 -f docker-compose.dev.yml exec backend \\
+    python manage.py seed_med246_qa_mock_data --reset --as-of 2026-07-31
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+
+from django.core.management.base import BaseCommand, CommandError
+
+from meta_ads.qa_mock_data import (
+    DEFAULT_QA_EMAIL,
+    DEFAULT_QA_PASSWORD,
+    DEFAULT_QA_USERNAME,
+    seed_med246_qa_mock_data,
+)
+
+
+class Command(BaseCommand):
+    help = (
+        "Seed MED-246 QA mock Meta ads rows (connection → account → campaign → "
+        "adset → creative → ad → insight_daily) aligned to current migrations."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--email",
+            default=DEFAULT_QA_EMAIL,
+            help=f"QA login email (default: {DEFAULT_QA_EMAIL})",
+        )
+        parser.add_argument(
+            "--username",
+            default=DEFAULT_QA_USERNAME,
+            help=f"QA username when creating the user (default: {DEFAULT_QA_USERNAME})",
+        )
+        parser.add_argument(
+            "--password",
+            default=DEFAULT_QA_PASSWORD,
+            help="Password set only when the QA user is created",
+        )
+        parser.add_argument(
+            "--as-of",
+            default=None,
+            help="Inclusive end date YYYY-MM-DD for the insight series (default: today UTC)",
+        )
+        parser.add_argument(
+            "--insight-days",
+            type=int,
+            default=5,
+            help="How many contiguous calendar days to seed ending on --as-of (min 2)",
+        )
+        parser.add_argument(
+            "--reset",
+            action="store_true",
+            help="Delete prior MED-246 seed ad-account/connection rows before seeding",
+        )
+
+    def handle(self, *args, **options):
+        as_of = options["as_of"]
+        as_of_date = None
+        if as_of:
+            try:
+                as_of_date = _dt.date.fromisoformat(as_of)
+            except ValueError as exc:
+                raise CommandError("--as-of must be YYYY-MM-DD") from exc
+
+        try:
+            summary = seed_med246_qa_mock_data(
+                email=options["email"],
+                username=options["username"],
+                password=options["password"],
+                as_of=as_of_date,
+                insight_days=options["insight_days"],
+                reset=options["reset"],
+            )
+        except ValueError as exc:
+            raise CommandError(str(exc)) from exc
+
+        self.stdout.write(self.style.SUCCESS("MED-246 QA mock data ready."))
+        self.stdout.write(f"  user_email:        {summary['user_email']}")
+        self.stdout.write(f"  user_id:           {summary['user_id']}")
+        self.stdout.write(f"  ad_account_id:     {summary['ad_account_id']}")
+        self.stdout.write(f"  ad_id:             {summary['ad_id']}")
+        self.stdout.write(f"  insight_dates:     {', '.join(summary['insight_dates'])}")
+        self.stdout.write(
+            f"  insights:          created={summary['insights_created']} "
+            f"updated={summary['insights_updated']}"
+        )
+        self.stdout.write(f"  last_synced_at:    {summary['last_synced_at']}")
+        self.stdout.write(f"  sync_run_id:       {summary['sync_run_id']}")
+        if summary.get("password_if_created"):
+            self.stdout.write(
+                self.style.WARNING(
+                    f"  new user password: {summary['password_if_created']}"
+                )
+            )
+        else:
+            self.stdout.write("  user already existed — password left unchanged")

--- a/backend/meta_ads/qa_mock_data.py
+++ b/backend/meta_ads/qa_mock_data.py
@@ -17,7 +17,7 @@ from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.utils import timezone
 
-from core.models import Organization, Project, ProjectMember
+from core.models import Organization, OrganizationMembership, Project, ProjectMember
 from facebook_integration.models import FacebookConnection, MetaAdAccount
 
 from .models import (
@@ -131,14 +131,30 @@ def seed_med246_qa_mock_data(
         defaults={
             "username": username,
             "organization": org,
+            "current_organization": org,
         },
     )
     if user_created:
         user.set_password(password)
         user.save(update_fields=["password"])
-    elif user.organization_id is None:
-        user.organization = org
-        user.save(update_fields=["organization"])
+    else:
+        user_updates: list[str] = []
+        if user.organization_id is None:
+            user.organization = org
+            user_updates.append("organization")
+        if getattr(user, "current_organization_id", None) is None:
+            user.current_organization = org
+            user_updates.append("current_organization")
+        if user_updates:
+            user.save(update_fields=user_updates)
+
+    # OnboardingGate keys off OrganizationMembership (not user.organization FK).
+    # Without this row the UI shows "Set up your first project" forever.
+    OrganizationMembership.objects.get_or_create(
+        user=user,
+        organization=org,
+        defaults={"role": "admin", "is_active": True},
+    )
 
     project, project_created = Project.objects.get_or_create(
         name=PROJECT_NAME,
@@ -150,6 +166,9 @@ def seed_med246_qa_mock_data(
         project=project,
         defaults={"role": "owner", "is_active": True},
     )
+    if getattr(user, "active_project_id", None) != project.id:
+        user.active_project = project
+        user.save(update_fields=["active_project"])
 
     connection, connection_created = FacebookConnection.objects.get_or_create(
         user=user,

--- a/backend/meta_ads/qa_mock_data.py
+++ b/backend/meta_ads/qa_mock_data.py
@@ -1,0 +1,308 @@
+"""Schema-aligned mock data for MED-246 QA (UTC rollover sync window).
+
+Builds the full Meta ads FK chain required by migrations/models, plus a
+contiguous `MetaInsightDaily` series that spans a UTC midnight boundary so QA
+can verify charts/tooltips without a live Ads API key.
+
+Stable Meta IDs make the seed idempotent (safe to re-run).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from decimal import Decimal
+from typing import Any
+
+from django.contrib.auth import get_user_model
+from django.db import transaction
+from django.utils import timezone
+
+from core.models import Organization, Project, ProjectMember
+from facebook_integration.models import FacebookConnection, MetaAdAccount
+
+from .models import (
+    MetaAd,
+    MetaAdCreative,
+    MetaAdSet,
+    MetaCampaign,
+    MetaInsightDaily,
+    MetaSyncRun,
+)
+
+# Stable identifiers — keep in sync with management command help text.
+SEED_MARKER = "med246"
+ORG_NAME = "MED-246 QA Org"
+ORG_SLUG = "med-246-qa-org"
+PROJECT_NAME = "MED-246 QA Project"
+DEFAULT_QA_EMAIL = "qa-med246@example.com"
+DEFAULT_QA_USERNAME = "qa_med246"
+DEFAULT_QA_PASSWORD = "qa-med246-pass"
+
+FB_USER_ID = f"{SEED_MARKER}-fb-user"
+META_ACCOUNT_ID = f"{SEED_MARKER}0001"
+META_CAMPAIGN_ID = f"{SEED_MARKER}-camp-1"
+META_ADSET_ID = f"{SEED_MARKER}-adset-1"
+META_CREATIVE_ID = f"{SEED_MARKER}-creative-1"
+META_AD_ID = f"{SEED_MARKER}-ad-1"
+
+
+def _insight_defaults_for_day(day_index: int, date: _dt.date) -> dict[str, Any]:
+    """Deterministic metric values that still look realistic in the UI."""
+    spend = Decimal("10.00") + Decimal(day_index) * Decimal("2.50")
+    impressions = 1000 + day_index * 150
+    clicks = 40 + day_index * 3
+    reach = max(impressions - 50, 1)
+    frequency = (Decimal(impressions) / Decimal(reach)).quantize(Decimal("0.0001"))
+    ctr = (Decimal(clicks) * Decimal("100") / Decimal(impressions)).quantize(
+        Decimal("0.0001")
+    )
+    cpc = (spend / Decimal(clicks)).quantize(Decimal("0.0001"))
+    cpm = (spend * Decimal("1000") / Decimal(impressions)).quantize(Decimal("0.0001"))
+    leads = 2 + (day_index % 3)
+    purchases = day_index % 2
+    revenue = Decimal(purchases) * Decimal("49.99")
+    return {
+        "spend": spend,
+        "impressions": impressions,
+        "reach": reach,
+        "clicks": clicks,
+        "frequency": frequency,
+        "ctr": ctr,
+        "cpc": cpc,
+        "cpm": cpm,
+        "leads": leads,
+        "calls": 0,
+        "purchases": purchases,
+        "messages": 1,
+        "lpv_count": 5 + day_index,
+        "video_3sec_count": 20 + day_index * 2,
+        "comment_count": day_index % 4,
+        "revenue": revenue,
+        "video_p25": 15 + day_index,
+        "video_p50": 10 + day_index,
+        "video_p75": 6 + day_index,
+        "video_p100": 3 + day_index,
+        "video_avg_watch_seconds": Decimal("12.50") + Decimal(day_index),
+        "raw": {
+            "seed": SEED_MARKER,
+            "ticket": "MED-246",
+            "date_start": date.isoformat(),
+            "note": "qa mock — not from Graph API",
+        },
+    }
+
+
+@transaction.atomic
+def seed_med246_qa_mock_data(
+    *,
+    email: str = DEFAULT_QA_EMAIL,
+    username: str = DEFAULT_QA_USERNAME,
+    password: str = DEFAULT_QA_PASSWORD,
+    as_of: _dt.date | None = None,
+    insight_days: int = 5,
+    reset: bool = False,
+) -> dict[str, Any]:
+    """Insert or refresh MED-246 QA rows. Returns a summary for CLI/tests.
+
+    `insight_days` counts calendar days ending on `as_of` (inclusive). Default
+    5 days gives QA a clear before/on/after UTC-rollover span without needing
+    a live sync.
+    """
+    if insight_days < 2:
+        raise ValueError("insight_days must be >= 2 so the series can span a day boundary")
+
+    as_of = as_of or timezone.now().date()
+    User = get_user_model()
+
+    if reset:
+        _reset_seed_rows()
+
+    org, org_created = Organization.objects.get_or_create(
+        slug=ORG_SLUG,
+        defaults={"name": ORG_NAME},
+    )
+    # Name is unique; keep slug as the stable key if an older row used another name.
+    if org.name != ORG_NAME and not Organization.objects.filter(name=ORG_NAME).exists():
+        org.name = ORG_NAME
+        org.save(update_fields=["name", "updated_at"])
+
+    user, user_created = User.objects.get_or_create(
+        email=email,
+        defaults={
+            "username": username,
+            "organization": org,
+        },
+    )
+    if user_created:
+        user.set_password(password)
+        user.save(update_fields=["password"])
+    elif user.organization_id is None:
+        user.organization = org
+        user.save(update_fields=["organization"])
+
+    project, project_created = Project.objects.get_or_create(
+        name=PROJECT_NAME,
+        organization=org,
+        defaults={"owner": user},
+    )
+    ProjectMember.objects.get_or_create(
+        user=user,
+        project=project,
+        defaults={"role": "owner", "is_active": True},
+    )
+
+    connection, connection_created = FacebookConnection.objects.get_or_create(
+        user=user,
+        defaults={
+            "fb_user_id": FB_USER_ID,
+            "fb_user_name": "MED-246 QA User",
+            "business_id": f"{SEED_MARKER}-biz",
+            "business_name": "MED-246 QA Business",
+            "is_active": True,
+            "last_synced_at": timezone.now(),
+        },
+    )
+    if not connection_created:
+        connection.fb_user_id = FB_USER_ID
+        connection.is_active = True
+        connection.last_synced_at = timezone.now()
+        connection.last_sync_error = ""
+        connection.save(
+            update_fields=[
+                "fb_user_id",
+                "is_active",
+                "last_synced_at",
+                "last_sync_error",
+                "updated_at",
+            ]
+        )
+
+    ad_account, ad_account_created = MetaAdAccount.objects.get_or_create(
+        connection=connection,
+        meta_account_id=META_ACCOUNT_ID,
+        defaults={
+            "name": "MED-246 QA Ad Account",
+            "currency": "USD",
+            "timezone_name": "UTC",
+            "account_status": 1,
+            "business_id": f"{SEED_MARKER}-biz",
+            "is_owned": True,
+            "project": project,
+        },
+    )
+    if ad_account.project_id != project.id:
+        ad_account.project = project
+        ad_account.name = "MED-246 QA Ad Account"
+        ad_account.account_status = 1
+        ad_account.save(
+            update_fields=["project", "name", "account_status", "updated_at"]
+        )
+
+    campaign, _ = MetaCampaign.objects.get_or_create(
+        ad_account=ad_account,
+        meta_campaign_id=META_CAMPAIGN_ID,
+        defaults={
+            "name": "MED-246 QA Campaign",
+            "objective": "OUTCOME_TRAFFIC",
+            "status": "ACTIVE",
+            "effective_status": "ACTIVE",
+        },
+    )
+    adset, _ = MetaAdSet.objects.get_or_create(
+        campaign=campaign,
+        meta_adset_id=META_ADSET_ID,
+        defaults={
+            "name": "MED-246 QA Ad Set",
+            "status": "ACTIVE",
+            "effective_status": "ACTIVE",
+            "billing_event": "IMPRESSIONS",
+            "optimization_goal": "LINK_CLICKS",
+        },
+    )
+    creative, _ = MetaAdCreative.objects.get_or_create(
+        ad_account=ad_account,
+        meta_creative_id=META_CREATIVE_ID,
+        defaults={
+            "name": "MED-246 QA Creative",
+            "title": "QA rollover creative",
+            "body": "Schema-aligned mock for MED-246",
+            "object_type": "SHARE",
+            "call_to_action_type": "LEARN_MORE",
+        },
+    )
+    ad, _ = MetaAd.objects.get_or_create(
+        adset=adset,
+        meta_ad_id=META_AD_ID,
+        defaults={
+            "name": "MED-246 QA Ad",
+            "status": "ACTIVE",
+            "effective_status": "ACTIVE",
+            "creative": creative,
+        },
+    )
+    if ad.creative_id is None:
+        ad.creative = creative
+        ad.save(update_fields=["creative", "updated_at"])
+
+    insight_dates = [
+        as_of - _dt.timedelta(days=offset)
+        for offset in range(insight_days - 1, -1, -1)
+    ]
+    insights_created = 0
+    insights_updated = 0
+    for index, date in enumerate(insight_dates):
+        _, created = MetaInsightDaily.objects.update_or_create(
+            ad=ad,
+            date=date,
+            defaults=_insight_defaults_for_day(index, date),
+        )
+        if created:
+            insights_created += 1
+        else:
+            insights_updated += 1
+
+    sync_run = MetaSyncRun.objects.create(
+        ad_account=ad_account,
+        kind="manual",
+        status="ok",
+        finished_at=timezone.now(),
+        level_counts={
+            "campaigns": 1,
+            "adsets": 1,
+            "creatives": 1,
+            "ads": 1,
+            "insights_rows": len(insight_dates),
+            "seed": SEED_MARKER,
+        },
+        current_phase="",
+        current_progress="",
+    )
+
+    return {
+        "org_id": org.id,
+        "org_created": org_created,
+        "user_id": user.id,
+        "user_email": user.email,
+        "user_created": user_created,
+        "project_id": project.id,
+        "project_created": project_created,
+        "connection_id": connection.id,
+        "connection_created": connection_created,
+        "ad_account_id": ad_account.id,
+        "ad_account_created": ad_account_created,
+        "ad_id": ad.id,
+        "insight_dates": [d.isoformat() for d in insight_dates],
+        "insights_created": insights_created,
+        "insights_updated": insights_updated,
+        "sync_run_id": sync_run.id,
+        "last_synced_at": connection.last_synced_at.isoformat()
+        if connection.last_synced_at
+        else None,
+        "password_if_created": password if user_created else None,
+    }
+
+
+def _reset_seed_rows() -> None:
+    """Remove prior MED-246 seed rows by stable Meta IDs (FK cascade handles children)."""
+    MetaAdAccount.objects.filter(meta_account_id=META_ACCOUNT_ID).delete()
+    FacebookConnection.objects.filter(fb_user_id=FB_USER_ID).delete()

--- a/backend/meta_ads/services.py
+++ b/backend/meta_ads/services.py
@@ -370,10 +370,43 @@ def backfill_missing_creative_fks(
     return fixed
 
 
+# Extra calendar day added on top of the caller-requested trailing window so a
+# sync that straddles UTC midnight still covers the day that just rolled over.
+# See MED-246. Pad=1 is enough for rollover; attribution freshness is handled
+# by the wider days=30 hourly path, not by enlarging this pad.
+INSIGHTS_WINDOW_OVERLAP_PAD = 1
+
+
+def build_insights_date_window(
+    days: int,
+    overlap_pad: int = INSIGHTS_WINDOW_OVERLAP_PAD,
+    *,
+    now: _dt.datetime | None = None,
+) -> tuple[_dt.date, _dt.date]:
+    """Compute the insights `since`/`until` window at request time.
+
+    Must be called immediately before the Graph insights request — not at
+    Celery task enqueue / `sync_ad_account` start — so the calendar day matches
+    the moment we actually query. `overlap_pad` widens the trailing window to
+    tolerate UTC midnight rollover (effective span = days + overlap_pad).
+    """
+    if days < 0:
+        raise ValueError("days must be >= 0")
+    if overlap_pad < 0:
+        raise ValueError("overlap_pad must be >= 0")
+    current = now if now is not None else timezone.now()
+    until = current.date()
+    since = until - _dt.timedelta(days=days + overlap_pad)
+    return since, until
+
+
 def sync_insights(ad_account: MetaAdAccount, access_token: str, *, days: int = 30) -> int:
-    """Pull per-ad per-day insights for the trailing `days` window."""
-    until = timezone.now().date()
-    since = until - _dt.timedelta(days=days)
+    """Pull per-ad per-day insights for the trailing `days` window.
+
+    The calendar window is anchored here (insights-query time), not earlier in
+    the sync pipeline, and includes INSIGHTS_WINDOW_OVERLAP_PAD extra day(s).
+    """
+    since, until = build_insights_date_window(days)
     time_range = f'{{"since":"{since.isoformat()}","until":"{until.isoformat()}"}}'
     params = {
         "fields": INSIGHT_FIELDS,

--- a/backend/meta_ads/services.py
+++ b/backend/meta_ads/services.py
@@ -441,6 +441,9 @@ def sync_insights(ad_account: MetaAdAccount, access_token: str, *, days: int = 3
             lpv_count = _parse_landing_page_views(actions)
             video_3sec_count = _parse_video_3sec(actions)
             comment_count = _parse_comments(actions)
+            # Upsert on unique (ad, date): overlap-widened windows may re-fetch
+            # the same calendar day; refresh metrics in place, never insert a
+            # second row (MED-246 acceptance: no duplicates from overlap).
             MetaInsightDaily.objects.update_or_create(
                 ad=ad,
                 date=_dt.date.fromisoformat(date_str),

--- a/backend/meta_ads/tasks.py
+++ b/backend/meta_ads/tasks.py
@@ -57,14 +57,33 @@ def sync_recent_meta(days: int = 2) -> dict:
 @shared_task
 def sync_single_ad_account(ad_account_id: int, days: int = 30) -> dict:
     """Manual sync trigger used by the UI Refresh button."""
+    from .models import MetaSyncRun
+
     try:
         ad_account = MetaAdAccount.objects.get(pk=ad_account_id)
     except MetaAdAccount.DoesNotExist:
         return {"error": "not_found"}
-    token = ad_account.connection.get_access_token()
+    connection = ad_account.connection
+    token = connection.get_access_token()
     if not token:
+        # Persist a failed run so the UI poll does not treat a prior seed/ok
+        # row as "this refresh just succeeded" (MED-246 QA / no-token case).
+        now = timezone.now()
+        MetaSyncRun.objects.create(
+            ad_account=ad_account,
+            kind="manual",
+            status="error",
+            finished_at=now,
+            error_message="no_token: reconnect Meta on the Integrations page",
+            level_counts={},
+            current_phase="",
+            current_progress="",
+        )
         return {"error": "no_token"}
     run = sync_ad_account(ad_account, token, days=days, kind="manual")
+    if run.status == "ok":
+        connection.last_synced_at = timezone.now()
+        connection.save(update_fields=["last_synced_at", "updated_at"])
     return {"status": run.status, "level_counts": run.level_counts, "error": run.error_message}
 
 

--- a/backend/meta_ads/test_med246_insights_window.py
+++ b/backend/meta_ads/test_med246_insights_window.py
@@ -1,0 +1,129 @@
+"""MED-246: insights date window is request-time + overlap-tolerant."""
+
+import datetime as _dt
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+from django.contrib.auth import get_user_model
+from django.test import SimpleTestCase, TestCase
+from freezegun import freeze_time
+
+from facebook_integration.models import FacebookConnection, MetaAdAccount
+from meta_ads.models import MetaAd, MetaAdSet, MetaCampaign, MetaInsightDaily
+from meta_ads.services import (
+    INSIGHTS_WINDOW_OVERLAP_PAD,
+    build_insights_date_window,
+    sync_insights,
+)
+
+
+class BuildInsightsDateWindowTests(SimpleTestCase):
+    def test_adds_overlap_pad_on_top_of_requested_days(self):
+        now = _dt.datetime(2026, 7, 31, 0, 5, tzinfo=ZoneInfo("UTC"))
+        since, until = build_insights_date_window(days=2, now=now)
+
+        self.assertEqual(until, _dt.date(2026, 7, 31))
+        self.assertEqual(since, _dt.date(2026, 7, 28))  # 2 + pad(1)
+        self.assertEqual(INSIGHTS_WINDOW_OVERLAP_PAD, 1)
+
+    def test_uses_timezone_now_when_now_not_passed(self):
+        with freeze_time("2026-07-30 23:50:00", tz_offset=0):
+            since, until = build_insights_date_window(days=2)
+
+        self.assertEqual(until, _dt.date(2026, 7, 30))
+        self.assertEqual(since, _dt.date(2026, 7, 27))
+
+    def test_window_moves_when_clock_crosses_utc_midnight(self):
+        before = build_insights_date_window(
+            days=2,
+            now=_dt.datetime(2026, 7, 30, 23, 50, tzinfo=ZoneInfo("UTC")),
+        )
+        after = build_insights_date_window(
+            days=2,
+            now=_dt.datetime(2026, 7, 31, 0, 5, tzinfo=ZoneInfo("UTC")),
+        )
+
+        self.assertEqual(before, (_dt.date(2026, 7, 27), _dt.date(2026, 7, 30)))
+        self.assertEqual(after, (_dt.date(2026, 7, 28), _dt.date(2026, 7, 31)))
+        # Rollover day remains covered after the clock flips.
+        self.assertIn(_dt.date(2026, 7, 30), _dates_in_window(*after))
+
+    def test_rejects_negative_inputs(self):
+        with self.assertRaises(ValueError):
+            build_insights_date_window(days=-1)
+        with self.assertRaises(ValueError):
+            build_insights_date_window(days=2, overlap_pad=-1)
+
+
+def _dates_in_window(since: _dt.date, until: _dt.date) -> set[_dt.date]:
+    days = (until - since).days
+    return {since + _dt.timedelta(days=i) for i in range(days + 1)}
+
+
+class SyncInsightsUsesRequestTimeWindowTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        User = get_user_model()
+        user = User.objects.create_user(
+            username="med246_window_user",
+            email="med246-window@example.com",
+            password="x",
+        )
+        connection = FacebookConnection.objects.create(
+            user=user, fb_user_id="fb-med246-window", is_active=True
+        )
+        cls.ad_account = MetaAdAccount.objects.create(
+            connection=connection,
+            meta_account_id="med246win",
+            name="MED-246 Window Account",
+            currency="USD",
+        )
+        campaign = MetaCampaign.objects.create(
+            ad_account=cls.ad_account,
+            meta_campaign_id="med246win-c",
+            name="Camp",
+        )
+        adset = MetaAdSet.objects.create(
+            campaign=campaign,
+            meta_adset_id="med246win-as",
+            name="Adset",
+        )
+        cls.ad = MetaAd.objects.create(
+            adset=adset, meta_ad_id="med246win-ad", name="Ad"
+        )
+
+    @freeze_time("2026-07-31 00:05:00", tz_offset=0)
+    def test_sync_insights_sends_overlap_widened_time_range(self):
+        captured: dict = {}
+
+        def fake_graph_paged(path, access_token, params=None):
+            captured["path"] = path
+            captured["params"] = params or {}
+            return iter(
+                [
+                    {
+                        "ad_id": self.ad.meta_ad_id,
+                        "date_start": "2026-07-30",
+                        "spend": "18.00",
+                        "impressions": "200",
+                        "reach": "180",
+                        "clicks": "9",
+                        "frequency": "1.1",
+                        "ctr": "4.5",
+                        "cpc": "2.0",
+                        "cpm": "90.0",
+                        "actions": [],
+                    }
+                ]
+            )
+
+        with patch("meta_ads.services.graph_paged", side_effect=fake_graph_paged):
+            count = sync_insights(self.ad_account, "fake-token", days=2)
+
+        self.assertEqual(count, 1)
+        self.assertEqual(
+            captured["params"]["time_range"],
+            '{"since":"2026-07-28","until":"2026-07-31"}',
+        )
+        row = MetaInsightDaily.objects.get(ad=self.ad, date=_dt.date(2026, 7, 30))
+        self.assertEqual(str(row.spend), "18.00")

--- a/backend/meta_ads/test_med246_insights_window.py
+++ b/backend/meta_ads/test_med246_insights_window.py
@@ -1,10 +1,12 @@
-"""MED-246: insights date window is request-time + overlap-tolerant."""
+"""MED-246: insights date window is request-time + overlap-tolerant upsert."""
 
 import datetime as _dt
+from decimal import Decimal
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 from django.contrib.auth import get_user_model
+from django.db import IntegrityError, transaction
 from django.test import SimpleTestCase, TestCase
 from freezegun import freeze_time
 
@@ -127,3 +129,129 @@ class SyncInsightsUsesRequestTimeWindowTests(TestCase):
         )
         row = MetaInsightDaily.objects.get(ad=self.ad, date=_dt.date(2026, 7, 30))
         self.assertEqual(str(row.spend), "18.00")
+
+
+def _graph_insight_row(meta_ad_id: str, date_str: str, *, spend: str, impressions: str):
+    return {
+        "ad_id": meta_ad_id,
+        "date_start": date_str,
+        "spend": spend,
+        "impressions": impressions,
+        "reach": "180",
+        "clicks": "9",
+        "frequency": "1.1",
+        "ctr": "4.5",
+        "cpc": "2.0",
+        "cpm": "90.0",
+        "actions": [],
+    }
+
+
+class SyncInsightsOverlapUpsertTests(TestCase):
+    """Overlap may re-fetch the same (ad, date); upsert must refresh, not duplicate."""
+
+    @classmethod
+    def setUpTestData(cls):
+        User = get_user_model()
+        user = User.objects.create_user(
+            username="med246_upsert_user",
+            email="med246-upsert@example.com",
+            password="x",
+        )
+        connection = FacebookConnection.objects.create(
+            user=user, fb_user_id="fb-med246-upsert", is_active=True
+        )
+        cls.ad_account = MetaAdAccount.objects.create(
+            connection=connection,
+            meta_account_id="med246upsert",
+            name="MED-246 Upsert Account",
+            currency="USD",
+        )
+        campaign = MetaCampaign.objects.create(
+            ad_account=cls.ad_account,
+            meta_campaign_id="med246upsert-c",
+            name="Camp",
+        )
+        adset = MetaAdSet.objects.create(
+            campaign=campaign,
+            meta_adset_id="med246upsert-as",
+            name="Adset",
+        )
+        cls.ad = MetaAd.objects.create(
+            adset=adset, meta_ad_id="med246upsert-ad", name="Ad"
+        )
+
+    def test_schema_rejects_duplicate_ad_date_rows(self):
+        MetaInsightDaily.objects.create(
+            ad=self.ad,
+            date=_dt.date(2026, 7, 30),
+            spend=Decimal("10.00"),
+            impressions=100,
+        )
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                MetaInsightDaily.objects.create(
+                    ad=self.ad,
+                    date=_dt.date(2026, 7, 30),
+                    spend=Decimal("99.00"),
+                    impressions=1,
+                )
+
+    @freeze_time("2026-07-30 23:50:00", tz_offset=0)
+    def test_first_sync_creates_row_for_rollover_day(self):
+        rows = [
+            _graph_insight_row(
+                self.ad.meta_ad_id, "2026-07-30", spend="10.00", impressions="100"
+            )
+        ]
+        with patch("meta_ads.services.graph_paged", return_value=iter(rows)):
+            created_count = sync_insights(self.ad_account, "fake-token", days=2)
+
+        self.assertEqual(created_count, 1)
+        self.assertEqual(MetaInsightDaily.objects.filter(ad=self.ad).count(), 1)
+        row = MetaInsightDaily.objects.get(ad=self.ad, date=_dt.date(2026, 7, 30))
+        self.assertEqual(row.spend, Decimal("10.00"))
+        self.assertEqual(row.impressions, 100)
+
+    def test_overlap_resync_updates_same_ad_date_without_duplicate(self):
+        """Simulate pre-midnight then post-midnight syncs that both include 7/30."""
+        first_rows = [
+            _graph_insight_row(
+                self.ad.meta_ad_id, "2026-07-30", spend="10.00", impressions="100"
+            )
+        ]
+        with freeze_time("2026-07-30 23:50:00", tz_offset=0):
+            with patch(
+                "meta_ads.services.graph_paged", return_value=iter(first_rows)
+            ):
+                sync_insights(self.ad_account, "fake-token", days=2)
+
+        # After UTC rollover the widened window still includes 7/30; Meta may
+        # return a fresher spend/impression total for that same calendar day.
+        second_rows = [
+            _graph_insight_row(
+                self.ad.meta_ad_id, "2026-07-30", spend="12.50", impressions="130"
+            ),
+            _graph_insight_row(
+                self.ad.meta_ad_id, "2026-07-31", spend="1.00", impressions="20"
+            ),
+        ]
+        with freeze_time("2026-07-31 00:05:00", tz_offset=0):
+            with patch(
+                "meta_ads.services.graph_paged", return_value=iter(second_rows)
+            ):
+                sync_insights(self.ad_account, "fake-token", days=2)
+
+        qs = MetaInsightDaily.objects.filter(ad=self.ad).order_by("date")
+        self.assertEqual(qs.count(), 2)
+        day_30 = qs.get(date=_dt.date(2026, 7, 30))
+        day_31 = qs.get(date=_dt.date(2026, 7, 31))
+        self.assertEqual(day_30.spend, Decimal("12.50"))
+        self.assertEqual(day_30.impressions, 130)
+        self.assertEqual(day_31.spend, Decimal("1.00"))
+        self.assertEqual(
+            MetaInsightDaily.objects.filter(
+                ad=self.ad, date=_dt.date(2026, 7, 30)
+            ).count(),
+            1,
+        )

--- a/backend/meta_ads/test_med246_qa_mock_data.py
+++ b/backend/meta_ads/test_med246_qa_mock_data.py
@@ -1,0 +1,82 @@
+"""Tests for MED-246 QA mock seed (schema alignment + idempotency)."""
+
+import datetime as _dt
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from freezegun import freeze_time
+
+from facebook_integration.models import FacebookConnection, MetaAdAccount
+from meta_ads.models import MetaAd, MetaInsightDaily, MetaSyncRun
+from meta_ads.qa_mock_data import (
+    META_ACCOUNT_ID,
+    META_AD_ID,
+    seed_med246_qa_mock_data,
+)
+
+
+class Med246QaMockDataTests(TestCase):
+    @freeze_time("2026-07-31 00:05:00", tz_offset=0)
+    def test_seed_builds_full_fk_chain_and_contiguous_insight_days(self):
+        summary = seed_med246_qa_mock_data(as_of=_dt.date(2026, 7, 31), insight_days=5)
+
+        self.assertEqual(
+            summary["insight_dates"],
+            [
+                "2026-07-27",
+                "2026-07-28",
+                "2026-07-29",
+                "2026-07-30",
+                "2026-07-31",
+            ],
+        )
+
+        account = MetaAdAccount.objects.get(meta_account_id=META_ACCOUNT_ID)
+        self.assertEqual(account.currency, "USD")
+        self.assertEqual(account.account_status, 1)
+        self.assertIsNotNone(account.project_id)
+
+        connection = FacebookConnection.objects.get(pk=account.connection_id)
+        self.assertTrue(connection.is_active)
+        self.assertIsNotNone(connection.last_synced_at)
+
+        ad = MetaAd.objects.get(meta_ad_id=META_AD_ID)
+        self.assertEqual(ad.adset.campaign.ad_account_id, account.id)
+        self.assertIsNotNone(ad.creative_id)
+
+        rows = list(
+            MetaInsightDaily.objects.filter(ad=ad).order_by("date").values_list(
+                "date", "spend", "impressions"
+            )
+        )
+        self.assertEqual(len(rows), 5)
+        self.assertEqual(rows[0][0], _dt.date(2026, 7, 27))
+        self.assertEqual(rows[-1][0], _dt.date(2026, 7, 31))
+        # Spans the UTC rollover boundary used in MED-246 scenarios.
+        self.assertIn(_dt.date(2026, 7, 30), [r[0] for r in rows])
+        self.assertIn(_dt.date(2026, 7, 31), [r[0] for r in rows])
+
+        self.assertTrue(
+            MetaSyncRun.objects.filter(ad_account=account, status="ok").exists()
+        )
+        self.assertEqual(
+            get_user_model().objects.get(pk=summary["user_id"]).email,
+            summary["user_email"],
+        )
+
+    @freeze_time("2026-07-31 00:05:00", tz_offset=0)
+    def test_seed_is_idempotent_on_unique_ad_date(self):
+        seed_med246_qa_mock_data(as_of=_dt.date(2026, 7, 31), insight_days=3)
+        second = seed_med246_qa_mock_data(as_of=_dt.date(2026, 7, 31), insight_days=3)
+
+        ad = MetaAd.objects.get(meta_ad_id=META_AD_ID)
+        self.assertEqual(MetaInsightDaily.objects.filter(ad=ad).count(), 3)
+        self.assertEqual(second["insights_created"], 0)
+        self.assertEqual(second["insights_updated"], 3)
+        self.assertEqual(
+            MetaAdAccount.objects.filter(meta_account_id=META_ACCOUNT_ID).count(), 1
+        )
+
+    def test_rejects_too_short_insight_window(self):
+        with self.assertRaises(ValueError):
+            seed_med246_qa_mock_data(insight_days=1)

--- a/backend/meta_ads/test_med246_qa_mock_data.py
+++ b/backend/meta_ads/test_med246_qa_mock_data.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from freezegun import freeze_time
 
+from core.models import OrganizationMembership
 from facebook_integration.models import FacebookConnection, MetaAdAccount
 from meta_ads.models import MetaAd, MetaInsightDaily, MetaSyncRun
 from meta_ads.qa_mock_data import (
@@ -59,10 +60,15 @@ class Med246QaMockDataTests(TestCase):
         self.assertTrue(
             MetaSyncRun.objects.filter(ad_account=account, status="ok").exists()
         )
-        self.assertEqual(
-            get_user_model().objects.get(pk=summary["user_id"]).email,
-            summary["user_email"],
+        user = get_user_model().objects.get(pk=summary["user_id"])
+        self.assertEqual(user.email, summary["user_email"])
+        self.assertTrue(
+            OrganizationMembership.objects.filter(
+                user=user, organization_id=summary["org_id"], is_active=True
+            ).exists()
         )
+        self.assertEqual(user.current_organization_id, summary["org_id"])
+        self.assertEqual(user.active_project_id, summary["project_id"])
 
     @freeze_time("2026-07-31 00:05:00", tz_offset=0)
     def test_seed_is_idempotent_on_unique_ad_date(self):

--- a/backend/meta_ads/test_med246_sync_no_token.py
+++ b/backend/meta_ads/test_med246_sync_no_token.py
@@ -1,0 +1,40 @@
+"""Manual sync must leave a pollable MetaSyncRun even when there is no token."""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from facebook_integration.models import FacebookConnection, MetaAdAccount
+from meta_ads.models import MetaSyncRun
+from meta_ads.tasks import sync_single_ad_account
+
+
+class SyncSingleAdAccountNoTokenTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        user = User.objects.create_user(
+            username="med246_notoken",
+            email="med246-notoken@example.com",
+            password="x",
+        )
+        self.connection = FacebookConnection.objects.create(
+            user=user,
+            fb_user_id="fb-med246-notoken",
+            is_active=True,
+            encrypted_access_token="",
+        )
+        self.account = MetaAdAccount.objects.create(
+            connection=self.connection,
+            meta_account_id="med246notoken",
+            name="No Token Account",
+            currency="USD",
+        )
+
+    def test_no_token_creates_error_sync_run(self):
+        result = sync_single_ad_account(self.account.id)
+
+        self.assertEqual(result, {"error": "no_token"})
+        run = MetaSyncRun.objects.get(ad_account=self.account)
+        self.assertEqual(run.status, "error")
+        self.assertEqual(run.kind, "manual")
+        self.assertIsNotNone(run.finished_at)
+        self.assertIn("no_token", run.error_message)

--- a/frontend/src/__tests__/components/meta-ads/LastSyncTimeTooltip.test.tsx
+++ b/frontend/src/__tests__/components/meta-ads/LastSyncTimeTooltip.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+
+import LastSyncTimeTooltip from '@/components/meta-ads/LastSyncTimeTooltip';
+import {
+  formatLastSyncedTooltip,
+  isNewerSyncRun,
+  resolveLastSyncedAt,
+} from '@/components/meta-ads/metaAdsUtils';
+
+describe('resolveLastSyncedAt', () => {
+  it('prefers finished_at over started_at and connection timestamp', () => {
+    expect(
+      resolveLastSyncedAt({
+        finishedAt: '2026-07-31T00:05:00Z',
+        startedAt: '2026-07-30T23:50:00Z',
+        connectionLastSyncedAt: '2026-07-29T12:00:00Z',
+      })
+    ).toBe('2026-07-31T00:05:00Z');
+  });
+
+  it('falls back to connection last_synced_at', () => {
+    expect(
+      resolveLastSyncedAt({
+        connectionLastSyncedAt: '2026-07-31T12:42:52Z',
+      })
+    ).toBe('2026-07-31T12:42:52Z');
+  });
+});
+
+describe('isNewerSyncRun', () => {
+  it('detects a new run by id', () => {
+    expect(
+      isNewerSyncRun(
+        { id: 3, started_at: '2026-07-31T14:00:00Z' },
+        2,
+        '2026-07-31T13:47:42Z'
+      )
+    ).toBe(true);
+  });
+
+  it('ignores the same baseline run', () => {
+    expect(
+      isNewerSyncRun(
+        { id: 2, started_at: '2026-07-31T13:47:42Z' },
+        2,
+        '2026-07-31T13:47:42Z'
+      )
+    ).toBe(false);
+  });
+});
+
+describe('formatLastSyncedTooltip', () => {
+  it('returns not-synced copy when empty', () => {
+    expect(formatLastSyncedTooltip(null)).toBe('Not synced yet');
+    expect(formatLastSyncedTooltip('not-a-date')).toBe('Not synced yet');
+  });
+
+  it('formats a valid ISO timestamp', () => {
+    const label = formatLastSyncedTooltip('2026-07-31T00:05:00.000Z');
+    expect(label.startsWith('Last synced:')).toBe(true);
+    expect(label).toMatch(/2026/);
+  });
+});
+
+describe('LastSyncTimeTooltip', () => {
+  it('exposes the formatted last-sync label for hover / a11y', () => {
+    render(
+      <LastSyncTimeTooltip lastSyncedAt="2026-07-31T00:05:00.000Z">
+        <button type="button">Refresh data</button>
+      </LastSyncTimeTooltip>
+    );
+
+    expect(screen.getByRole('button', { name: /refresh data/i })).toBeInTheDocument();
+    expect(screen.getAllByLabelText(/last synced:/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole('tooltip').textContent).toMatch(/Last synced:/);
+  });
+
+  it('shows not-synced copy when timestamp is missing', () => {
+    render(
+      <LastSyncTimeTooltip lastSyncedAt={null}>
+        <button type="button">Refresh data</button>
+      </LastSyncTimeTooltip>
+    );
+
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Not synced yet');
+  });
+});

--- a/frontend/src/app/(project)/meta-ads/page.tsx
+++ b/frontend/src/app/(project)/meta-ads/page.tsx
@@ -42,7 +42,13 @@ import CampaignHierarchyTable from '@/components/meta-ads/CampaignHierarchyTable
 import CreativesPanel from '@/components/meta-ads/CreativesPanel';
 import CreativeRankPanel from '@/components/meta-ads/CreativeRankPanel';
 import ExportActionMenu from '@/components/meta-ads/ExportActionMenu';
+import LastSyncTimeTooltip from '@/components/meta-ads/LastSyncTimeTooltip';
 import RankingPanel from '@/components/meta-ads/RankingPanel';
+import {
+  formatLastSyncedTooltip,
+  isNewerSyncRun,
+  resolveLastSyncedAt,
+} from '@/components/meta-ads/metaAdsUtils';
 import {
   facebookApi,
   type FacebookAdAccount,
@@ -201,6 +207,9 @@ function MetaAdsContent() {
   const [pendingMoveAccount, setPendingMoveAccount] =
     useState<FacebookAdAccount | null>(null);
   const [latestRun, setLatestRun] = useState<MetaSyncRun | null>(null);
+  const [connectionLastSyncedAt, setConnectionLastSyncedAt] = useState<
+    string | null
+  >(null);
   const [viewTab, setViewTab] = useState<ViewKey>(initialTab);
   const [selectedCampaignIds, setSelectedCampaignIds] = useState<Set<number>>(
     new Set()
@@ -237,6 +246,7 @@ function MetaAdsContent() {
       .then((status) => {
         if (!active) return;
         setConnected(status.connected);
+        setConnectionLastSyncedAt(status.last_synced_at ?? null);
         const accounts = status.ad_accounts ?? [];
         setAdAccounts(accounts);
         setAccountTotalCount(null);
@@ -253,12 +263,25 @@ function MetaAdsContent() {
           setSelectedId(null);
         }
       })
-      .catch(() => setConnected(false))
+      .catch(() => {
+        setConnected(false);
+        setConnectionLastSyncedAt(null);
+      })
       .finally(() => setLoadingStatus(false));
     return () => {
       active = false;
     };
   }, [activeProjectId, hasProjectStoreHydrated]);
+
+  const lastSyncedAt = useMemo(
+    () =>
+      resolveLastSyncedAt({
+        finishedAt: latestRun?.finished_at,
+        startedAt: latestRun?.started_at,
+        connectionLastSyncedAt,
+      }),
+    [latestRun?.finished_at, latestRun?.started_at, connectionLastSyncedAt]
+  );
 
   const handleSelectAccount = useCallback((id: number, account?: FacebookAdAccount) => {
     setSelectedId(id);
@@ -398,6 +421,8 @@ function MetaAdsContent() {
   const handleSync = async () => {
     if (!selectedId) return;
     setSyncing(true);
+    const baselineRunId = latestRun?.id ?? null;
+    const baselineStartedAt = latestRun?.started_at ?? null;
     try {
       await facebookApi.triggerAdAccountSync(selectedId);
       toast.success('Sync started. Data will refresh when it finishes.');
@@ -409,31 +434,57 @@ function MetaAdsContent() {
       setTimeout(() => {
         facebookApi
           .getSyncRuns(accountId)
-          .then((runs) => setLatestRun(runs[0] ?? null))
+          .then((runs) => {
+            const run = runs[0] ?? null;
+            if (run && isNewerSyncRun(run, baselineRunId, baselineStartedAt)) {
+              setLatestRun(run);
+            }
+          })
           .catch(() => undefined);
       }, 500);
-      pollSync(selectedId);
+      pollSync(selectedId, baselineRunId, baselineStartedAt);
     } catch {
       toast.error('Failed to start sync.');
       setSyncing(false);
     }
   };
 
-  const pollSync = (adAccountId: number) => {
+  const pollSync = (
+    adAccountId: number,
+    baselineRunId: number | null,
+    baselineStartedAt: string | null
+  ) => {
     let stopped = false;
     let attempts = 0;
     const tick = async () => {
       if (stopped || attempts > 60) {
         setSyncing(false);
+        if (attempts > 60) {
+          toast.error('Sync timed out waiting for a new run. Check Celery / Meta connection.');
+        }
         return;
       }
       attempts += 1;
       try {
         const runs = await facebookApi.getSyncRuns(adAccountId);
         const run = runs[0];
-        if (run) setLatestRun(run);
-        if (run && (run.status === 'ok' || run.status === 'error')) {
+        // Ignore the previous completed run until a NEW MetaSyncRun appears.
+        // Otherwise a no-token / delayed worker makes Refresh look successful
+        // while the tooltip stays stuck on the old timestamp.
+        if (!run || !isNewerSyncRun(run, baselineRunId, baselineStartedAt)) {
+          setTimeout(tick, 2000);
+          return;
+        }
+        setLatestRun(run);
+        if (run.status === 'running') {
+          setTimeout(tick, 2000);
+          return;
+        }
+        if (run.status === 'ok' || run.status === 'error') {
           setSyncing(false);
+          if (run.finished_at) {
+            setConnectionLastSyncedAt(run.finished_at);
+          }
           if (run.status === 'ok') {
             toast.success(
               `Synced ${run.level_counts?.campaigns ?? 0} campaigns, ${run.level_counts?.ads ?? 0} ads, ${run.level_counts?.insights_rows ?? 0} insight rows.`
@@ -452,7 +503,7 @@ function MetaAdsContent() {
       } catch {
         // keep polling
       }
-      setTimeout(tick, 5000);
+      setTimeout(tick, 2000);
     };
     tick();
     return () => {
@@ -622,18 +673,20 @@ function MetaAdsContent() {
             onAccountsLoaded={handleAccountsLoaded}
           />
           {canSyncSelectedAccount && (
-            <button
-              onClick={handleSync}
-              disabled={syncing}
-              className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50"
-            >
-              {syncing ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <RefreshCcw className="h-4 w-4" />
-              )}
-              {syncing ? 'Syncing...' : 'Refresh data'}
-            </button>
+            <LastSyncTimeTooltip lastSyncedAt={lastSyncedAt}>
+              <button
+                onClick={handleSync}
+                disabled={syncing}
+                className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50"
+              >
+                {syncing ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <RefreshCcw className="h-4 w-4" />
+                )}
+                {syncing ? 'Syncing...' : 'Refresh data'}
+              </button>
+            </LastSyncTimeTooltip>
           )}
         </div>
       </header>
@@ -1045,7 +1098,10 @@ function SyncStatusCard({ run }: { run: MetaSyncRun }) {
           {s.icon}
           <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <span className="text-xs font-semibold text-gray-900">
+              <span
+                className="text-xs font-semibold text-gray-900"
+                title={formatLastSyncedTooltip(run.finished_at || run.started_at)}
+              >
                 Last sync · {timeAgo(run.started_at)}
               </span>
               <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium uppercase ${s.chip}`}>

--- a/frontend/src/components/meta-ads/LastSyncTimeTooltip.tsx
+++ b/frontend/src/components/meta-ads/LastSyncTimeTooltip.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import type { ReactElement } from 'react';
+
+import { formatLastSyncedTooltip } from '@/components/meta-ads/metaAdsUtils';
+
+/**
+ * Hover tooltip showing when ads data was last synced (MED-246).
+ * Uses a CSS hover panel (plus native title) so QA can verify without Ads API keys
+ * as long as `lastSyncedAt` is present from status / sync-run payloads.
+ */
+export default function LastSyncTimeTooltip({
+  lastSyncedAt,
+  children,
+}: {
+  lastSyncedAt: string | null | undefined;
+  children: ReactElement;
+}) {
+  const label = formatLastSyncedTooltip(lastSyncedAt);
+
+  return (
+    <div className="relative inline-flex group">
+      <div title={label} aria-label={label}>
+        {children}
+      </div>
+      <div
+        role="tooltip"
+        className="pointer-events-none absolute left-1/2 bottom-full z-20 mb-2 w-max max-w-xs -translate-x-1/2 rounded-md bg-gray-900 px-2.5 py-1.5 text-xs text-white opacity-0 shadow-lg transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+      >
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/meta-ads/metaAdsUtils.ts
+++ b/frontend/src/components/meta-ads/metaAdsUtils.ts
@@ -26,6 +26,46 @@ export function formatPercent(value: string | number, digits = 2): string {
   return `${n.toFixed(digits)}%`;
 }
 
+/** Prefer finished_at, then started_at, then connection-level last_synced_at. */
+export function resolveLastSyncedAt(sources: {
+  finishedAt?: string | null;
+  startedAt?: string | null;
+  connectionLastSyncedAt?: string | null;
+}): string | null {
+  return (
+    sources.finishedAt ||
+    sources.startedAt ||
+    sources.connectionLastSyncedAt ||
+    null
+  );
+}
+
+/** True when `run` is newer than the sync that was visible before Refresh. */
+export function isNewerSyncRun(
+  run: { id: number; started_at: string },
+  baselineRunId: number | null,
+  baselineStartedAt: string | null
+): boolean {
+  if (baselineRunId != null && run.id !== baselineRunId) return true;
+  if (baselineRunId == null && baselineStartedAt == null) return true;
+  if (baselineStartedAt != null && run.started_at > baselineStartedAt) return true;
+  return false;
+}
+
+/** Human-readable tooltip / title text for last sync time (MED-246). */
+export function formatLastSyncedTooltip(
+  iso: string | null | undefined,
+  locale = 'en-US'
+): string {
+  if (!iso) return 'Not synced yet';
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return 'Not synced yet';
+  return `Last synced: ${parsed.toLocaleString(locale, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })}`;
+}
+
 export function hookRateBandClass(rate: string | number): string {
   const n = typeof rate === 'string' ? Number(rate) : rate;
   if (!Number.isFinite(n) || n <= 0) return 'bg-gray-100 text-gray-400';


### PR DESCRIPTION
## Summary
- Re-anchor Meta insights `since`/`until` at **request time** (not earlier in the sync pipeline) and add **overlap pad = 1** so UTC midnight rollover does not miss a day (especially `days=2` / 15min path).
- Keep idempotent **upsert** on `(ad, date)` so overlap re-fetches update in place instead of duplicating rows.
- Add schema-aligned **QA mock seed** (`seed_med246_qa_mock_data`) plus last-sync tooltip and refresh-poll fixes (no false success / clearer `no_token` error run).

## Scope notes
- **In this repo:** Meta Ads path only (Google/TikTok do not have equivalent daily insights sync here yet).
- **Out of scope:** historical backfill of days already missing before this fix.
- **QA:** passed on mock UI + automated tests (partial). Live Meta smoke follow-up when Ads API key is available.

## Ticket
MED-246

## Test plan
- [x] Backend: `meta_ads.test_med246_insights_window`
- [x] Backend: `meta_ads.test_med246_qa_mock_data`
- [x] Backend: `meta_ads.test_med246_sync_no_token`
- [x] Frontend: `LastSyncTimeTooltip` unit tests
- [x] QA: mock login + Refresh without token → expected `no_token` ERROR
- [ ] Follow-up: live Meta Refresh smoke around UTC rollover (when API key available)