### PR TITLE
ci: free disk space on runner before Docker builds (application_test, image_scan, lighthouse)

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -28,6 +28,17 @@ jobs:
       # https://docs.docker.com/build/ci/github-actions/build-summary/#disable-job-summary
       DOCKER_BUILD_SUMMARY: false
     steps:
+      - name: Free disk space on runner
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: false
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/mediajira-ci.yml
+++ b/.github/workflows/mediajira-ci.yml
@@ -207,6 +207,16 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Free disk space on runner
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: false
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -284,6 +294,16 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Free disk space on runner
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: false
       - name: Checkout code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

`application_test`, `image_scan`, and `lighthouse` have all been repeatedly failing mid-build with `no space left on device` on the standard `ubuntu-latest` GitHub Actions runner. The runner ships with ~14GB free disk, which isn't enough once the backend Docker image is built and loaded (`docker/build-push-action` with `load: true`) and the frontend image build starts on top of it — confirmed via 3 consecutive identical failures on PR #772 (MED-338) for the first two jobs, all dying at the same `Build frontend image` step, and then again on this PR's own `lighthouse` run.

This PR adds `jlumbroso/free-disk-space@main` as the very first step of all three jobs — `application_test` and `image_scan` in `mediajira-ci.yml`, and `lighthouse` in the separate `lighthouse-ci.yml` — before checkout/build runs. It removes preinstalled Android SDK, .NET, and Haskell toolchains (frees ~20GB+) and unused default Docker images — none of which this repo uses — leaving `tool-cache`, `large-packages`, and `swap-storage` cleanup disabled to keep the step fast and avoid touching anything the build might still need.

## Changes

- `.github/workflows/mediajira-ci.yml`: add a `Free disk space on runner` step as the first step in both the `application_test` and `image_scan` jobs.
- `.github/workflows/lighthouse-ci.yml`: add the same step as the first step of the `lighthouse` job, which has an identical backend+frontend Docker build pattern and hit the same failure.

## Tests

- Validated YAML syntax locally for both files: `python3 -c "import yaml; yaml.safe_load(open('...'))"` — OK.
- No application code changed; this is CI-workflow-only. Verification is this PR's own CI run passing `application_test`, `image_scan`, and `lighthouse`.

## Notes

- Migrations: no.
- Approved by Ray after CI disk-exhaustion was flagged on PR #772 (MED-338). Once this merges, MED-338's `application_test`/`image_scan`/`lighthouse` should pass on a re-run.
- `lighthouse-ci.yml` already had a `docker buildx prune` step between the backend and frontend builds (added previously for the same symptom) — left in place; it wasn't sufficient on its own, so the new step supplements rather than replaces it, matching the same pattern already in `mediajira-ci.yml`.
- Out of scope: not investigating whether the underlying frontend image itself has grown unnecessarily large — this fix addresses runner capacity, not image size.