### PR TITLE
fix(agent): redact API keys from debug log paths

### DIFF
--- a/backend/agent/gemini_client.py
+++ b/backend/agent/gemini_client.py
@@ -12,6 +12,8 @@ import time
 import requests
 from django.conf import settings
 
+from agent.log_redaction import redact_string
+
 logger = logging.getLogger(__name__)
 
 GEMINI_MODEL = "gemini-2.5-flash-lite"
@@ -69,10 +71,10 @@ def _gemini_request_with_retry(
             if status_code == 429:
                 raise GeminiRetriesExhausted("Gemini rate limited (HTTP 429).") from exc
             raise RuntimeError(
-                f"Gemini request failed with HTTP {status_code or 'unknown'}."
+                redact_string(f"Gemini request failed with HTTP {status_code or 'unknown'}.")
             ) from exc
         except requests.exceptions.RequestException as exc:
-            raise RuntimeError("Gemini network error.") from exc
+            raise RuntimeError(redact_string(f"Gemini network error: {exc}")) from exc
     raise GeminiRetriesExhausted("Gemini rate limited (HTTP 429).") from last_http_error
 
 

--- a/backend/agent/llm_client.py
+++ b/backend/agent/llm_client.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from django.conf import settings
 
+from agent.log_redaction import redact_string
 from stripe_meta.exceptions import QuotaError
 from stripe_meta.models import LLMCallLog
 from stripe_meta.services import (
@@ -132,7 +133,7 @@ def call_llm(
             output_cost_cents=0,
             total_cost_cents=0,
             success=False,
-            error_message=str(exc)[:500],
+            error_message=redact_string(str(exc))[:500],
         )
         raise
 

--- a/backend/agent/log_redaction.py
+++ b/backend/agent/log_redaction.py
@@ -1,0 +1,81 @@
+"""
+Central log redaction for the agent app.
+
+Provider clients (llm_client.py, gemini_client.py) embed API keys in request
+URLs and headers. The `requests`/`urllib3` libraries can log full URLs and
+headers at DEBUG level, and raw exception text can leak keys into tracebacks.
+This module scrubs both structured logging args and free-text log messages
+before they reach any handler (console, Loki, etc).
+"""
+import logging
+import re
+
+REDACTED = "***REDACTED***"
+
+SENSITIVE_HEADER_NAMES = {
+    "authorization",
+    "proxy-authorization",
+    "x-api-key",
+    "api-key",
+    "openai-api-key",
+    "anthropic-api-key",
+    "x-goog-api-key",
+    "cookie",
+    "set-cookie",
+}
+
+_BEARER_RE = re.compile(r"Bearer\s+\S+", re.IGNORECASE)
+_QUERY_PARAM_RE = re.compile(r"([?&](?:key|token)=)([^&\s\"']+)", re.IGNORECASE)
+_OPENAI_ANTHROPIC_KEY_RE = re.compile(r"sk-[A-Za-z0-9\-_]{6,}")
+_GOOGLE_KEY_RE = re.compile(r"AIzaSy[A-Za-z0-9_\-]{10,}")
+
+
+def _is_sensitive_key(key) -> bool:
+    return isinstance(key, str) and key.lower() in SENSITIVE_HEADER_NAMES
+
+
+def redact_headers(headers: dict) -> dict:
+    """Return a copy of `headers` with sensitive values masked."""
+    if not isinstance(headers, dict):
+        return headers
+    return {
+        key: (REDACTED if _is_sensitive_key(key) else value)
+        for key, value in headers.items()
+    }
+
+
+def redact_string(text: str) -> str:
+    """Scrub known secret patterns (Bearer tokens, sk-*, AIzaSy*, ?key=/?token=) from free text."""
+    if not isinstance(text, str) or not text:
+        return text
+    text = _BEARER_RE.sub(f"Bearer {REDACTED}", text)
+    text = _QUERY_PARAM_RE.sub(lambda m: f"{m.group(1)}{REDACTED}", text)
+    text = _OPENAI_ANTHROPIC_KEY_RE.sub(REDACTED, text)
+    text = _GOOGLE_KEY_RE.sub(REDACTED, text)
+    return text
+
+
+def _redact_value(value):
+    if isinstance(value, dict):
+        return {
+            key: (REDACTED if _is_sensitive_key(key) else _redact_value(val))
+            for key, val in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_value(item) for item in value)
+    if isinstance(value, str):
+        return redact_string(value)
+    return value
+
+
+class RedactSecretsFilter(logging.Filter):
+    """Sanitises log records in place. Never suppresses a record."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if isinstance(record.msg, str):
+            record.msg = redact_string(record.msg)
+        if record.args:
+            record.args = _redact_value(record.args)
+        return True

--- a/backend/agent/tests/test_log_redaction.py
+++ b/backend/agent/tests/test_log_redaction.py
@@ -1,0 +1,73 @@
+import logging
+
+from agent.log_redaction import RedactSecretsFilter, redact_headers, redact_string
+
+
+def test_redact_headers_masks_sensitive_keys():
+    headers = {
+        "Authorization": "Bearer sk-live-abc123",
+        "Content-Type": "application/json",
+        "authorization": "Bearer sk-live-xyz789",
+        "X-Api-Key": "abc123",
+    }
+    redacted = redact_headers(headers)
+
+    assert redacted["Authorization"] == "***REDACTED***"
+    assert redacted["authorization"] == "***REDACTED***"
+    assert redacted["X-Api-Key"] == "***REDACTED***"
+    assert redacted["Content-Type"] == "application/json"
+
+
+def test_redact_string_bearer_token():
+    assert redact_string("Bearer sk-proj-abc123xyz") == "Bearer ***REDACTED***"
+
+
+def test_redact_string_query_param_key():
+    result = redact_string("?key=AIzaSyD_secretkey123456789012345678")
+    assert "AIzaSyD_secretkey123456789012345678" not in result
+    assert "?key=***REDACTED***" in result
+
+
+def test_redact_string_sk_pattern():
+    assert redact_string("sk-ant-api03-longkey123") == "***REDACTED***"
+
+
+def test_redact_string_preserves_safe_text():
+    text = "Calling Gemini model=gemini-2.5-flash-lite system_chars=120 user_chars=40"
+    assert redact_string(text) == text
+
+
+def test_filter_redacts_structured_args():
+    record = logging.LogRecord(
+        name="agent.test",
+        level=logging.DEBUG,
+        pathname=__file__,
+        lineno=1,
+        msg="headers=%s",
+        args=({"Authorization": "Bearer sk-live-xxx"},),
+        exc_info=None,
+    )
+    RedactSecretsFilter().filter(record)
+    formatted = record.getMessage()
+
+    assert "sk-live" not in formatted
+    assert "***REDACTED***" in formatted
+
+
+def test_filter_redacts_via_caplog(caplog):
+    logger = logging.getLogger("agent.test_log_redaction")
+    logger.addFilter(RedactSecretsFilter())
+
+    with caplog.at_level(logging.DEBUG, logger="agent.test_log_redaction"):
+        logger.debug("headers=%s", {"Authorization": "Bearer sk-test-key123"})
+
+    assert "***REDACTED***" in caplog.text
+    assert "sk-test-key123" not in caplog.text
+
+
+def test_url_key_param_redacted():
+    url = "https://example.com/v1/model:generate?key=AIzaSyDsecretkey12345678901234567890"
+    result = redact_string(url)
+
+    assert "AIzaSyDsecretkey12345678901234567890" not in result
+    assert "?key=***REDACTED***" in result

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -716,6 +716,11 @@ formatter = json_log_formatter.JSONFormatter()
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
+    'filters': {
+        'redact_secrets': {
+            '()': 'agent.log_redaction.RedactSecretsFilter',
+        },
+    },
     'formatters': {
         'verbose': {
             'format': '{levelname} {asctime} {module} {process:d} {thread:d} {message}',
@@ -728,21 +733,24 @@ LOGGING = {
         'json': {
             '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
             'format': '%(asctime)s %(name)s %(levelname)s %(message)s'
-        },        
+        },
     },
     'handlers': {
         'console': {
             'class': 'logging.StreamHandler',
             'formatter': 'verbose',
+            'filters': ['redact_secrets'],
         },
         'console': {
             'class': 'logging.StreamHandler',
             'formatter': 'json',
-        },        
+            'filters': ['redact_secrets'],
+        },
     },
     'root': {
         'handlers': ['console'],
         'level': 'INFO',
+        'filters': ['redact_secrets'],
     },
     'loggers': {
         'django': {


### PR DESCRIPTION
## Summary

Fixes MED-334 by removing API key leakage from agent debug log paths. `llm_client.py` and `gemini_client.py` embed the Gemini API key in the request URL as `?key={api_key}`, which is required by the Gemini API, but `requests`/`urllib3` can log full URLs and headers at DEBUG level, and raw exception text (e.g. `str(exc)`) can carry that URL into tracebacks and DB-persisted error logs. This PR adds a central redaction layer rather than removing the key from the URL (not possible — Gemini requires it) or suppressing the logs entirely (loses debuggability).

The approach is a `logging.Filter` (`agent/log_redaction.py`) wired into Django's `LOGGING` config so it applies to every handler, including third-party loggers like `urllib3`, plus two targeted call-site fixes where a key could otherwise leak into a raised exception message or a database row.

## Backend

- Added `agent/log_redaction.py` — `RedactSecretsFilter(logging.Filter)` with two-layer protection: Layer 1 walks `record.args` (dicts/lists/tuples, including the dict-collapsed case Python's logging module uses for `logger.debug("...%s", {...})`) and masks values under sensitive header keys (`authorization`, `x-api-key`, `cookie`, etc., case-insensitive); Layer 2 regex-scrubs `record.msg` for `Bearer <token>`, `sk-*`, `AIzaSy*`, and `?key=`/`?token=` query params. The filter always returns `True` — it sanitises, never suppresses. Also exports `redact_headers()` and `redact_string()` as standalone helpers for direct use.
- Wired `redact_secrets` into `backend/settings.py`'s `LOGGING['filters']`, attached to the console handler and the root logger, so DEBUG-level output from `requests`/`urllib3` is covered, not just our own `logger.*` calls.
- `agent/gemini_client.py` — kept the `?key={api_key}` URL construction as-is (required by the Gemini API), but `_gemini_request_with_retry`'s `RuntimeError` on HTTP/network failure is now built with `redact_string()`. This matters because `requests.exceptions.ConnectionError`'s own `str()` embeds the full failed URL (including the key) — verified this leaks in the raw exception and is scrubbed in what we re-raise.
- `agent/llm_client.py` — `call_llm()`'s failure path (line 135) now writes `error_message=redact_string(str(exc))[:500]` instead of the raw `str(exc)[:500]`, so a leaked key can no longer land in `LLMCallLog.error_message`.

## Frontend

No frontend changes.

## Tests

- Django backend targeted pytest:
    - `docker compose -f docker-compose.dev.yml --env-file .env exec backend pytest agent/tests/test_log_redaction.py --no-cov -v`
    - Result: 8 passed
    - (`--no-cov` used to avoid tripping the global coverage threshold gate on a targeted run)

- Django backend regression pytest:
    - `docker compose -f docker-compose.dev.yml --env-file .env exec backend pytest agent/test_call_llm.py agent/tests/ --no-cov -q`
    - Result: 25 passed (confirms no behavior change to quota reservation/commit/logging flow in `call_llm`)

- Django config check:
    - `docker compose -f docker-compose.dev.yml --env-file .env exec backend python manage.py check`
    - Result: System check identified no issues

- Frontend targeted unit tests: N/A — no frontend files changed.

- Diff hygiene:
    - `git diff --check`
    - Result: clean

## QA

- Demo video and QA checklist submitted in Discord `#qa-feedback`.

## Notes

- Migrations: no.
- No Vault integration — explicitly out of scope per the ticket.
- The `?key={api_key}` query param itself is intentionally left in the request URLs in both clients (required by the Gemini API); only its leakage into logs/errors is fixed.
- Manually verified end-to-end with simulated `requests.exceptions.ConnectionError` (the kind urllib3 raises on a real network failure, embedding the full URL+key) flowing through both `gemini_client._gemini_request_with_retry` and `llm_client.call_llm` → `LLMCallLog.error_message`; confirmed the key is redacted at both points.
