### PR TITLE
Fix/med 240 budget approval org admin

### DIFF
--- a/backend/access_control/middleware/authorization.py
+++ b/backend/access_control/middleware/authorization.py
@@ -82,6 +82,10 @@ class AuthorizationMiddleware:
                 self._log_override(request, user, 'SUPERUSER', module_key, action_key)
             return None
 
+        # Propagate org-admin role context for downstream permission checks (MED-240).
+        # Default False; set True when a valid Organization Admin (level == 2) role exists.
+        request.is_org_admin = False
+
         # Org admins (role level == 2) bypass module-level permission checks.
         # Level 2 is the Organization Admin level created by assign_org_admin().
         # This matches the criterion used by is_org_admin() in admin_utils.py.
@@ -95,6 +99,7 @@ class AuthorizationMiddleware:
                 role__level=2,
                 valid_from__lte=_now,
             ).filter(Q(valid_to__gte=_now) | Q(valid_to__isnull=True)).exists():
+                request.is_org_admin = True
                 if has_permission_gate:
                     self._log_override(request, user, 'ORG_ADMIN', module_key, action_key)
                 return None

--- a/backend/budget_approval/approver_access.py
+++ b/backend/budget_approval/approver_access.py
@@ -1,0 +1,50 @@
+"""Who may approve/reject a budget request (chain approver vs org-admin override).
+
+Shared by DRF permissions and BudgetRequestService so both gates use one rule.
+"""
+
+from __future__ import annotations
+
+from core.admin_utils import is_org_admin
+
+
+def budget_request_organization(budget_request):
+    """Resolve the org that owns this request (via budget_pool → project)."""
+    if budget_request is None:
+        return None
+    try:
+        return budget_request.budget_pool.project.organization
+    except Exception:
+        return None
+
+
+def user_is_org_admin_for_budget_request(user, budget_request) -> bool:
+    """True when user is org-admin of the same org as the budget request."""
+    if user is None or budget_request is None:
+        return False
+    if not is_org_admin(user):
+        return False
+
+    request_org = budget_request_organization(budget_request)
+    if request_org is None:
+        return False
+
+    user_org = getattr(user, 'current_organization', None) or getattr(user, 'organization', None)
+    if user_org is None:
+        return False
+
+    return user_org.id == request_org.id
+
+
+def user_may_process_budget_approval(user, budget_request) -> bool:
+    """Superuser, current chain approver, or same-org org-admin (MED-240)."""
+    if user is None or budget_request is None:
+        return False
+
+    if getattr(user, 'is_superuser', False):
+        return True
+
+    if budget_request.current_approver_id is not None and budget_request.current_approver_id == getattr(user, 'id', None):
+        return True
+
+    return user_is_org_admin_for_budget_request(user, budget_request)

--- a/backend/budget_approval/approver_access.py
+++ b/backend/budget_approval/approver_access.py
@@ -1,6 +1,10 @@
 """Who may approve/reject a budget request (chain approver vs org-admin override).
 
 Shared by DRF permissions and BudgetRequestService so both gates use one rule.
+
+MED-240 enforcement lives only on the backend. The UI (FSMActionBar Approve/Reject)
+is a convenience: hiding or showing buttons must never be treated as authorization.
+Org is resolved from budget_pool → project → organization, never from the client.
 """
 
 from __future__ import annotations
@@ -41,7 +45,11 @@ def user_is_org_admin_for_budget_request(user, budget_request) -> bool:
 
 
 def user_may_process_budget_approval(user, budget_request) -> bool:
-    """Superuser, current chain approver, or same-org org-admin (MED-240)."""
+    """Backend-only gate: superuser, current chain approver, or same-org org-admin.
+
+    Callers (ApprovalPermission, BudgetRequestService, TaskAPI.make_approval) must
+    use this helper. Frontend `is_org_admin` only controls button visibility.
+    """
     if user is None or budget_request is None:
         return False
 
@@ -55,7 +63,11 @@ def user_may_process_budget_approval(user, budget_request) -> bool:
 
 
 def is_org_admin_override_action(user, budget_request) -> bool:
-    """True when a same-org org-admin acts while not the assigned chain approver."""
+    """True when a same-org org-admin acts while not the assigned chain approver.
+
+    If the org-admin *is* the current chain approver, this is a normal approval
+    (no override marker, `is_admin_override` stays false).
+    """
     if user is None or budget_request is None:
         return False
     if budget_request.current_approver_id == getattr(user, 'id', None):

--- a/backend/budget_approval/approver_access.py
+++ b/backend/budget_approval/approver_access.py
@@ -7,6 +7,10 @@ from __future__ import annotations
 
 from core.admin_utils import is_org_admin
 
+# Prefixed on ApprovalRecord.comment / BudgetRequest.notes so override is
+# detectable without a new DB column (MED-240: migrations = no).
+ORG_ADMIN_OVERRIDE_PREFIX = "[ORG_ADMIN_OVERRIDE]"
+
 
 def budget_request_organization(budget_request):
     """Resolve the org that owns this request (via budget_pool → project)."""
@@ -48,3 +52,30 @@ def user_may_process_budget_approval(user, budget_request) -> bool:
         return True
 
     return user_is_org_admin_for_budget_request(user, budget_request)
+
+
+def is_org_admin_override_action(user, budget_request) -> bool:
+    """True when a same-org org-admin acts while not the assigned chain approver."""
+    if user is None or budget_request is None:
+        return False
+    if budget_request.current_approver_id == getattr(user, 'id', None):
+        return False
+    return user_is_org_admin_for_budget_request(user, budget_request)
+
+
+def budget_request_has_admin_override(budget_request) -> bool:
+    """Whether this request was decided via an org-admin override (audit marker)."""
+    if budget_request is None:
+        return False
+
+    notes = budget_request.notes or ""
+    if ORG_ADMIN_OVERRIDE_PREFIX in notes:
+        return True
+
+    task = getattr(budget_request, 'task', None)
+    if task is None:
+        return False
+
+    return task.approval_records.filter(
+        comment__startswith=ORG_ADMIN_OVERRIDE_PREFIX
+    ).exists()

--- a/backend/budget_approval/approver_access.py
+++ b/backend/budget_approval/approver_access.py
@@ -9,11 +9,18 @@ Org is resolved from budget_pool → project → organization, never from the cl
 
 from __future__ import annotations
 
+import re
+from typing import Optional
+
 from core.admin_utils import is_org_admin
 
 # Prefixed on ApprovalRecord.comment / BudgetRequest.notes so override is
 # detectable without a new DB column (MED-240: migrations = no).
 ORG_ADMIN_OVERRIDE_PREFIX = "[ORG_ADMIN_OVERRIDE]"
+ORG_ADMIN_OVERRIDE_TYPE = "org_admin"
+
+# Machine-readable kv on the marker line, e.g. user_id=9 decision=approve
+_MARKER_KV_RE = re.compile(r"(\w+)=(\S+)")
 
 
 def budget_request_organization(budget_request):
@@ -75,19 +82,141 @@ def is_org_admin_override_action(user, budget_request) -> bool:
     return user_is_org_admin_for_budget_request(user, budget_request)
 
 
+def format_org_admin_override_marker(
+    *,
+    user_id,
+    decision: str,
+    replaced_step=None,
+    timestamp: Optional[str] = None,
+) -> str:
+    """Build the notes/comment marker line (no new DB column)."""
+    parts = [
+        ORG_ADMIN_OVERRIDE_PREFIX,
+        f"user_id={user_id}",
+        f"decision={decision}",
+    ]
+    if replaced_step is not None:
+        parts.append(f"replaced_step={replaced_step}")
+    if timestamp:
+        parts.append(f"ts={timestamp}")
+    return " ".join(parts)
+
+
+def parse_org_admin_override_marker(text: Optional[str]) -> Optional[dict]:
+    """Parse the last `[ORG_ADMIN_OVERRIDE]` line into structured audit fields.
+
+    Missing keys (legacy markers without replaced_step/ts) come back as None.
+    """
+    if not text or ORG_ADMIN_OVERRIDE_PREFIX not in text:
+        return None
+
+    line = None
+    for raw in str(text).splitlines():
+        if ORG_ADMIN_OVERRIDE_PREFIX in raw:
+            line = raw
+    if line is None:
+        line = str(text)
+
+    kv = dict(_MARKER_KV_RE.findall(line))
+    decision = kv.get("decision")
+    if decision not in ("approve", "reject"):
+        decision = None
+
+    return {
+        "override_by_user_id": _int_or_none(kv.get("user_id")),
+        "override_type": ORG_ADMIN_OVERRIDE_TYPE,
+        "replaced_step": _int_or_none(kv.get("replaced_step")),
+        "override_timestamp": kv.get("ts") or None,
+        "final_outcome": decision,
+    }
+
+
+def infer_replaced_step(budget_request):
+    """Chain step the org-admin replaced.
+
+    Prefer a marker already written on an ApprovalRecord (make_approval writes
+    it before advancing the chain). Otherwise use the task's current step.
+    """
+    task = getattr(budget_request, "task", None)
+    if task is None:
+        return None
+
+    rec = (
+        task.approval_records.filter(comment__startswith=ORG_ADMIN_OVERRIDE_PREFIX)
+        .order_by("-id")
+        .first()
+    )
+    if rec is not None:
+        parsed = parse_org_admin_override_marker(rec.comment or "")
+        if parsed and parsed.get("replaced_step") is not None:
+            return parsed["replaced_step"]
+
+    return getattr(task, "current_approval_step", None)
+
+
 def budget_request_has_admin_override(budget_request) -> bool:
     """Whether this request was decided via an org-admin override (audit marker)."""
+    return budget_request_admin_override(budget_request) is not None
+
+
+def budget_request_admin_override(budget_request) -> Optional[dict]:
+    """Structured override audit for the API, or None when this was a chain decision.
+
+    Assembled from notes + ApprovalRecord so we do not need a migration.
+    """
     if budget_request is None:
-        return False
+        return None
 
     notes = budget_request.notes or ""
-    if ORG_ADMIN_OVERRIDE_PREFIX in notes:
-        return True
+    parsed = parse_org_admin_override_marker(notes)
 
-    task = getattr(budget_request, 'task', None)
-    if task is None:
-        return False
+    rec = None
+    task = getattr(budget_request, "task", None)
+    if task is not None:
+        rec = (
+            task.approval_records.filter(comment__startswith=ORG_ADMIN_OVERRIDE_PREFIX)
+            .order_by("-decided_time", "-id")
+            .first()
+        )
 
-    return task.approval_records.filter(
-        comment__startswith=ORG_ADMIN_OVERRIDE_PREFIX
-    ).exists()
+    if parsed is None and rec is None:
+        return None
+    if parsed is None and rec is not None:
+        if ORG_ADMIN_OVERRIDE_PREFIX not in (rec.comment or ""):
+            return None
+
+    payload = {
+        "override_by_user_id": None,
+        "override_type": ORG_ADMIN_OVERRIDE_TYPE,
+        "replaced_step": None,
+        "override_timestamp": None,
+        "final_outcome": None,
+    }
+
+    for source in (parsed, parse_org_admin_override_marker(rec.comment if rec else None)):
+        if not source:
+            continue
+        for key, value in source.items():
+            if value is not None:
+                payload[key] = value
+
+    if rec is not None:
+        if payload["override_by_user_id"] is None:
+            payload["override_by_user_id"] = rec.approved_by_id
+        if payload["final_outcome"] is None:
+            payload["final_outcome"] = "approve" if rec.is_approved else "reject"
+        if payload["override_timestamp"] is None and rec.decided_time is not None:
+            payload["override_timestamp"] = rec.decided_time.isoformat()
+        if payload["replaced_step"] is None:
+            payload["replaced_step"] = rec.step_number
+
+    return payload
+
+
+def _int_or_none(value):
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/backend/budget_approval/exceptions.py
+++ b/backend/budget_approval/exceptions.py
@@ -1,0 +1,16 @@
+"""Domain errors for budget approval (mapped to HTTP in views)."""
+
+
+class ApprovalConflict(Exception):
+    """Another actor already decided this step.
+
+    Views should return HTTP 409 so the client refreshes, matching
+    TaskAPI.make_approval. Distinct from ValidationError (HTTP 400).
+    """
+
+    default_message = (
+        "This budget request has already been decided by another approver."
+    )
+
+    def __init__(self, message=None):
+        super().__init__(message or self.default_message)

--- a/backend/budget_approval/permissions.py
+++ b/backend/budget_approval/permissions.py
@@ -2,6 +2,11 @@ from rest_framework import permissions
 from django.conf import settings
 import logging
 from .models import BudgetRequestStatus
+from .approver_access import (
+    user_is_org_admin_for_budget_request,
+    user_may_process_budget_approval,
+)
+from core.admin_utils import is_org_admin
 from utils.rbac_utils import has_rbac_permission, require_user_context, user_has_team
 
 class BudgetRequestPermission(permissions.BasePermission):
@@ -121,6 +126,11 @@ class ApprovalPermission(permissions.BasePermission):
         # if user has team, must have x-team-id
         if not require_user_context(request, user_has_team(request.user)):
             return False
+
+        # MED-240: org-admin may reach the decision endpoint without APPROVE RBAC.
+        # Object-level check still enforces same-org + override rules.
+        if is_org_admin(request.user) or getattr(request, 'is_org_admin', False):
+            return True
         
         # Get team_id if user has team
         team_id = request.headers.get('x-team-id') if user_has_team(request.user) else None
@@ -140,10 +150,14 @@ class ApprovalPermission(permissions.BasePermission):
         # Super admin bypass all object permission checks
         if request.user.is_superuser:
             return True
-            
-        # Only the current approver can make a decision
-        if obj.current_approver != request.user:
+
+        # MED-240: chain approver OR same-org org-admin override
+        if not user_may_process_budget_approval(request.user, obj):
             return False
+
+        # Org-admin override does not require BUDGET_REQUEST.APPROVE RBAC
+        if user_is_org_admin_for_budget_request(request.user, obj):
+            return True
         
         # Get team_id if user has team
         team_id = request.headers.get('x-team-id') if user_has_team(request.user) else None
@@ -160,7 +174,7 @@ class ApprovalPermission(permissions.BasePermission):
         if organization is None:
             organization = getattr(request.user, 'organization', None)
 
-        # Check if the user has approval permission with organization check
+        # Chain approver still needs APPROVE RBAC
         return has_rbac_permission(request.user, 'BUDGET_REQUEST', 'APPROVE', organization, team_id)
 
 

--- a/backend/budget_approval/permissions.py
+++ b/backend/budget_approval/permissions.py
@@ -109,7 +109,11 @@ class BudgetRequestPermission(permissions.BasePermission):
 
 
 class ApprovalPermission(permissions.BasePermission):
-    """Permissions to approve or reject budget requests"""
+    """Permissions to approve or reject budget requests.
+
+    This class (plus BudgetRequestService / make_approval) is the authorization
+    gate. Frontend Approve/Reject visibility is not a security boundary.
+    """
     
     def has_permission(self, request, view):
         """Check if the user has permission to access the decision API"""

--- a/backend/budget_approval/serializers.py
+++ b/backend/budget_approval/serializers.py
@@ -17,6 +17,7 @@ class BudgetRequestSerializer(serializers.ModelSerializer):
     status = serializers.ReadOnlyField()
     submitted_at = serializers.ReadOnlyField()
     is_escalated = serializers.SerializerMethodField()
+    is_admin_override = serializers.SerializerMethodField()
     budget_pool_id = serializers.IntegerField(write_only=True, required=False, allow_null=True)
     budget_pool = serializers.SerializerMethodField()
     current_approver = serializers.PrimaryKeyRelatedField(queryset=User.objects.all(), required=False, allow_null=True)
@@ -28,10 +29,13 @@ class BudgetRequestSerializer(serializers.ModelSerializer):
         model = BudgetRequest
         fields = [
             'id', 'task', 'requested_by', 'amount', 'currency', 'status',
-            'submitted_at', 'is_escalated', 'budget_pool', 'budget_pool_id',
+            'submitted_at', 'is_escalated', 'is_admin_override', 'budget_pool', 'budget_pool_id',
             'notes', 'current_approver', 'current_approver_name', 'ad_channel', 'ad_channel_name',
         ]
-        read_only_fields = ['id', 'requested_by', 'status', 'submitted_at', 'is_escalated', 'budget_pool']
+        read_only_fields = [
+            'id', 'requested_by', 'status', 'submitted_at', 'is_escalated',
+            'is_admin_override', 'budget_pool',
+        ]
 
     def get_requested_by(self, obj):
         u = obj.requested_by
@@ -41,6 +45,10 @@ class BudgetRequestSerializer(serializers.ModelSerializer):
 
     def get_is_escalated(self, obj):
         return obj.is_escalated
+
+    def get_is_admin_override(self, obj):
+        from .approver_access import budget_request_has_admin_override
+        return budget_request_has_admin_override(obj)
 
     def get_budget_pool(self, obj):
         p = obj.budget_pool

--- a/backend/budget_approval/serializers.py
+++ b/backend/budget_approval/serializers.py
@@ -18,6 +18,7 @@ class BudgetRequestSerializer(serializers.ModelSerializer):
     submitted_at = serializers.ReadOnlyField()
     is_escalated = serializers.SerializerMethodField()
     is_admin_override = serializers.SerializerMethodField()
+    admin_override = serializers.SerializerMethodField()
     budget_pool_id = serializers.IntegerField(write_only=True, required=False, allow_null=True)
     budget_pool = serializers.SerializerMethodField()
     current_approver = serializers.PrimaryKeyRelatedField(queryset=User.objects.all(), required=False, allow_null=True)
@@ -29,12 +30,13 @@ class BudgetRequestSerializer(serializers.ModelSerializer):
         model = BudgetRequest
         fields = [
             'id', 'task', 'requested_by', 'amount', 'currency', 'status',
-            'submitted_at', 'is_escalated', 'is_admin_override', 'budget_pool', 'budget_pool_id',
+            'submitted_at', 'is_escalated', 'is_admin_override', 'admin_override',
+            'budget_pool', 'budget_pool_id',
             'notes', 'current_approver', 'current_approver_name', 'ad_channel', 'ad_channel_name',
         ]
         read_only_fields = [
             'id', 'requested_by', 'status', 'submitted_at', 'is_escalated',
-            'is_admin_override', 'budget_pool',
+            'is_admin_override', 'admin_override', 'budget_pool',
         ]
 
     def get_requested_by(self, obj):
@@ -49,6 +51,10 @@ class BudgetRequestSerializer(serializers.ModelSerializer):
     def get_is_admin_override(self, obj):
         from .approver_access import budget_request_has_admin_override
         return budget_request_has_admin_override(obj)
+
+    def get_admin_override(self, obj):
+        from .approver_access import budget_request_admin_override
+        return budget_request_admin_override(obj)
 
     def get_budget_pool(self, obj):
         p = obj.budget_pool

--- a/backend/budget_approval/services.py
+++ b/backend/budget_approval/services.py
@@ -3,7 +3,8 @@ from django.db import transaction, OperationalError
 from django.db.models import Max
 from .models import BudgetRequest, BudgetPool, BudgetEscalationRule, BudgetRequestStatus
 from .approver_access import (
-    ORG_ADMIN_OVERRIDE_PREFIX,
+    format_org_admin_override_marker,
+    infer_replaced_step,
     is_org_admin_override_action,
     user_may_process_budget_approval,
 )
@@ -45,16 +46,26 @@ class BudgetRequestService:
         return budget_pool.available_amount >= amount
     
     @staticmethod
-    def _write_org_admin_override_audit(budget_request, approver, is_approved, comment):
+    def _write_org_admin_override_audit(
+        budget_request, approver, is_approved, comment, replaced_step=None
+    ):
         """Persist override audit without a new migration (ApprovalRecord + notes marker)."""
+        from django.utils import timezone
         from task.models import ApprovalRecord
 
-        user_comment = (comment or "").strip()
-        audit_comment = (
-            f"{ORG_ADMIN_OVERRIDE_PREFIX} {user_comment}".strip()
-            if user_comment
-            else ORG_ADMIN_OVERRIDE_PREFIX
+        decision = 'approve' if is_approved else 'reject'
+        if replaced_step is None:
+            replaced_step = infer_replaced_step(budget_request)
+        timestamp = timezone.now().isoformat()
+        marker = format_org_admin_override_marker(
+            user_id=approver.id,
+            decision=decision,
+            replaced_step=replaced_step,
+            timestamp=timestamp,
         )
+
+        user_comment = (comment or "").strip()
+        audit_comment = f"{marker} {user_comment}".strip() if user_comment else marker
 
         task = budget_request.task
         if task is not None:
@@ -69,14 +80,10 @@ class BudgetRequestService:
             )
 
         # Notes marker keeps override discoverable on BudgetRequest itself (and
-        # covers requests with no linked task).
-        decision = 'approve' if is_approved else 'reject'
-        line = (
-            f"{ORG_ADMIN_OVERRIDE_PREFIX} user_id={approver.id} "
-            f"decision={decision}"
-        )
+        # covers requests with no linked task). Includes replaced_step so GET
+        # can return structured audit without a new column.
         existing = (budget_request.notes or "").strip()
-        budget_request.notes = f"{existing}\n{line}".strip() if existing else line
+        budget_request.notes = f"{existing}\n{marker}".strip() if existing else marker
         budget_request.save(update_fields=['notes'])
 
     @staticmethod
@@ -213,6 +220,8 @@ class BudgetRequestService:
 
         # Capture before mutation: override = org-admin acting outside the chain
         is_override = is_org_admin_override_action(approver, budget_request)
+        # Record the replaced chain step before we advance current_approval_step.
+        replaced_step = infer_replaced_step(budget_request) if is_override else None
 
         # MED-240: org-admin replaces the current step only. Next person comes from
         # the original ApprovalChain (not a client-supplied next_approver).
@@ -278,6 +287,7 @@ class BudgetRequestService:
                     approver=approver,
                     is_approved=is_approved,
                     comment=comment,
+                    replaced_step=replaced_step,
                 )
 
             return locked_request

--- a/backend/budget_approval/services.py
+++ b/backend/budget_approval/services.py
@@ -203,7 +203,8 @@ class BudgetRequestService:
             to ensure consistency with the database state after the atomic transaction.
             The original object's ID remains unchanged - only the Python object reference changes.
         """
-        # Chain approver, superuser, or same-org org-admin override (MED-240)
+        # Backend is the only enforcement (UI buttons are not authorization).
+        # Chain approver, superuser, or same-org org-admin override (MED-240).
         if not user_may_process_budget_approval(approver, budget_request):
             raise ValidationError("Only the assigned approver can process this request")
         

--- a/backend/budget_approval/services.py
+++ b/backend/budget_approval/services.py
@@ -1,6 +1,7 @@
 from django.core.exceptions import ValidationError
 from django.db import transaction, OperationalError
 from .models import BudgetRequest, BudgetPool, BudgetEscalationRule, BudgetRequestStatus
+from .approver_access import user_may_process_budget_approval
 from .tasks import trigger_escalation
 from . import notifications as budget_notifications
 from core.models import AdChannel
@@ -130,8 +131,8 @@ class BudgetRequestService:
             to ensure consistency with the database state after the atomic transaction.
             The original object's ID remains unchanged - only the Python object reference changes.
         """
-        # Check if current approver matches (super admin can bypass this check)
-        if not approver.is_superuser and budget_request.current_approver != approver:
+        # Chain approver, superuser, or same-org org-admin override (MED-240)
+        if not user_may_process_budget_approval(approver, budget_request):
             raise ValidationError("Only the assigned approver can process this request")
         
         if not budget_request.can_approve() and not budget_request.can_reject():

--- a/backend/budget_approval/services.py
+++ b/backend/budget_approval/services.py
@@ -1,7 +1,12 @@
 from django.core.exceptions import ValidationError
 from django.db import transaction, OperationalError
+from django.db.models import Max
 from .models import BudgetRequest, BudgetPool, BudgetEscalationRule, BudgetRequestStatus
-from .approver_access import user_may_process_budget_approval
+from .approver_access import (
+    ORG_ADMIN_OVERRIDE_PREFIX,
+    is_org_admin_override_action,
+    user_may_process_budget_approval,
+)
 from .tasks import trigger_escalation
 from . import notifications as budget_notifications
 from core.models import AdChannel
@@ -39,6 +44,41 @@ class BudgetRequestService:
         """Check if budget pool has sufficient available amount"""
         return budget_pool.available_amount >= amount
     
+    @staticmethod
+    def _write_org_admin_override_audit(budget_request, approver, is_approved, comment):
+        """Persist override audit without a new migration (ApprovalRecord + notes marker)."""
+        from task.models import ApprovalRecord
+
+        user_comment = (comment or "").strip()
+        audit_comment = (
+            f"{ORG_ADMIN_OVERRIDE_PREFIX} {user_comment}".strip()
+            if user_comment
+            else ORG_ADMIN_OVERRIDE_PREFIX
+        )
+
+        task = budget_request.task
+        if task is not None:
+            last_step = task.approval_records.aggregate(m=Max('step_number'))['m'] or 0
+            ApprovalRecord.objects.create(
+                task=task,
+                approved_by=approver,
+                is_approved=is_approved,
+                comment=audit_comment,
+                step_number=last_step + 1,
+                revision_round=getattr(task, 'revision_round', 0) or 0,
+            )
+
+        # Notes marker keeps override discoverable on BudgetRequest itself (and
+        # covers requests with no linked task).
+        decision = 'approve' if is_approved else 'reject'
+        line = (
+            f"{ORG_ADMIN_OVERRIDE_PREFIX} user_id={approver.id} "
+            f"decision={decision}"
+        )
+        existing = (budget_request.notes or "").strip()
+        budget_request.notes = f"{existing}\n{line}".strip() if existing else line
+        budget_request.save(update_fields=['notes'])
+
     @staticmethod
     def check_escalation_rules(budget_request):
         """Check if budget request should be escalated based on rules"""
@@ -137,6 +177,9 @@ class BudgetRequestService:
         
         if not budget_request.can_approve() and not budget_request.can_reject():
             raise ValidationError("Budget request cannot be processed in current status")
+
+        # Capture before mutation: override = org-admin acting outside the chain
+        is_override = is_org_admin_override_action(approver, budget_request)
         
         with transaction.atomic():
             # Lock the budget request for update to ensure atomic state transition
@@ -179,6 +222,14 @@ class BudgetRequestService:
                     locked_request,
                     actor_id=approver.id if approver else None,
                     comment=comment or "",
+                )
+
+            if is_override:
+                BudgetRequestService._write_org_admin_override_audit(
+                    locked_request,
+                    approver=approver,
+                    is_approved=is_approved,
+                    comment=comment,
                 )
 
             return locked_request

--- a/backend/budget_approval/services.py
+++ b/backend/budget_approval/services.py
@@ -80,6 +80,38 @@ class BudgetRequestService:
         budget_request.save(update_fields=['notes'])
 
     @staticmethod
+    def _resolve_next_from_approval_chain(budget_request):
+        """Next chain step after the task's current step, or None (legacy / last step).
+
+        Org-admin override must continue the *original* ApprovalChain — the admin
+        does not pick the next approver. Returns (approver_user, next_step_number).
+        """
+        task = getattr(budget_request, 'task', None)
+        if task is None or not getattr(task, 'approval_chain_id', None):
+            return None, None
+
+        chain = task.approval_chain
+        if chain is None:
+            return None, None
+
+        current_step = task.current_approval_step or 1
+        next_step_num = current_step + 1
+        next_step = chain.get_step(next_step_num)
+        if next_step is None:
+            return None, None
+        return next_step.approver, next_step_num
+
+    @staticmethod
+    def _sync_task_chain_advance(budget_request, next_approver, next_step_num):
+        """Keep linked Task chain pointer in sync when BudgetRequest advances."""
+        task = getattr(budget_request, 'task', None)
+        if task is None or next_approver is None or next_step_num is None:
+            return
+        task.current_approver = next_approver
+        task.current_approval_step = next_step_num
+        task.save(update_fields=['current_approver', 'current_approval_step'])
+
+    @staticmethod
     def check_escalation_rules(budget_request):
         """Check if budget request should be escalated based on rules"""
         escalation_rules = BudgetEscalationRule.objects.filter(
@@ -180,6 +212,17 @@ class BudgetRequestService:
 
         # Capture before mutation: override = org-admin acting outside the chain
         is_override = is_org_admin_override_action(approver, budget_request)
+
+        # MED-240: org-admin replaces the current step only. Next person comes from
+        # the original ApprovalChain (not a client-supplied next_approver).
+        # Legacy / no remaining steps → finalize (effective_next stays None).
+        if is_override and is_approved:
+            effective_next, next_step_num = (
+                BudgetRequestService._resolve_next_from_approval_chain(budget_request)
+            )
+        else:
+            effective_next = next_approver
+            next_step_num = None
         
         with transaction.atomic():
             # Lock the budget request for update to ensure atomic state transition
@@ -196,14 +239,18 @@ class BudgetRequestService:
                 locked_request.save()
 
                 # status: APPROVED --> UNDER_REVIEW (multi-step chain)
-                if next_approver:
+                if effective_next:
                     locked_request.forward_to_next()
-                    locked_request.current_approver = next_approver
+                    locked_request.current_approver = effective_next
                     locked_request.save()
+                    if is_override and next_step_num is not None:
+                        BudgetRequestService._sync_task_chain_advance(
+                            locked_request, effective_next, next_step_num
+                        )
                     budget_notifications.notify_budget_forwarded(
                         locked_request,
                         actor_id=approver.id if approver else None,
-                        next_approver_id=next_approver.id,
+                        next_approver_id=effective_next.id,
                     )
                 else:
                     budget_notifications.notify_budget_approved(

--- a/backend/budget_approval/services.py
+++ b/backend/budget_approval/services.py
@@ -2,6 +2,7 @@ from django.core.exceptions import ValidationError
 from django.db import transaction, OperationalError
 from django.db.models import Max
 from .models import BudgetRequest, BudgetPool, BudgetEscalationRule, BudgetRequestStatus
+from .exceptions import ApprovalConflict
 from .approver_access import (
     format_org_admin_override_marker,
     infer_replaced_step,
@@ -188,7 +189,39 @@ class BudgetRequestService:
                 trigger_escalation.delay(budget_request.id)
             
             return budget_request
-    
+
+    _DECIDED_STATUSES = (
+        BudgetRequestStatus.APPROVED,
+        BudgetRequestStatus.REJECTED,
+        BudgetRequestStatus.LOCKED,
+        BudgetRequestStatus.CANCELLED,
+    )
+
+    @staticmethod
+    def _raise_if_not_processable(budget_request):
+        """409 if another actor already decided; 400 if the status is not reviewable."""
+        if budget_request.status in BudgetRequestService._DECIDED_STATUSES:
+            raise ApprovalConflict()
+        if not budget_request.can_approve() and not budget_request.can_reject():
+            raise ValidationError("Budget request cannot be processed in current status")
+
+    @staticmethod
+    def _raise_if_step_moved(locked_request, approver, *, is_override, expected_approver_id):
+        """Under lock: this actor must still be acting on the same chain step.
+
+        After an override (or chain approve) forwards to the next person, status
+        is UNDER_REVIEW again. Without this check the loser of the race would
+        approve the *next* step.
+        """
+        if getattr(approver, 'is_superuser', False):
+            return
+        if is_override:
+            if locked_request.current_approver_id != expected_approver_id:
+                raise ApprovalConflict()
+            return
+        if locked_request.current_approver_id != approver.id:
+            raise ApprovalConflict()
+
     @staticmethod
     def process_approval(budget_request, approver, is_approved, comment, next_approver=None):
         """Process approval or rejection of a budget request
@@ -214,13 +247,13 @@ class BudgetRequestService:
         # Chain approver, superuser, or same-org org-admin override (MED-240).
         if not user_may_process_budget_approval(approver, budget_request):
             raise ValidationError("Only the assigned approver can process this request")
-        
-        if not budget_request.can_approve() and not budget_request.can_reject():
-            raise ValidationError("Budget request cannot be processed in current status")
 
-        # Capture before mutation: override = org-admin acting outside the chain
+        BudgetRequestService._raise_if_not_processable(budget_request)
+
+        # Capture before mutation: override = org-admin acting outside the chain.
+        # These snapshots are what the actor intended to act on; re-checked under lock.
         is_override = is_org_admin_override_action(approver, budget_request)
-        # Record the replaced chain step before we advance current_approval_step.
+        expected_approver_id = budget_request.current_approver_id
         replaced_step = infer_replaced_step(budget_request) if is_override else None
 
         # MED-240: org-admin replaces the current step only. Next person comes from
@@ -237,10 +270,15 @@ class BudgetRequestService:
         with transaction.atomic():
             # Lock the budget request for update to ensure atomic state transition
             locked_request = BudgetRequest.objects.select_for_update().get(id=budget_request.id)
-            
-            # Re-check if the request can still be processed (status might have changed)
-            if not locked_request.can_approve() and not locked_request.can_reject():
-                raise ValidationError("Budget request cannot be processed in current status")
+
+            # Re-read under lock: status and current step may have changed while we waited.
+            BudgetRequestService._raise_if_not_processable(locked_request)
+            BudgetRequestService._raise_if_step_moved(
+                locked_request,
+                approver,
+                is_override=is_override,
+                expected_approver_id=expected_approver_id,
+            )
             
             
             # status: UNDER_REVIEW --> APPROVED

--- a/backend/budget_approval/tests/conftest.py
+++ b/backend/budget_approval/tests/conftest.py
@@ -255,6 +255,27 @@ def superuser(db):
 
 
 @pytest.fixture
+def org_admin(organization, tenant_schema):
+    """Org admin in the same org, but NOT the chain approver (MED-240).
+
+    Uses assign_org_admin() so is_org_admin() returns True. Sets
+    current_organization because is_org_admin checks that field first.
+    """
+    from core.admin_utils import assign_org_admin
+
+    uid = uuid.uuid4().hex[:8]
+    user = User.objects.create_user(
+        username=f'orgadmin_{uid}',
+        email=f'orgadmin_{uid}@test.com',
+        password='testpass123',
+        organization=organization,
+        current_organization=organization,
+    )
+    assign_org_admin(user, organization)
+    return user
+
+
+@pytest.fixture
 def different_organization(db):
     """Create a different organization for cross-org testing"""
     return Organization.objects.create(

--- a/backend/budget_approval/tests/test_approver_access.py
+++ b/backend/budget_approval/tests/test_approver_access.py
@@ -1,0 +1,51 @@
+"""Unit tests for org-admin override marker format/parse (no DB)."""
+from budget_approval.approver_access import (
+    ORG_ADMIN_OVERRIDE_PREFIX,
+    format_org_admin_override_marker,
+    parse_org_admin_override_marker,
+)
+
+
+class TestOverrideMarkerRoundTrip:
+    def test_format_includes_replaced_step_and_timestamp(self):
+        line = format_org_admin_override_marker(
+            user_id=9,
+            decision="approve",
+            replaced_step=1,
+            timestamp="2026-08-12T11:04:35+00:00",
+        )
+        assert line.startswith(ORG_ADMIN_OVERRIDE_PREFIX)
+        parsed = parse_org_admin_override_marker(line)
+        assert parsed == {
+            "override_by_user_id": 9,
+            "override_type": "org_admin",
+            "replaced_step": 1,
+            "override_timestamp": "2026-08-12T11:04:35+00:00",
+            "final_outcome": "approve",
+        }
+
+    def test_legacy_marker_without_replaced_step_still_parses(self):
+        legacy = f"{ORG_ADMIN_OVERRIDE_PREFIX} user_id=9 decision=reject"
+        parsed = parse_org_admin_override_marker(legacy)
+        assert parsed["override_by_user_id"] == 9
+        assert parsed["final_outcome"] == "reject"
+        assert parsed["replaced_step"] is None
+        assert parsed["override_timestamp"] is None
+
+    def test_parses_last_marker_line_in_notes(self):
+        notes = "\n".join(
+            [
+                "Please prioritize",
+                f"{ORG_ADMIN_OVERRIDE_PREFIX} user_id=1 decision=approve replaced_step=1",
+                f"{ORG_ADMIN_OVERRIDE_PREFIX} user_id=9 decision=reject replaced_step=2",
+            ]
+        )
+        parsed = parse_org_admin_override_marker(notes)
+        assert parsed["override_by_user_id"] == 9
+        assert parsed["final_outcome"] == "reject"
+        assert parsed["replaced_step"] == 2
+
+    def test_returns_none_when_no_marker(self):
+        assert parse_org_admin_override_marker("just a note") is None
+        assert parse_org_admin_override_marker("") is None
+        assert parse_org_admin_override_marker(None) is None

--- a/backend/budget_approval/tests/test_override_race.py
+++ b/backend/budget_approval/tests/test_override_race.py
@@ -1,0 +1,222 @@
+"""
+MED-240: org-admin override vs chain approver must serialize on one step.
+
+Two actors clicking approve at once must not let the loser stamp the *next*
+chain step. PostgreSQL SELECT FOR UPDATE is required; skipped on SQLite.
+"""
+import threading
+
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.db import connection, connections
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from budget_approval.exceptions import ApprovalConflict
+from budget_approval.models import BudgetRequest, BudgetRequestStatus
+from budget_approval.services import BudgetRequestService
+from core.services.tenant import slug_to_schema_name
+from task.models import ApprovalChain, ApprovalChainStep, Task
+
+pytestmark = [
+    pytest.mark.django_db(transaction=True),
+    pytest.mark.skipif(
+        connection.vendor != 'postgresql',
+        reason='select_for_update row locking requires PostgreSQL (no-op on SQLite).',
+    ),
+]
+
+
+def _set_tenant_search_path(user):
+    schema = slug_to_schema_name(user.organization.slug)
+    with connection.cursor() as cursor:
+        cursor.execute(f'SET search_path TO {schema}, public')
+
+
+def _attach_two_step_chain(budget_request, project, user2, user3):
+    task = budget_request.task
+    chain = ApprovalChain.objects.create(
+        name='Step1 → Step2',
+        project=project,
+        task_type='budget',
+    )
+    ApprovalChainStep.objects.create(chain=chain, order=1, approver=user2)
+    ApprovalChainStep.objects.create(chain=chain, order=2, approver=user3)
+    task.approval_chain = chain
+    task.current_approval_step = 1
+    task.current_approver = user2
+    task.save(
+        update_fields=['approval_chain', 'current_approval_step', 'current_approver']
+    )
+    return task
+
+
+class TestOrgAdminOverrideRace:
+    """Org-admin and the assigned approver must not both win the same step."""
+
+    def test_concurrent_org_admin_and_approver_one_winner(
+        self, budget_request_under_review, org_admin, user2
+    ):
+        """Same step, no chain advance: one 200-equivalent, one ApprovalConflict."""
+        request_id = budget_request_under_review.id
+        barrier = threading.Barrier(2)
+        outcomes = []
+        lock = threading.Lock()
+
+        def _run(user_id, is_approved):
+            try:
+                User = get_user_model()
+                user = User.objects.get(id=user_id)
+                _set_tenant_search_path(user)
+                barrier.wait(timeout=5)
+                br = BudgetRequest.objects.get(id=request_id)
+                with patch('budget_approval.services.budget_notifications'):
+                    BudgetRequestService.process_approval(
+                        budget_request=br,
+                        approver=user,
+                        is_approved=is_approved,
+                        comment=f'race from {user_id}',
+                    )
+                with lock:
+                    outcomes.append(('ok', user_id))
+            except ApprovalConflict:
+                with lock:
+                    outcomes.append(('conflict', user_id))
+            except Exception as exc:
+                with lock:
+                    outcomes.append(('error', f'{user_id}:{exc}'))
+            finally:
+                connections.close_all()
+
+        threads = [
+            threading.Thread(target=_run, args=(org_admin.id, True)),
+            threading.Thread(target=_run, args=(user2.id, False)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=15)
+
+        kinds = [k for k, _ in outcomes]
+        assert kinds.count('ok') == 1, outcomes
+        assert kinds.count('conflict') == 1, outcomes
+        assert 'error' not in kinds, outcomes
+
+        final = BudgetRequest.objects.get(id=request_id)
+        assert final.status in (
+            BudgetRequestStatus.APPROVED,
+            BudgetRequestStatus.REJECTED,
+        )
+
+    def test_concurrent_override_does_not_let_step1_stamp_step2(
+        self, budget_request_under_review, org_admin, user2, user3, project
+    ):
+        """Override advances to step 2; late step-1 approver must not approve step 2."""
+        _attach_two_step_chain(budget_request_under_review, project, user2, user3)
+        request_id = budget_request_under_review.id
+        barrier = threading.Barrier(2)
+        outcomes = []
+        lock = threading.Lock()
+
+        def _run(user_id):
+            try:
+                User = get_user_model()
+                user = User.objects.get(id=user_id)
+                _set_tenant_search_path(user)
+                barrier.wait(timeout=5)
+                br = BudgetRequest.objects.get(id=request_id)
+                with patch('budget_approval.services.budget_notifications'):
+                    BudgetRequestService.process_approval(
+                        budget_request=br,
+                        approver=user,
+                        is_approved=True,
+                        comment=f'race from {user_id}',
+                    )
+                with lock:
+                    outcomes.append(('ok', user_id))
+            except ApprovalConflict:
+                with lock:
+                    outcomes.append(('conflict', user_id))
+            except Exception as exc:
+                with lock:
+                    outcomes.append(('error', f'{user_id}:{exc}'))
+            finally:
+                connections.close_all()
+
+        threads = [
+            threading.Thread(target=_run, args=(org_admin.id,)),
+            threading.Thread(target=_run, args=(user2.id,)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=15)
+
+        kinds = [k for k, _ in outcomes]
+        assert kinds.count('ok') == 1, outcomes
+        assert kinds.count('conflict') == 1, outcomes
+        assert 'error' not in kinds, outcomes
+
+        final = BudgetRequest.objects.get(id=request_id)
+        winner_id = next(uid for kind, uid in outcomes if kind == 'ok')
+        if winner_id == org_admin.id:
+            # Admin replaced step 1 and forwarded — step 2 still belongs to user3.
+            assert final.status == BudgetRequestStatus.UNDER_REVIEW
+            assert final.current_approver_id == user3.id
+        else:
+            # Chain approver won step 1 (no auto-forward without next_approver).
+            assert final.status == BudgetRequestStatus.APPROVED
+            assert final.current_approver_id == user2.id
+
+        task_row = Task.objects.filter(pk=budget_request_under_review.task_id).values(
+            'current_approver_id', 'current_approval_step'
+        ).get()
+        if winner_id == org_admin.id:
+            assert task_row['current_approver_id'] == user3.id
+            assert task_row['current_approval_step'] == 2
+
+    def test_decision_api_org_admin_vs_approver_returns_409(
+        self, budget_request_under_review, org_admin, user2, team, user_role2, role_permissions
+    ):
+        """HTTP: concurrent PATCH decision → one 200, one 409."""
+        url = reverse(
+            'budget-request-decision',
+            kwargs={'pk': budget_request_under_review.id},
+        )
+        barrier = threading.Barrier(2)
+        results = [None, None]
+
+        def _patch(index, user, role):
+            try:
+                _set_tenant_search_path(user)
+                barrier.wait(timeout=5)
+                client = APIClient()
+                client.force_authenticate(user=user)
+                client.credentials(
+                    HTTP_X_USER_ROLE=role,
+                    HTTP_X_ORGANIZATION_SLUG=team.organization.slug,
+                    HTTP_X_TEAM_ID=str(team.id),
+                )
+                response = client.patch(
+                    url,
+                    {'decision': 'approve', 'comment': f'from {user.id}'},
+                    format='json',
+                )
+                results[index] = response.status_code
+            finally:
+                connections.close_all()
+
+        threads = [
+            threading.Thread(target=_patch, args=(0, org_admin, 'org_admin')),
+            threading.Thread(target=_patch, args=(1, user2, 'team_leader')),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=15)
+
+        assert status.HTTP_200_OK in results, results
+        assert status.HTTP_409_CONFLICT in results, results

--- a/backend/budget_approval/tests/test_permissions.py
+++ b/backend/budget_approval/tests/test_permissions.py
@@ -221,6 +221,7 @@ class TestOrgAdminApprovalOverridePermissions:
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['status'] == BudgetRequestStatus.APPROVED
+        assert response.data['budget_request']['is_admin_override'] is True
 
     def test_org_admin_can_reject_outside_chain(
         self, api_client, org_admin, budget_request_under_review, team, user2
@@ -243,6 +244,7 @@ class TestOrgAdminApprovalOverridePermissions:
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['status'] == BudgetRequestStatus.REJECTED
+        assert response.data['budget_request']['is_admin_override'] is True
 
     def test_approval_permission_object_allows_org_admin(
         self, org_admin, budget_request_under_review, user2

--- a/backend/budget_approval/tests/test_permissions.py
+++ b/backend/budget_approval/tests/test_permissions.py
@@ -220,8 +220,7 @@ class TestOrgAdminApprovalOverridePermissions:
         )
 
         assert response.status_code == status.HTTP_200_OK
-        budget_request_under_review.refresh_from_db()
-        assert budget_request_under_review.status == BudgetRequestStatus.APPROVED
+        assert response.data['status'] == BudgetRequestStatus.APPROVED
 
     def test_org_admin_can_reject_outside_chain(
         self, api_client, org_admin, budget_request_under_review, team, user2
@@ -243,8 +242,7 @@ class TestOrgAdminApprovalOverridePermissions:
         )
 
         assert response.status_code == status.HTTP_200_OK
-        budget_request_under_review.refresh_from_db()
-        assert budget_request_under_review.status == BudgetRequestStatus.REJECTED
+        assert response.data['status'] == BudgetRequestStatus.REJECTED
 
     def test_approval_permission_object_allows_org_admin(
         self, org_admin, budget_request_under_review, user2

--- a/backend/budget_approval/tests/test_permissions.py
+++ b/backend/budget_approval/tests/test_permissions.py
@@ -199,6 +199,81 @@ class TestOrgAdminApprovalOverridePermissions:
       - superuser                  → already covered
     """
 
+    def test_org_admin_can_approve_via_task_make_approval(
+        self, api_client, org_admin, budget_request_under_review, team, user2, project
+    ):
+        """UI path: TaskAPI.makeApproval must allow same-org org-admin override (MED-240)."""
+        from core.models import ProjectMember
+        from django.contrib.contenttypes.models import ContentType
+        from budget_approval.approver_access import (
+            ORG_ADMIN_OVERRIDE_PREFIX,
+            budget_request_has_admin_override,
+        )
+        from budget_approval.models import BudgetRequest
+        from task.models import Task
+
+        br = budget_request_under_review
+        assert br.current_approver_id == user2.id
+        assert org_admin.id != user2.id
+
+        task = br.task
+        task.current_approver = user2
+        task.content_type = ContentType.objects.get_for_model(br)
+        task.object_id = br.id
+        task.save(update_fields=['current_approver', 'content_type', 'object_id'])
+        # FSM protected field — walk transitions instead of assigning status.
+        if task.status == Task.Status.DRAFT:
+            task.submit()
+            task.start_review()
+            task.save()
+        elif task.status == Task.Status.SUBMITTED:
+            task.start_review()
+            task.save()
+        assert task.status == Task.Status.UNDER_REVIEW
+
+        ProjectMember.objects.get_or_create(
+            user=org_admin,
+            project=project,
+            defaults={'is_active': True},
+        )
+
+        api_client.force_authenticate(user=org_admin)
+        api_client.credentials(
+            HTTP_X_USER_ROLE='org_admin',
+            HTTP_X_ORGANIZATION_SLUG=team.organization.slug,
+        )
+
+        url = reverse('task-make-approval', kwargs={'pk': task.slug})
+        response = api_client.post(
+            url,
+            {'action': 'approve', 'comment': 'Org-admin UI override'},
+            format='json',
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.data
+        # Task endpoint may leave search_path on the tenant schema used by middleware;
+        # assert from the response (and restore path before any ORM refresh).
+        assert response.data['task']['status'] in (
+            Task.Status.APPROVED,
+            Task.Status.UNDER_REVIEW,
+        )
+        assert ORG_ADMIN_OVERRIDE_PREFIX in (
+            response.data.get('approval_record', {}).get('comment') or ''
+        )
+        linked = response.data['task'].get('linked_object') or {}
+        assert linked.get('is_admin_override') is True
+
+        from django.db import connection
+        from core.services.tenant import slug_to_schema_name
+
+        schema = slug_to_schema_name(team.organization.slug)
+        with connection.cursor() as cursor:
+            cursor.execute(f'SET search_path TO {schema}, public')
+        # FSM protected status: refresh_from_db() setattr fails — re-fetch instead.
+        br = BudgetRequest.objects.get(pk=br.pk)
+        assert br.status == BudgetRequestStatus.APPROVED
+        assert budget_request_has_admin_override(br) is True
+
     def test_org_admin_can_approve_outside_chain(
         self, api_client, org_admin, budget_request_under_review, team, user2
     ):

--- a/backend/budget_approval/tests/test_permissions.py
+++ b/backend/budget_approval/tests/test_permissions.py
@@ -262,6 +262,12 @@ class TestOrgAdminApprovalOverridePermissions:
         )
         linked = response.data['task'].get('linked_object') or {}
         assert linked.get('is_admin_override') is True
+        audit = linked.get('admin_override') or {}
+        assert audit.get('override_by_user_id') == org_admin.id
+        assert audit.get('override_type') == 'org_admin'
+        assert audit.get('final_outcome') == 'approve'
+        assert audit.get('replaced_step') is not None
+        assert audit.get('override_timestamp')
 
         from django.db import connection
         from core.services.tenant import slug_to_schema_name
@@ -297,6 +303,55 @@ class TestOrgAdminApprovalOverridePermissions:
         assert response.status_code == status.HTTP_200_OK
         assert response.data['status'] == BudgetRequestStatus.APPROVED
         assert response.data['budget_request']['is_admin_override'] is True
+        audit = response.data['budget_request']['admin_override']
+        assert audit['override_by_user_id'] == org_admin.id
+        assert audit['override_type'] == 'org_admin'
+        assert audit['final_outcome'] == 'approve'
+        assert audit['override_timestamp']
+
+    def test_get_detail_after_override_returns_structured_admin_override(
+        self, api_client, org_admin, budget_request_under_review, team, user1, user2
+    ):
+        """PATCH decision then GET detail: structured audit is readable on the resource."""
+        task = budget_request_under_review.task
+        task.current_approval_step = 1
+        task.save(update_fields=['current_approval_step'])
+
+        api_client.force_authenticate(user=org_admin)
+        api_client.credentials(
+            HTTP_X_USER_ROLE='org_admin',
+            HTTP_X_ORGANIZATION_SLUG=team.organization.slug,
+        )
+        decision_url = reverse(
+            'budget-request-decision',
+            kwargs={'pk': budget_request_under_review.id},
+        )
+        decide = api_client.patch(
+            decision_url,
+            {'decision': 'approve', 'comment': 'Org-admin override'},
+            format='json',
+        )
+        assert decide.status_code == status.HTTP_200_OK, decide.data
+
+        api_client.force_authenticate(user=user1)
+        api_client.credentials(
+            HTTP_X_USER_ROLE='team_member',
+            HTTP_X_TEAM_ID=str(team.id),
+            HTTP_X_ORGANIZATION_SLUG=team.organization.slug,
+        )
+        detail_url = reverse(
+            'budget-request-detail',
+            kwargs={'pk': budget_request_under_review.id},
+        )
+        response = api_client.get(detail_url)
+        assert response.status_code == status.HTTP_200_OK, response.data
+        assert response.data['is_admin_override'] is True
+        audit = response.data['admin_override']
+        assert audit['override_by_user_id'] == org_admin.id
+        assert audit['override_type'] == 'org_admin'
+        assert audit['replaced_step'] == 1
+        assert audit['final_outcome'] == 'approve'
+        assert audit['override_timestamp']
 
     def test_org_admin_can_reject_outside_chain(
         self, api_client, org_admin, budget_request_under_review, team, user2
@@ -320,6 +375,9 @@ class TestOrgAdminApprovalOverridePermissions:
         assert response.status_code == status.HTTP_200_OK
         assert response.data['status'] == BudgetRequestStatus.REJECTED
         assert response.data['budget_request']['is_admin_override'] is True
+        audit = response.data['budget_request']['admin_override']
+        assert audit['override_by_user_id'] == org_admin.id
+        assert audit['final_outcome'] == 'reject'
 
     def test_approval_permission_object_allows_org_admin(
         self, org_admin, budget_request_under_review, user2
@@ -505,6 +563,7 @@ class TestOrgAdminApprovalOverridePermissions:
         )
         linked = response.data['task'].get('linked_object') or {}
         assert linked.get('is_admin_override') is False
+        assert linked.get('admin_override') in (None, {})
 
         from django.db import connection
         from core.services.tenant import slug_to_schema_name

--- a/backend/budget_approval/tests/test_permissions.py
+++ b/backend/budget_approval/tests/test_permissions.py
@@ -188,6 +188,101 @@ class TestBudgetRequestApprovalPermissions:
 
 @pytest.mark.django_db
 @pytest.mark.timeout(600)
+class TestOrgAdminApprovalOverridePermissions:
+    """MED-240: org-admin can approve outside the chain; non-admins unchanged.
+
+    Matrix:
+      - chain approver (user2)     → already covered above (can approve)
+      - non-chain member (user3)   → already covered (403)
+      - request owner (user1)      → already covered (403)
+      - org-admin (not approver)   → MUST be allowed (this class)
+      - superuser                  → already covered
+    """
+
+    def test_org_admin_can_approve_outside_chain(
+        self, api_client, org_admin, budget_request_under_review, team, user2
+    ):
+        """Org-admin who is NOT current_approver can still approve (override)."""
+        assert budget_request_under_review.current_approver_id == user2.id
+        assert org_admin.id != user2.id
+
+        api_client.force_authenticate(user=org_admin)
+        api_client.credentials(
+            HTTP_X_USER_ROLE='org_admin',
+            HTTP_X_ORGANIZATION_SLUG=team.organization.slug,
+        )
+
+        url = reverse('budget-request-decision', kwargs={'pk': budget_request_under_review.id})
+        response = api_client.patch(
+            url,
+            {'decision': 'approve', 'comment': 'Org-admin override'},
+            format='json',
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        budget_request_under_review.refresh_from_db()
+        assert budget_request_under_review.status == BudgetRequestStatus.APPROVED
+
+    def test_org_admin_can_reject_outside_chain(
+        self, api_client, org_admin, budget_request_under_review, team, user2
+    ):
+        """Org-admin who is NOT current_approver can reject (override)."""
+        assert budget_request_under_review.current_approver_id == user2.id
+
+        api_client.force_authenticate(user=org_admin)
+        api_client.credentials(
+            HTTP_X_USER_ROLE='org_admin',
+            HTTP_X_ORGANIZATION_SLUG=team.organization.slug,
+        )
+
+        url = reverse('budget-request-decision', kwargs={'pk': budget_request_under_review.id})
+        response = api_client.patch(
+            url,
+            {'decision': 'reject', 'comment': 'Org-admin override reject'},
+            format='json',
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        budget_request_under_review.refresh_from_db()
+        assert budget_request_under_review.status == BudgetRequestStatus.REJECTED
+
+    def test_approval_permission_object_allows_org_admin(
+        self, org_admin, budget_request_under_review, user2
+    ):
+        """Unit: ApprovalPermission.has_object_permission is True for org-admin."""
+        assert budget_request_under_review.current_approver_id == user2.id
+        assert org_admin.id != user2.id
+
+        permission = ApprovalPermission()
+        request = type('Req', (), {
+            'user': org_admin,
+            'method': 'PATCH',
+            'headers': {'x-user-role': 'org_admin'},
+        })()
+        assert permission.has_object_permission(
+            request, None, budget_request_under_review
+        ) is True
+
+    def test_approval_permission_object_denies_non_chain_non_admin(
+        self, user3, budget_request_under_review, user2, user_role3, role_permissions
+    ):
+        """Unit: non-admin who is not current_approver is still denied."""
+        assert budget_request_under_review.current_approver_id == user2.id
+        assert user3.id != user2.id
+
+        permission = ApprovalPermission()
+        request = type('Req', (), {
+            'user': user3,
+            'method': 'PATCH',
+            'headers': {'x-user-role': 'team_member', 'x-team-id': '1'},
+        })()
+        assert permission.has_object_permission(
+            request, None, budget_request_under_review
+        ) is False
+
+
+@pytest.mark.django_db
+@pytest.mark.timeout(600)
 class TestBudgetPoolPermissions:
     """Test budget pool permissions"""
     

--- a/backend/budget_approval/tests/test_permissions.py
+++ b/backend/budget_approval/tests/test_permissions.py
@@ -355,6 +355,167 @@ class TestOrgAdminApprovalOverridePermissions:
             request, None, budget_request_under_review
         ) is False
 
+    def test_org_admin_of_other_org_cannot_process_approval(
+        self, org_admin, budget_request_different_org, user2
+    ):
+        """Unit: org-admin of org A cannot override a request owned by org B."""
+        from budget_approval.approver_access import (
+            is_org_admin_override_action,
+            user_is_org_admin_for_budget_request,
+            user_may_process_budget_approval,
+        )
+
+        assert budget_request_different_org.current_approver_id == user2.id
+        assert org_admin.id != user2.id
+        assert user_is_org_admin_for_budget_request(
+            org_admin, budget_request_different_org
+        ) is False
+        assert user_may_process_budget_approval(
+            org_admin, budget_request_different_org
+        ) is False
+        assert is_org_admin_override_action(
+            org_admin, budget_request_different_org
+        ) is False
+
+        permission = ApprovalPermission()
+        request = type('Req', (), {
+            'user': org_admin,
+            'method': 'PATCH',
+            'headers': {'x-user-role': 'org_admin'},
+        })()
+        assert permission.has_object_permission(
+            request, None, budget_request_different_org
+        ) is False
+
+    def test_org_admin_cannot_approve_different_organization(
+        self, api_client, budget_request_under_review, team, user2, different_organization
+    ):
+        """API: org-admin of org B cannot approve a request owned by org A (403).
+
+        The request is fetched in org A's tenant (so this is not a 404 from
+        schema isolation); ApprovalPermission then denies the override.
+        """
+        import uuid
+        from django.contrib.auth import get_user_model
+        from core.admin_utils import assign_org_admin
+
+        User = get_user_model()
+        uid = uuid.uuid4().hex[:8]
+        other_admin = User.objects.create_user(
+            username=f'otheradmin_{uid}',
+            email=f'otheradmin_{uid}@test.com',
+            password='testpass123',
+            organization=different_organization,
+            current_organization=different_organization,
+        )
+        assign_org_admin(other_admin, different_organization)
+
+        assert budget_request_under_review.current_approver_id == user2.id
+        assert other_admin.id != user2.id
+
+        api_client.force_authenticate(user=other_admin)
+        api_client.credentials(
+            HTTP_X_USER_ROLE='org_admin',
+            HTTP_X_ORGANIZATION_SLUG=team.organization.slug,
+        )
+
+        url = reverse(
+            'budget-request-decision',
+            kwargs={'pk': budget_request_under_review.id},
+        )
+        response = api_client.patch(
+            url,
+            {'decision': 'approve', 'comment': 'Cross-org should be denied'},
+            format='json',
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_org_admin_who_is_current_approver_is_not_override(
+        self, org_admin, budget_request_under_review
+    ):
+        """Unit: org-admin on the chain is a normal approval, not an override."""
+        from budget_approval.approver_access import (
+            is_org_admin_override_action,
+            user_may_process_budget_approval,
+        )
+
+        budget_request_under_review.current_approver = org_admin
+        budget_request_under_review.save(update_fields=['current_approver'])
+
+        assert user_may_process_budget_approval(
+            org_admin, budget_request_under_review
+        ) is True
+        assert is_org_admin_override_action(
+            org_admin, budget_request_under_review
+        ) is False
+
+    def test_org_admin_as_current_approver_make_approval_is_not_override(
+        self, api_client, org_admin, budget_request_under_review, team, project
+    ):
+        """UI path: org-admin who IS current_approver must not get override audit."""
+        from core.models import ProjectMember
+        from django.contrib.contenttypes.models import ContentType
+        from budget_approval.approver_access import (
+            ORG_ADMIN_OVERRIDE_PREFIX,
+            budget_request_has_admin_override,
+        )
+        from budget_approval.models import BudgetRequest
+        from task.models import Task
+
+        br = budget_request_under_review
+        br.current_approver = org_admin
+        br.save(update_fields=['current_approver'])
+
+        task = br.task
+        task.current_approver = org_admin
+        task.content_type = ContentType.objects.get_for_model(br)
+        task.object_id = br.id
+        task.save(update_fields=['current_approver', 'content_type', 'object_id'])
+        if task.status == Task.Status.DRAFT:
+            task.submit()
+            task.start_review()
+            task.save()
+        elif task.status == Task.Status.SUBMITTED:
+            task.start_review()
+            task.save()
+        assert task.status == Task.Status.UNDER_REVIEW
+
+        ProjectMember.objects.get_or_create(
+            user=org_admin,
+            project=project,
+            defaults={'is_active': True},
+        )
+
+        api_client.force_authenticate(user=org_admin)
+        api_client.credentials(
+            HTTP_X_USER_ROLE='org_admin',
+            HTTP_X_ORGANIZATION_SLUG=team.organization.slug,
+        )
+
+        url = reverse('task-make-approval', kwargs={'pk': task.slug})
+        response = api_client.post(
+            url,
+            {'action': 'approve', 'comment': 'Admin is the assigned approver'},
+            format='json',
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.data
+        assert ORG_ADMIN_OVERRIDE_PREFIX not in (
+            response.data.get('approval_record', {}).get('comment') or ''
+        )
+        linked = response.data['task'].get('linked_object') or {}
+        assert linked.get('is_admin_override') is False
+
+        from django.db import connection
+        from core.services.tenant import slug_to_schema_name
+
+        schema = slug_to_schema_name(team.organization.slug)
+        with connection.cursor() as cursor:
+            cursor.execute(f'SET search_path TO {schema}, public')
+        br = BudgetRequest.objects.get(pk=br.pk)
+        assert br.status == BudgetRequestStatus.APPROVED
+        assert budget_request_has_admin_override(br) is False
+
 
 @pytest.mark.django_db
 @pytest.mark.timeout(600)

--- a/backend/budget_approval/tests/test_permissions.py
+++ b/backend/budget_approval/tests/test_permissions.py
@@ -309,6 +309,34 @@ class TestOrgAdminApprovalOverridePermissions:
         assert audit['final_outcome'] == 'approve'
         assert audit['override_timestamp']
 
+    def test_second_decision_returns_409_conflict(
+        self, api_client, org_admin, budget_request_under_review, team, user2
+    ):
+        """Duplicate decision after a final override is 409, not 400."""
+        api_client.force_authenticate(user=org_admin)
+        api_client.credentials(
+            HTTP_X_USER_ROLE='org_admin',
+            HTTP_X_ORGANIZATION_SLUG=team.organization.slug,
+        )
+        url = reverse(
+            'budget-request-decision',
+            kwargs={'pk': budget_request_under_review.id},
+        )
+        first = api_client.patch(
+            url,
+            {'decision': 'approve', 'comment': 'First override'},
+            format='json',
+        )
+        assert first.status_code == status.HTTP_200_OK, first.data
+
+        second = api_client.patch(
+            url,
+            {'decision': 'approve', 'comment': 'Duplicate click'},
+            format='json',
+        )
+        assert second.status_code == status.HTTP_409_CONFLICT
+        assert 'already been decided' in (second.data.get('error') or '').lower()
+
     def test_get_detail_after_override_returns_structured_admin_override(
         self, api_client, org_admin, budget_request_under_review, team, user1, user2
     ):

--- a/backend/budget_approval/tests/test_permissions.py
+++ b/backend/budget_approval/tests/test_permissions.py
@@ -199,6 +199,79 @@ class TestOrgAdminApprovalOverridePermissions:
       - superuser                  → already covered
     """
 
+    def test_team_member_cannot_approve_via_decision_api(
+        self, api_client, user3, budget_request_under_review, team, user_role3, role_permissions
+    ):
+        """MED-240: non-approver team member → PATCH decision is 403 (API enforcement)."""
+        assert budget_request_under_review.current_approver_id != user3.id
+
+        api_client.force_authenticate(user=user3)
+        api_client.credentials(
+            HTTP_X_USER_ROLE='team_member',
+            HTTP_X_TEAM_ID=str(team.id),
+            HTTP_X_ORGANIZATION_SLUG=team.organization.slug,
+        )
+
+        url = reverse(
+            'budget-request-decision',
+            kwargs={'pk': budget_request_under_review.id},
+        )
+        response = api_client.patch(
+            url,
+            {'decision': 'approve', 'comment': 'Member must not approve'},
+            format='json',
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_team_member_cannot_make_approval_on_budget_task(
+        self, api_client, user3, budget_request_under_review, team, user2, project, user_role3
+    ):
+        """MED-240: non-approver team member → POST make-approval is 403."""
+        from core.models import ProjectMember
+        from django.contrib.contenttypes.models import ContentType
+        from budget_approval.models import BudgetRequest
+        from task.models import Task
+
+        br = budget_request_under_review
+        assert br.current_approver_id == user2.id
+        assert user3.id != user2.id
+
+        task = br.task
+        task.current_approver = user2
+        task.content_type = ContentType.objects.get_for_model(BudgetRequest)
+        task.object_id = br.id
+        task.save(update_fields=['current_approver', 'content_type', 'object_id'])
+        if task.status == Task.Status.DRAFT:
+            task.submit()
+            task.start_review()
+            task.save()
+        elif task.status == Task.Status.SUBMITTED:
+            task.start_review()
+            task.save()
+        assert task.status == Task.Status.UNDER_REVIEW
+
+        ProjectMember.objects.get_or_create(
+            user=user3,
+            project=project,
+            defaults={'is_active': True},
+        )
+
+        api_client.force_authenticate(user=user3)
+        api_client.credentials(
+            HTTP_X_USER_ROLE='team_member',
+            HTTP_X_TEAM_ID=str(team.id),
+            HTTP_X_ORGANIZATION_SLUG=team.organization.slug,
+        )
+
+        url = reverse('task-make-approval', kwargs={'pk': task.slug})
+        response = api_client.post(
+            url,
+            {'action': 'approve', 'comment': 'Member must not approve'},
+            format='json',
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert 'designated approver' in (response.data.get('error') or '').lower()
+
     def test_org_admin_can_approve_via_task_make_approval(
         self, api_client, org_admin, budget_request_under_review, team, user2, project
     ):

--- a/backend/budget_approval/tests/test_serializers_coverage.py
+++ b/backend/budget_approval/tests/test_serializers_coverage.py
@@ -30,6 +30,8 @@ class TestBudgetRequestSerializerRead:
         assert d['currency'] == 'AUD'
         assert d['status'] == BudgetRequestStatus.DRAFT
         assert d['is_escalated'] is False
+        assert d['is_admin_override'] is False
+        assert d['admin_override'] is None
 
     def test_get_requested_by_returns_username(self, budget_request_draft, user1):
         s = BudgetRequestSerializer(budget_request_draft)

--- a/backend/budget_approval/tests/test_services.py
+++ b/backend/budget_approval/tests/test_services.py
@@ -13,6 +13,7 @@ from django.core.exceptions import ValidationError
 
 from budget_approval.models import BudgetPool, BudgetRequest, BudgetRequestStatus
 from budget_approval.services import BudgetRequestService, BudgetPoolService
+from budget_approval.exceptions import ApprovalConflict
 
 
 # ---------------------------------------------------------------------------
@@ -399,6 +400,80 @@ class TestProcessApproval:
         audit = BudgetRequestSerializer(result).data['admin_override']
         assert audit['replaced_step'] == 1
         assert 'replaced_step=1' in (result.notes or "")
+
+    def test_stale_step1_approver_conflicts_after_override_advances(
+        self, budget_request_under_review, org_admin, user2, user3, project
+    ):
+        """MED-240: after override moves to step 2, a stale step-1 approve must 409.
+
+        Simulates the in-flight request that passed the lock-outer permission
+        check while current_approver was still user2.
+        """
+        from task.models import ApprovalChain, ApprovalChainStep
+
+        task = budget_request_under_review.task
+        chain = ApprovalChain.objects.create(
+            name="Buyer → Lead",
+            project=project,
+            task_type="budget",
+        )
+        ApprovalChainStep.objects.create(chain=chain, order=1, approver=user2)
+        ApprovalChainStep.objects.create(chain=chain, order=2, approver=user3)
+        task.approval_chain = chain
+        task.current_approval_step = 1
+        task.current_approver = user2
+        task.save(
+            update_fields=['approval_chain', 'current_approval_step', 'current_approver']
+        )
+
+        stale = budget_request_under_review
+        assert stale.current_approver_id == user2.id
+
+        with patch('budget_approval.services.budget_notifications'):
+            result = BudgetRequestService.process_approval(
+                stale,
+                org_admin,
+                is_approved=True,
+                comment="Override step 1",
+            )
+
+        assert result.status == BudgetRequestStatus.UNDER_REVIEW
+        assert result.current_approver_id == user3.id
+        # Original Python object was not refreshed — still looks like step 1.
+        assert stale.current_approver_id == user2.id
+
+        with patch('budget_approval.services.budget_notifications'):
+            with pytest.raises(ApprovalConflict):
+                BudgetRequestService.process_approval(
+                    stale,
+                    user2,
+                    is_approved=True,
+                    comment="Late step-1 approve",
+                )
+
+        fresh = BudgetRequest.objects.get(pk=result.pk)
+        assert fresh.current_approver_id == user3.id
+        assert fresh.status == BudgetRequestStatus.UNDER_REVIEW
+
+    def test_second_approve_on_same_step_raises_conflict(
+        self, budget_request_under_review, user2
+    ):
+        """Duplicate approve after a final decision is a conflict, not a 400."""
+        with patch('budget_approval.services.budget_notifications'):
+            BudgetRequestService.process_approval(
+                budget_request_under_review,
+                user2,
+                is_approved=True,
+                comment="First",
+            )
+        with patch('budget_approval.services.budget_notifications'):
+            with pytest.raises(ApprovalConflict):
+                BudgetRequestService.process_approval(
+                    budget_request_under_review,
+                    user2,
+                    is_approved=True,
+                    comment="Duplicate click",
+                )
 
     def test_org_admin_override_finalizes_when_no_next_chain_step(
         self, budget_request_under_review, org_admin, user2, project

--- a/backend/budget_approval/tests/test_services.py
+++ b/backend/budget_approval/tests/test_services.py
@@ -355,6 +355,69 @@ class TestProcessApproval:
             )
         assert result.status == BudgetRequestStatus.APPROVED
 
+    def test_org_admin_override_writes_audit_entry(
+        self, budget_request_under_review, org_admin, user2
+    ):
+        """MED-240: org-admin override must leave an auditable ApprovalRecord + marker."""
+        from task.models import ApprovalRecord
+        from budget_approval.approver_access import (
+            ORG_ADMIN_OVERRIDE_PREFIX,
+            budget_request_has_admin_override,
+        )
+        from budget_approval.serializers import BudgetRequestSerializer
+
+        assert budget_request_under_review.current_approver_id == user2.id
+        task = budget_request_under_review.task
+        assert task is not None
+
+        with patch('budget_approval.services.budget_notifications'):
+            result = BudgetRequestService.process_approval(
+                budget_request_under_review,
+                org_admin,
+                is_approved=True,
+                comment="Emergency approve",
+            )
+
+        assert budget_request_has_admin_override(result) is True
+        assert ORG_ADMIN_OVERRIDE_PREFIX in (result.notes or "")
+
+        records = ApprovalRecord.objects.filter(
+            task=task,
+            approved_by=org_admin,
+            comment__startswith=ORG_ADMIN_OVERRIDE_PREFIX,
+        )
+        assert records.count() == 1
+        assert records.first().is_approved is True
+        assert "Emergency approve" in records.first().comment
+
+        payload = BudgetRequestSerializer(result).data
+        assert payload['is_admin_override'] is True
+
+    def test_chain_approver_does_not_write_override_audit(
+        self, budget_request_under_review, user2
+    ):
+        """Normal chain approval must not be marked as admin override."""
+        from task.models import ApprovalRecord
+        from budget_approval.approver_access import (
+            ORG_ADMIN_OVERRIDE_PREFIX,
+            budget_request_has_admin_override,
+        )
+
+        task = budget_request_under_review.task
+        before = ApprovalRecord.objects.filter(task=task).count()
+
+        with patch('budget_approval.services.budget_notifications'):
+            result = BudgetRequestService.process_approval(
+                budget_request_under_review,
+                user2,
+                is_approved=True,
+                comment="Normal approve",
+            )
+
+        assert budget_request_has_admin_override(result) is False
+        assert ORG_ADMIN_OVERRIDE_PREFIX not in (result.notes or "")
+        assert ApprovalRecord.objects.filter(task=task).count() == before
+
     def test_raises_when_not_under_review(self, budget_request_draft, user2):
         with pytest.raises(ValidationError, match="cannot be processed"):
             BudgetRequestService.process_approval(

--- a/backend/budget_approval/tests/test_services.py
+++ b/backend/budget_approval/tests/test_services.py
@@ -339,6 +339,22 @@ class TestProcessApproval:
             )
         assert result.status == BudgetRequestStatus.APPROVED
 
+    def test_org_admin_can_bypass_approver_check(
+        self, budget_request_under_review, org_admin, user2
+    ):
+        """MED-240: org-admin may process approval even when not current_approver."""
+        assert budget_request_under_review.current_approver_id == user2.id
+        assert org_admin.id != user2.id
+
+        with patch('budget_approval.services.budget_notifications'):
+            result = BudgetRequestService.process_approval(
+                budget_request_under_review,
+                org_admin,
+                is_approved=True,
+                comment="Org-admin override",
+            )
+        assert result.status == BudgetRequestStatus.APPROVED
+
     def test_raises_when_not_under_review(self, budget_request_draft, user2):
         with pytest.raises(ValidationError, match="cannot be processed"):
             BudgetRequestService.process_approval(

--- a/backend/budget_approval/tests/test_services.py
+++ b/backend/budget_approval/tests/test_services.py
@@ -355,6 +355,78 @@ class TestProcessApproval:
             )
         assert result.status == BudgetRequestStatus.APPROVED
 
+    def test_org_admin_override_auto_advances_original_chain(
+        self, budget_request_under_review, org_admin, user2, user3, project
+    ):
+        """MED-240: override approve continues the original ApprovalChain (not admin-picked)."""
+        from task.models import ApprovalChain, ApprovalChainStep
+
+        task = budget_request_under_review.task
+        chain = ApprovalChain.objects.create(
+            name="Buyer → Lead → Client",
+            project=project,
+            task_type="budget",
+        )
+        ApprovalChainStep.objects.create(chain=chain, order=1, approver=user2)
+        ApprovalChainStep.objects.create(chain=chain, order=2, approver=user3)
+        task.approval_chain = chain
+        task.current_approval_step = 1
+        task.current_approver = user2
+        task.save(
+            update_fields=['approval_chain', 'current_approval_step', 'current_approver']
+        )
+
+        with patch('budget_approval.services.budget_notifications') as mock_notif:
+            result = BudgetRequestService.process_approval(
+                budget_request_under_review,
+                org_admin,
+                is_approved=True,
+                comment="Override step 1",
+                next_approver=org_admin,  # must be ignored — chain picks user3
+            )
+
+        assert result.status == BudgetRequestStatus.UNDER_REVIEW
+        assert result.current_approver_id == user3.id
+        # Avoid Task.refresh_from_db() — FSMField(protected) blocks status setattr
+        from task.models import Task
+        task_row = Task.objects.filter(pk=task.pk).values(
+            'current_approval_step', 'current_approver_id'
+        ).get()
+        assert task_row['current_approval_step'] == 2
+        assert task_row['current_approver_id'] == user3.id
+        mock_notif.notify_budget_forwarded.assert_called_once()
+
+    def test_org_admin_override_finalizes_when_no_next_chain_step(
+        self, budget_request_under_review, org_admin, user2, project
+    ):
+        """Last chain step / legacy: override approve finalizes APPROVED."""
+        from task.models import ApprovalChain, ApprovalChainStep
+
+        task = budget_request_under_review.task
+        chain = ApprovalChain.objects.create(
+            name="Single step",
+            project=project,
+            task_type="budget",
+        )
+        ApprovalChainStep.objects.create(chain=chain, order=1, approver=user2)
+        task.approval_chain = chain
+        task.current_approval_step = 1
+        task.current_approver = user2
+        task.save(
+            update_fields=['approval_chain', 'current_approval_step', 'current_approver']
+        )
+
+        with patch('budget_approval.services.budget_notifications') as mock_notif:
+            result = BudgetRequestService.process_approval(
+                budget_request_under_review,
+                org_admin,
+                is_approved=True,
+                comment="Override last step",
+            )
+
+        assert result.status == BudgetRequestStatus.APPROVED
+        mock_notif.notify_budget_approved.assert_called_once()
+
     def test_org_admin_override_writes_audit_entry(
         self, budget_request_under_review, org_admin, user2
     ):

--- a/backend/budget_approval/tests/test_services.py
+++ b/backend/budget_approval/tests/test_services.py
@@ -490,6 +490,30 @@ class TestProcessApproval:
         assert ORG_ADMIN_OVERRIDE_PREFIX not in (result.notes or "")
         assert ApprovalRecord.objects.filter(task=task).count() == before
 
+    def test_org_admin_as_current_approver_does_not_write_override_audit(
+        self, budget_request_under_review, org_admin
+    ):
+        """MED-240: org-admin who is the assigned approver is not an override."""
+        from budget_approval.approver_access import (
+            ORG_ADMIN_OVERRIDE_PREFIX,
+            budget_request_has_admin_override,
+        )
+
+        budget_request_under_review.current_approver = org_admin
+        budget_request_under_review.save(update_fields=['current_approver'])
+
+        with patch('budget_approval.services.budget_notifications'):
+            result = BudgetRequestService.process_approval(
+                budget_request_under_review,
+                org_admin,
+                is_approved=True,
+                comment="Admin is on the chain",
+            )
+
+        assert result.status == BudgetRequestStatus.APPROVED
+        assert budget_request_has_admin_override(result) is False
+        assert ORG_ADMIN_OVERRIDE_PREFIX not in (result.notes or "")
+
     def test_raises_when_not_under_review(self, budget_request_draft, user2):
         with pytest.raises(ValidationError, match="cannot be processed"):
             BudgetRequestService.process_approval(

--- a/backend/budget_approval/tests/test_services.py
+++ b/backend/budget_approval/tests/test_services.py
@@ -395,6 +395,10 @@ class TestProcessApproval:
         assert task_row['current_approval_step'] == 2
         assert task_row['current_approver_id'] == user3.id
         mock_notif.notify_budget_forwarded.assert_called_once()
+        from budget_approval.serializers import BudgetRequestSerializer
+        audit = BudgetRequestSerializer(result).data['admin_override']
+        assert audit['replaced_step'] == 1
+        assert 'replaced_step=1' in (result.notes or "")
 
     def test_org_admin_override_finalizes_when_no_next_chain_step(
         self, budget_request_under_review, org_admin, user2, project
@@ -441,6 +445,8 @@ class TestProcessApproval:
         assert budget_request_under_review.current_approver_id == user2.id
         task = budget_request_under_review.task
         assert task is not None
+        task.current_approval_step = 1
+        task.save(update_fields=['current_approval_step'])
 
         with patch('budget_approval.services.budget_notifications'):
             result = BudgetRequestService.process_approval(
@@ -464,6 +470,14 @@ class TestProcessApproval:
 
         payload = BudgetRequestSerializer(result).data
         assert payload['is_admin_override'] is True
+        audit = payload['admin_override']
+        assert audit is not None
+        assert audit['override_by_user_id'] == org_admin.id
+        assert audit['override_type'] == 'org_admin'
+        assert audit['final_outcome'] == 'approve'
+        assert audit['replaced_step'] == 1
+        assert audit['override_timestamp']
+        assert f'replaced_step=1' in (result.notes or "")
 
     def test_chain_approver_does_not_write_override_audit(
         self, budget_request_under_review, user2
@@ -513,6 +527,8 @@ class TestProcessApproval:
         assert result.status == BudgetRequestStatus.APPROVED
         assert budget_request_has_admin_override(result) is False
         assert ORG_ADMIN_OVERRIDE_PREFIX not in (result.notes or "")
+        from budget_approval.serializers import BudgetRequestSerializer
+        assert BudgetRequestSerializer(result).data['admin_override'] is None
 
     def test_raises_when_not_under_review(self, budget_request_draft, user2):
         with pytest.raises(ValidationError, match="cannot be processed"):

--- a/backend/budget_approval/views.py
+++ b/backend/budget_approval/views.py
@@ -21,6 +21,7 @@ from .permissions import (
     EscalationPermission
 )
 from .services import BudgetRequestService, BudgetPoolService
+from .exceptions import ApprovalConflict
 
 
 class BudgetRequestViewSet(viewsets.ModelViewSet):
@@ -123,6 +124,11 @@ class BudgetRequestDecisionView(generics.UpdateAPIView):
                     'budget_request': budget_request_serializer.data
                 }, status=status.HTTP_200_OK)
                 
+            except ApprovalConflict as e:
+                return Response(
+                    {'error': str(e)},
+                    status=status.HTTP_409_CONFLICT,
+                )
             except Exception as e:
                 return Response({
                     'error': str(e)

--- a/backend/task/views.py
+++ b/backend/task/views.py
@@ -1315,12 +1315,31 @@ class TaskViewSet(SlugLookupViewSetMixin, viewsets.ModelViewSet):
                         status=status.HTTP_400_BAD_REQUEST
                     )
 
-                # Verify the requesting user is the designated approver for this step
-                if task.current_approver_id and request.user.id != task.current_approver_id:
-                    return Response(
-                        {'error': 'Only the designated approver for this step can approve or reject.'},
-                        status=status.HTTP_403_FORBIDDEN
-                    )
+                # Designated chain approver, or same-org org-admin override on budget (MED-240).
+                is_current_approver = (
+                    task.current_approver_id is not None
+                    and request.user.id == task.current_approver_id
+                )
+                is_admin_override = False
+                if task.current_approver_id and not is_current_approver:
+                    if task.type == 'budget':
+                        from budget_approval.approver_access import (
+                            is_org_admin_override_action,
+                            user_may_process_budget_approval,
+                        )
+                        br = task.linked_object or task.budget_requests.first()
+                        if br is not None and user_may_process_budget_approval(request.user, br):
+                            is_admin_override = is_org_admin_override_action(request.user, br)
+                        else:
+                            return Response(
+                                {'error': 'Only the designated approver for this step can approve or reject.'},
+                                status=status.HTTP_403_FORBIDDEN
+                            )
+                    else:
+                        return Response(
+                            {'error': 'Only the designated approver for this step can approve or reject.'},
+                            status=status.HTTP_403_FORBIDDEN
+                        )
 
                 # Execute the action
                 if action == 'approve':
@@ -1336,12 +1355,21 @@ class TaskViewSet(SlugLookupViewSetMixin, viewsets.ModelViewSet):
                     if task.current_approval_step
                     else task.approval_records.count() + 1
                 )
-                # Update revision round so next submission is tracked as a new round
+                # Attribute the decision to the actor (org-admin on override, not the chain assignee).
+                from budget_approval.approver_access import ORG_ADMIN_OVERRIDE_PREFIX
+                record_comment = comment
+                if is_admin_override:
+                    decision = 'approve' if is_approved else 'reject'
+                    marker = (
+                        f'{ORG_ADMIN_OVERRIDE_PREFIX} user_id={request.user.id} '
+                        f'decision={decision}'
+                    )
+                    record_comment = f'{marker}\n{comment}'.strip() if comment else marker
                 ApprovalRecord.objects.create(
                     task=task,
-                    approved_by=task.current_approver or request.user,
+                    approved_by=request.user,
                     is_approved=is_approved,
-                    comment=comment,
+                    comment=record_comment,
                     step_number=step_number,
                     revision_round=task.revision_round,
                     resubmitted_after_reject=task.revision_round > 0,

--- a/backend/task/views.py
+++ b/backend/task/views.py
@@ -1356,13 +1356,17 @@ class TaskViewSet(SlugLookupViewSetMixin, viewsets.ModelViewSet):
                     else task.approval_records.count() + 1
                 )
                 # Attribute the decision to the actor (org-admin on override, not the chain assignee).
-                from budget_approval.approver_access import ORG_ADMIN_OVERRIDE_PREFIX
+                from budget_approval.approver_access import (
+                    format_org_admin_override_marker,
+                )
                 record_comment = comment
                 if is_admin_override:
                     decision = 'approve' if is_approved else 'reject'
-                    marker = (
-                        f'{ORG_ADMIN_OVERRIDE_PREFIX} user_id={request.user.id} '
-                        f'decision={decision}'
+                    marker = format_org_admin_override_marker(
+                        user_id=request.user.id,
+                        decision=decision,
+                        replaced_step=step_number,
+                        timestamp=timezone.now().isoformat(),
                     )
                     record_comment = f'{marker}\n{comment}'.strip() if comment else marker
                 ApprovalRecord.objects.create(

--- a/frontend/e2e/budget/budget-admin-override.spec.ts
+++ b/frontend/e2e/budget/budget-admin-override.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * MED-240: Playwright coverage for org-admin override UI.
+ *
+ * Asserts the Admin override badge surfaces when a budget request is flagged
+ * `is_admin_override` (e.g. after a chain-outside org-admin decision).
+ * Uses response interception so the badge contract can be verified without a
+ * second seeded org-admin account.
+ */
+
+import { test, expect, type Page, type Route } from '@playwright/test';
+import {
+  createDraftTaskViaApi,
+  deleteTaskById,
+  navigateToTasksAndSelectProject,
+  waitForTasksPageReady,
+  getActiveProjectSlug,
+  buildTasksListDrawerUrl,
+} from '../tasks/tasks-helpers';
+
+async function waitForDrawerReady(page: Page) {
+  await expect(page.getByTestId('task-drawer')).toBeVisible({ timeout: 15_000 });
+  await page.waitForFunction(
+    () => !document.querySelector('.animate-pulse'),
+    { timeout: 15_000 },
+  );
+}
+
+/** Patch task / budget payloads so linked budget data exposes the override flag. */
+function withAdminOverrideFlag(body: Record<string, unknown>): Record<string, unknown> {
+  const linked =
+    body.linked_object && typeof body.linked_object === 'object'
+      ? { ...(body.linked_object as Record<string, unknown>) }
+      : {
+          id: body.object_id ?? 1,
+          status: body.status ?? 'APPROVED',
+          amount: '100.00',
+          currency: 'AUD',
+          notes: 'E2E override fixture',
+        };
+
+  return {
+    ...body,
+    type: 'budget',
+    linked_object: {
+      ...linked,
+      is_admin_override: true,
+    },
+  };
+}
+
+async function fulfillJson(route: Route, body: unknown) {
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+}
+
+test.describe('Budget admin override badge (MED-240)', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let projectId: number;
+  let projectSlug: string;
+  let taskId: number | null = null;
+  let taskSlug: string | null = null;
+
+  test.beforeAll(async ({ browser }) => {
+    const ctx = await browser.newContext({ storageState: 'e2e/.auth/user.json' });
+    const page = await ctx.newPage();
+    projectId = await navigateToTasksAndSelectProject(page);
+    projectSlug = await getActiveProjectSlug(page);
+    await ctx.close();
+  });
+
+  test.afterEach(async ({ browser }) => {
+    if (taskId == null) return;
+    const ctx = await browser.newContext({ storageState: 'e2e/.auth/user.json' });
+    const page = await ctx.newPage();
+    await page.goto(`/projects/${encodeURIComponent(projectSlug)}/tasks`);
+    await waitForTasksPageReady(page);
+    await deleteTaskById(page, taskId).catch(() => {});
+    await ctx.close();
+    taskId = null;
+    taskSlug = null;
+  });
+
+  test('shows Admin override badge when budget linked_object is_admin_override', async ({
+    page,
+  }) => {
+    await page.goto(`/projects/${encodeURIComponent(projectSlug)}/tasks`);
+    await waitForTasksPageReady(page);
+
+    const fixture = await createDraftTaskViaApi(
+      page,
+      projectId,
+      `E2E MED-240 admin override ${Date.now()}`,
+      { type: 'budget' },
+    );
+    taskId = fixture.id;
+    taskSlug = fixture.slug;
+
+    await page.route(`**/api/tasks/${taskId}/**`, async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.continue();
+        return;
+      }
+      const response = await route.fetch();
+      const data = (await response.json()) as Record<string, unknown>;
+      await fulfillJson(route, withAdminOverrideFlag(data));
+    });
+
+    // Also cover legacy BudgetRequestDetail fetch path
+    await page.route('**/api/budgets/requests/**', async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.continue();
+        return;
+      }
+      const response = await route.fetch();
+      const data = (await response.json()) as Record<string, unknown>;
+      await fulfillJson(route, { ...data, is_admin_override: true, status: data.status ?? 'APPROVED' });
+    });
+
+    await page.goto(buildTasksListDrawerUrl(projectSlug, taskSlug!));
+    await waitForDrawerReady(page);
+
+    await expect(page.getByTestId('admin-override-badge').first()).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByTestId('admin-override-badge').first()).toHaveText(/admin override/i);
+  });
+
+  test('does not show Admin override badge for a normal budget draft', async ({ page }) => {
+    await page.goto(`/projects/${encodeURIComponent(projectSlug)}/tasks`);
+    await waitForTasksPageReady(page);
+
+    const fixture = await createDraftTaskViaApi(
+      page,
+      projectId,
+      `E2E MED-240 no override ${Date.now()}`,
+      { type: 'budget' },
+    );
+    taskId = fixture.id;
+    taskSlug = fixture.slug;
+
+    await page.goto(buildTasksListDrawerUrl(projectSlug, taskSlug!));
+    await waitForDrawerReady(page);
+
+    await expect(page.locator('section', { hasText: /budget details/i })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByTestId('admin-override-badge')).toHaveCount(0);
+  });
+});

--- a/frontend/e2e/budget/budget-admin-override.spec.ts
+++ b/frontend/e2e/budget/budget-admin-override.spec.ts
@@ -1,150 +1,206 @@
 /**
  * MED-240: Playwright coverage for org-admin override UI.
  *
- * Asserts the Admin override badge surfaces when a budget request is flagged
- * `is_admin_override` (e.g. after a chain-outside org-admin decision).
- * Uses response interception so the badge contract can be verified without a
- * second seeded org-admin account.
+ * Fully mocked (no real login / backend) so it runs inside the frontend
+ * Docker image without DEV_USER credentials. Asserts the Admin override
+ * badge contract against TaskTypeBlock / BudgetRequestDetail.
  */
 
-import { test, expect, type Page, type Route } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import {
-  createDraftTaskViaApi,
-  deleteTaskById,
-  navigateToTasksAndSelectProject,
-  waitForTasksPageReady,
-  getActiveProjectSlug,
-  buildTasksListDrawerUrl,
-} from '../tasks/tasks-helpers';
+  seedAuthenticatedUser,
+  mockAuthenticatedUserApis,
+  mockProjectShellApis,
+  seedActiveProject,
+} from '../messages/messages-helpers';
 
-async function waitForDrawerReady(page: Page) {
-  await expect(page.getByTestId('task-drawer')).toBeVisible({ timeout: 15_000 });
-  await page.waitForFunction(
-    () => !document.querySelector('.animate-pulse'),
-    { timeout: 15_000 },
-  );
-}
+const PROJECT = {
+  id: 2401,
+  name: 'MED-240 Override Project',
+  slug: 'med-240-override',
+  member_count: 1,
+};
 
-/** Patch task / budget payloads so linked budget data exposes the override flag. */
-function withAdminOverrideFlag(body: Record<string, unknown>): Record<string, unknown> {
-  const linked =
-    body.linked_object && typeof body.linked_object === 'object'
-      ? { ...(body.linked_object as Record<string, unknown>) }
-      : {
-          id: body.object_id ?? 1,
-          status: body.status ?? 'APPROVED',
-          amount: '100.00',
-          currency: 'AUD',
-          notes: 'E2E override fixture',
-        };
-
-  return {
-    ...body,
-    type: 'budget',
-    linked_object: {
-      ...linked,
-      is_admin_override: true,
+const TASK = {
+  id: 24001,
+  slug: 'e2e-med-240-budget-task',
+  summary: 'E2E MED-240 budget override',
+  type: 'budget',
+  status: 'APPROVED',
+  project_id: PROJECT.id,
+  project: PROJECT,
+  current_approver: { id: 99, username: 'chain-approver', email: 'approver@example.com' },
+  owner: { id: 1, username: 'e2e-user', email: 'e2e@example.com' },
+  blocks: [],
+  is_blocked_by: [],
+  causes: [],
+  is_caused_by: [],
+  relations: {
+    blocks: [],
+    is_blocked_by: [],
+    causes: [],
+    is_caused_by: [],
+  },
+  linked_object: {
+    id: 8801,
+    status: 'APPROVED',
+    amount: '100.00',
+    currency: 'AUD',
+    notes: 'User visible note',
+    is_escalated: false,
+    is_admin_override: true,
+    current_approver_name: 'chain-approver',
+    ad_channel_name: 'Meta',
+    budget_pool: {
+      id: 1,
+      name: 'Pool A',
+      currency: 'AUD',
+      total_amount: '1000.00',
+      available_amount: '900.00',
     },
-  };
-}
+  },
+};
 
-async function fulfillJson(route: Route, body: unknown) {
-  await route.fulfill({
-    status: 200,
-    contentType: 'application/json',
-    body: JSON.stringify(body),
+test.use({ storageState: { cookies: [], origins: [] } });
+
+async function mockBudgetTaskShell(page: Page, withOverride: boolean) {
+  const linked = {
+    ...TASK.linked_object,
+    is_admin_override: withOverride,
+  };
+  const taskPayload = { ...TASK, linked_object: linked };
+
+  await page.route('**/api/core/onboarding-status/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ needs_onboarding: false, has_org: true, has_project: true }),
+    });
+  });
+
+  await page.route('**/api/core/projects**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([PROJECT]),
+    });
+  });
+
+  await page.route(`**/api/core/projects/${PROJECT.id}/members/**`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ results: [], next: null }),
+    });
+  });
+
+  const emptyRelations = {
+    causes: [],
+    is_caused_by: [],
+    blocks: [],
+    is_blocked_by: [],
+    clones: [],
+    is_cloned_by: [],
+    relates_to: [],
+  };
+
+  await page.route('**/api/tasks/**', async (route) => {
+    const url = route.request().url();
+    const method = route.request().method();
+    if (method !== 'GET') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+      return;
+    }
+
+    // Sub-resources must be matched before task detail (same URL prefix).
+    if (url.includes('/relations')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(emptyRelations),
+      });
+      return;
+    }
+    if (url.includes('/budget-request') || url.includes('/onboarding-status') || url.includes('/field-history')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(url.includes('/budget-request') ? linked : {}),
+      });
+      return;
+    }
+
+    // Detail by id or slug
+    if (url.includes(`/tasks/${TASK.id}`) || url.includes(`/tasks/${TASK.slug}`)) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(taskPayload),
+      });
+      return;
+    }
+
+    // List
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ count: 1, next: null, previous: null, results: [taskPayload] }),
+    });
+  });
+
+  await page.route('**/api/budgets/requests/**', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(linked),
+    });
+  });
+
+  await page.route('**/api/budgets/pools/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ count: 0, results: [] }),
+    });
   });
 }
 
 test.describe('Budget admin override badge (MED-240)', () => {
-  test.describe.configure({ mode: 'serial' });
-
-  let projectId: number;
-  let projectSlug: string;
-  let taskId: number | null = null;
-  let taskSlug: string | null = null;
-
-  test.beforeAll(async ({ browser }) => {
-    const ctx = await browser.newContext({ storageState: 'e2e/.auth/user.json' });
-    const page = await ctx.newPage();
-    projectId = await navigateToTasksAndSelectProject(page);
-    projectSlug = await getActiveProjectSlug(page);
-    await ctx.close();
+  test.beforeEach(async ({ page }) => {
+    await seedAuthenticatedUser(page);
+    await mockAuthenticatedUserApis(page);
+    await mockProjectShellApis(page);
+    await seedActiveProject(page, PROJECT);
   });
 
-  test.afterEach(async ({ browser }) => {
-    if (taskId == null) return;
-    const ctx = await browser.newContext({ storageState: 'e2e/.auth/user.json' });
-    const page = await ctx.newPage();
-    await page.goto(`/projects/${encodeURIComponent(projectSlug)}/tasks`);
-    await waitForTasksPageReady(page);
-    await deleteTaskById(page, taskId).catch(() => {});
-    await ctx.close();
-    taskId = null;
-    taskSlug = null;
-  });
+  test('shows Admin override badge when is_admin_override is true', async ({ page }) => {
+    await mockBudgetTaskShell(page, true);
 
-  test('shows Admin override badge when budget linked_object is_admin_override', async ({
-    page,
-  }) => {
-    await page.goto(`/projects/${encodeURIComponent(projectSlug)}/tasks`);
-    await waitForTasksPageReady(page);
-
-    const fixture = await createDraftTaskViaApi(
-      page,
-      projectId,
-      `E2E MED-240 admin override ${Date.now()}`,
-      { type: 'budget' },
+    await page.goto(
+      `/projects/${encodeURIComponent(PROJECT.slug)}/tasks/${encodeURIComponent(TASK.slug)}`,
     );
-    taskId = fixture.id;
-    taskSlug = fixture.slug;
 
-    await page.route(`**/api/tasks/${taskId}/**`, async (route) => {
-      if (route.request().method() !== 'GET') {
-        await route.continue();
-        return;
-      }
-      const response = await route.fetch();
-      const data = (await response.json()) as Record<string, unknown>;
-      await fulfillJson(route, withAdminOverrideFlag(data));
-    });
-
-    // Also cover legacy BudgetRequestDetail fetch path
-    await page.route('**/api/budgets/requests/**', async (route) => {
-      if (route.request().method() !== 'GET') {
-        await route.continue();
-        return;
-      }
-      const response = await route.fetch();
-      const data = (await response.json()) as Record<string, unknown>;
-      await fulfillJson(route, { ...data, is_admin_override: true, status: data.status ?? 'APPROVED' });
-    });
-
-    await page.goto(buildTasksListDrawerUrl(projectSlug, taskSlug!));
-    await waitForDrawerReady(page);
-
+    await expect(page.getByTestId('task-drawer')).toBeVisible({ timeout: 20_000 });
     await expect(page.getByTestId('admin-override-badge').first()).toBeVisible({
       timeout: 15_000,
     });
     await expect(page.getByTestId('admin-override-badge').first()).toHaveText(/admin override/i);
   });
 
-  test('does not show Admin override badge for a normal budget draft', async ({ page }) => {
-    await page.goto(`/projects/${encodeURIComponent(projectSlug)}/tasks`);
-    await waitForTasksPageReady(page);
+  test('does not show Admin override badge when is_admin_override is false', async ({
+    page,
+  }) => {
+    await mockBudgetTaskShell(page, false);
 
-    const fixture = await createDraftTaskViaApi(
-      page,
-      projectId,
-      `E2E MED-240 no override ${Date.now()}`,
-      { type: 'budget' },
+    await page.goto(
+      `/projects/${encodeURIComponent(PROJECT.slug)}/tasks/${encodeURIComponent(TASK.slug)}`,
     );
-    taskId = fixture.id;
-    taskSlug = fixture.slug;
 
-    await page.goto(buildTasksListDrawerUrl(projectSlug, taskSlug!));
-    await waitForDrawerReady(page);
-
+    await expect(page.getByTestId('task-drawer')).toBeVisible({ timeout: 20_000 });
     await expect(page.locator('section', { hasText: /budget details/i })).toBeVisible({
       timeout: 15_000,
     });

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -121,5 +121,12 @@ export default defineConfig({
       },
       testMatch: /e2e[\\/]messages[\\/]messages-reconnect-attachments\.spec\.ts$/,
     },
+    {
+      name: 'budget-mock',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+      testMatch: /e2e[\\/]budget[\\/]budget-admin-override\.spec\.ts$/,
+    },
   ],
 });

--- a/frontend/src/__tests__/components/budget/AdminOverrideBadge.test.tsx
+++ b/frontend/src/__tests__/components/budget/AdminOverrideBadge.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import {
+  AdminOverrideBadge,
+  stripAdminOverrideNotes,
+} from '@/components/budget/AdminOverrideBadge';
+
+describe('AdminOverrideBadge', () => {
+  it('renders the override label', () => {
+    render(<AdminOverrideBadge />);
+    expect(screen.getByTestId('admin-override-badge')).toHaveTextContent('Admin override');
+  });
+});
+
+describe('stripAdminOverrideNotes', () => {
+  it('removes machine-readable override marker lines', () => {
+    const notes = [
+      'Please prioritize',
+      '[ORG_ADMIN_OVERRIDE] user_id=9 decision=approve',
+      'Thanks',
+    ].join('\n');
+    expect(stripAdminOverrideNotes(notes)).toBe('Please prioritize\nThanks');
+  });
+
+  it('returns empty string when only override markers remain', () => {
+    expect(stripAdminOverrideNotes('[ORG_ADMIN_OVERRIDE] alone')).toBe('');
+  });
+});

--- a/frontend/src/__tests__/lib/budget/orgAdminOverrideUi.test.ts
+++ b/frontend/src/__tests__/lib/budget/orgAdminOverrideUi.test.ts
@@ -1,0 +1,58 @@
+import {
+  canOrgAdminOverrideBudgetUi,
+  resolveTaskProjectOrgId,
+  resolveUserOrgId,
+} from '@/lib/budget/orgAdminOverrideUi';
+import type { User } from '@/types/auth';
+
+const orgAdmin: User = {
+  email: 'admin@test.com',
+  username: 'admin',
+  is_org_admin: true,
+  organization: null,
+  current_organization: { id: 10, name: 'Org A', slug: 'org-a' },
+  roles: [],
+};
+
+describe('orgAdminOverrideUi', () => {
+  it('resolveUserOrgId prefers current_organization', () => {
+    expect(resolveUserOrgId(orgAdmin)).toBe(10);
+  });
+
+  it('canOrgAdminOverrideBudgetUi is false when orgs differ', () => {
+    expect(
+      canOrgAdminOverrideBudgetUi(
+        orgAdmin,
+        { type: 'budget', project_id: 1, project: { id: 1, name: 'P' } },
+        {
+          id: 1,
+          name: 'P',
+          organization: { id: 99, name: 'Other org' },
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it('canOrgAdminOverrideBudgetUi is true when orgs match', () => {
+    expect(
+      canOrgAdminOverrideBudgetUi(
+        orgAdmin,
+        { type: 'budget', project_id: 1, project: { id: 1, name: 'P' } },
+        {
+          id: 1,
+          name: 'P',
+          organization: { id: 10, name: 'Org A' },
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it('resolveTaskProjectOrgId returns null when active project does not match task', () => {
+    expect(
+      resolveTaskProjectOrgId(
+        { project_id: 2, project: { id: 2, name: 'Other' } },
+        { id: 1, name: 'Active', organization: { id: 10, name: 'Org A' } },
+      ),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/components/budget/AdminOverrideBadge.tsx
+++ b/frontend/src/components/budget/AdminOverrideBadge.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+/**
+ * Visible marker when a budget decision was made by an org-admin outside the
+ * assigned approval chain (MED-240). Render only when `is_admin_override` is true.
+ */
+export function AdminOverrideBadge({
+  className,
+  label = "Admin override",
+}: {
+  className?: string;
+  label?: string;
+}) {
+  return (
+    <Badge
+      variant="outline"
+      data-testid="admin-override-badge"
+      title="Approved or rejected by an organization admin outside the approval chain"
+      className={cn(
+        "border-amber-300 bg-amber-50 text-amber-900 font-medium",
+        className,
+      )}
+    >
+      {label}
+    </Badge>
+  );
+}
+
+/** Strip machine-readable override audit lines from user-facing notes. */
+export function stripAdminOverrideNotes(notes?: string | null): string {
+  if (!notes) return "";
+  return notes
+    .split("\n")
+    .filter((line) => !line.includes("[ORG_ADMIN_OVERRIDE]"))
+    .join("\n")
+    .trim();
+}

--- a/frontend/src/components/tasks/BudgetRequestDetail.tsx
+++ b/frontend/src/components/tasks/BudgetRequestDetail.tsx
@@ -1,6 +1,10 @@
 
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "../ui/accordion";
 import { BudgetRequestData, BudgetPoolData } from "@/lib/api/budgetApi";
+import {
+  AdminOverrideBadge,
+  stripAdminOverrideNotes,
+} from "@/components/budget/AdminOverrideBadge";
 
 interface BudgetRequestDetailProps {
   budgetRequest?: BudgetRequestData;
@@ -54,6 +58,8 @@ export default function BudgetRequestDetail({ budgetRequest, budgetPool, loading
     );
   }
 
+  const visibleNotes = stripAdminOverrideNotes(budgetRequest.notes);
+
   return (
     <section>
       <Accordion type="multiple" defaultValue={["item-1"]}>
@@ -63,11 +69,12 @@ export default function BudgetRequestDetail({ budgetRequest, budgetPool, loading
           </AccordionTrigger>
           <AccordionContent className="min-h-0 overflow-y-auto">
             <div className="space-y-8">
-              <div className="flex flex-row items-center gap-3">
+              <div className="flex flex-row items-center gap-3 flex-wrap">
                 <label className="block text-sm font-semibold text-gray-900 tracking-wide">Status</label>
                   <span className={`inline-block px-2 py-1 text-sm font-medium rounded-full ${getStatusColor(budgetRequest.status)}`}>
                     {budgetRequest.status || 'Unknown'}
                   </span>
+                  {budgetRequest.is_admin_override ? <AdminOverrideBadge /> : null}
               </div>
               <div className="flex flex-row items-center gap-3">
                 <label className="block text-sm font-semibold text-gray-900 tracking-wide">Amount</label>
@@ -131,7 +138,7 @@ export default function BudgetRequestDetail({ budgetRequest, budgetPool, loading
               <div className="flex flex-col gap-3">
                 <label className="block text-sm font-semibold text-gray-900 tracking-wide">Notes</label>
                 <span className="text-sm text-gray-900">
-                  {budgetRequest.notes || 'No notes'}
+                  {visibleNotes || 'No notes'}
                 </span>
               </div>
             </div>

--- a/frontend/src/components/tasks/detail/FSMActionBar.tsx
+++ b/frontend/src/components/tasks/detail/FSMActionBar.tsx
@@ -8,6 +8,8 @@ import type { ProjectMemberData } from '@/lib/api/projectApi';
 import InlineSelect, { UserInitialsAvatar, type InlineSelectOption } from './InlineSelect';
 import { getTypeSchema } from '@/lib/tasks/typeFieldSchemas';
 import { useAuthStore } from '@/lib/authStore';
+import { useProjectStore } from '@/lib/projectStore';
+import { canOrgAdminOverrideBudgetUi } from '@/lib/budget/orgAdminOverrideUi';
 
 type Variant = 'primary' | 'ghost' | 'danger';
 
@@ -60,17 +62,20 @@ export default function FSMActionBar({ task, members, onMutated }: Props) {
   const [forwardApprover, setForwardApprover] = useState<number | null>(null);
 
   const currentUser = useAuthStore((s) => s.user);
+  const activeProject = useProjectStore((s) => s.activeProject);
   const isCurrentApprover =
     currentUser?.id != null &&
     task.current_approver?.id != null &&
     Number(currentUser.id) === Number(task.current_approver.id);
-  // MED-240: show Approve/Reject for org-admin on budget tasks. Backend
+  // MED-240: show Approve/Reject for same-org org-admin on budget tasks. Backend
   // (user_may_process_budget_approval) is the only enforcement; this is UI only.
-  const isOrgAdmin = Boolean(currentUser?.is_org_admin);
-  const canApprove =
-    isCurrentApprover || (isOrgAdmin && task.type === 'budget');
-  const isAdminOverride =
-    isOrgAdmin && !isCurrentApprover && task.type === 'budget';
+  const canOrgAdminOverride = canOrgAdminOverrideBudgetUi(
+    currentUser,
+    task,
+    activeProject,
+  );
+  const canApprove = isCurrentApprover || canOrgAdminOverride;
+  const isAdminOverride = canOrgAdminOverride && !isCurrentApprover;
 
   const isOwner =
     currentUser?.id != null &&

--- a/frontend/src/components/tasks/detail/FSMActionBar.tsx
+++ b/frontend/src/components/tasks/detail/FSMActionBar.tsx
@@ -64,7 +64,8 @@ export default function FSMActionBar({ task, members, onMutated }: Props) {
     currentUser?.id != null &&
     task.current_approver?.id != null &&
     Number(currentUser.id) === Number(task.current_approver.id);
-  // MED-240: same-org org-admin may approve/reject budget tasks outside the chain.
+  // MED-240: show Approve/Reject for org-admin on budget tasks. Backend
+  // (user_may_process_budget_approval) is the only enforcement; this is UI only.
   const isOrgAdmin = Boolean(currentUser?.is_org_admin);
   const canApprove =
     isCurrentApprover || (isOrgAdmin && task.type === 'budget');

--- a/frontend/src/components/tasks/detail/FSMActionBar.tsx
+++ b/frontend/src/components/tasks/detail/FSMActionBar.tsx
@@ -60,10 +60,16 @@ export default function FSMActionBar({ task, members, onMutated }: Props) {
   const [forwardApprover, setForwardApprover] = useState<number | null>(null);
 
   const currentUser = useAuthStore((s) => s.user);
-  const isApprover =
+  const isCurrentApprover =
     currentUser?.id != null &&
     task.current_approver?.id != null &&
     Number(currentUser.id) === Number(task.current_approver.id);
+  // MED-240: same-org org-admin may approve/reject budget tasks outside the chain.
+  const isOrgAdmin = Boolean(currentUser?.is_org_admin);
+  const canApprove =
+    isCurrentApprover || (isOrgAdmin && task.type === 'budget');
+  const isAdminOverride =
+    isOrgAdmin && !isCurrentApprover && task.type === 'budget';
 
   const isOwner =
     currentUser?.id != null &&
@@ -174,26 +180,38 @@ export default function FSMActionBar({ task, members, onMutated }: Props) {
       });
       break;
     case 'SUBMITTED':
-      if (isApprover) {
+      if (isCurrentApprover) {
         buttons.push({ label: 'Start Review', variant: 'primary', action: () => run(() => TaskAPI.startReview(id)) });
       }
-      if (isApprover || isOwner) {
+      if (isCurrentApprover || isOwner) {
         buttons.push({ label: 'Cancel', variant: 'danger', action: () => run(() => TaskAPI.cancelTask(id)) });
       }
       break;
     case 'UNDER_REVIEW':
-      if (isApprover) {
+      if (canApprove) {
         buttons.push({
           label: 'Approve',
           variant: 'primary',
+          title: isAdminOverride
+            ? 'Org-admin override — approve outside the approval chain'
+            : undefined,
           action: () => run(() => TaskAPI.makeApproval(id, { action: 'approve' })),
         });
-        buttons.push({ label: 'Reject', variant: 'danger', action: () => setRejectOpen(true) });
+        buttons.push({
+          label: 'Reject',
+          variant: 'danger',
+          title: isAdminOverride
+            ? 'Org-admin override — reject outside the approval chain'
+            : undefined,
+          action: () => setRejectOpen(true),
+        });
+      }
+      if (isCurrentApprover) {
         buttons.push({ label: 'Cancel', variant: 'danger', action: () => run(() => TaskAPI.cancelTask(id)) });
       }
       break;
     case 'APPROVED':
-      if (isApprover) {
+      if (isCurrentApprover) {
         buttons.push({ label: 'Lock', variant: 'primary', action: () => run(() => TaskAPI.lock(id)) });
         buttons.push({ label: 'Forward', variant: 'ghost', action: () => setForwardOpen(true) });
         buttons.push({ label: 'Cancel', variant: 'danger', action: () => run(() => TaskAPI.cancelTask(id)) });
@@ -204,7 +222,7 @@ export default function FSMActionBar({ task, members, onMutated }: Props) {
       buttons.push({ label: 'Revise', variant: 'primary', action: () => run(() => TaskAPI.revise(id)) });
       break;
     case 'LOCKED':
-      if (isApprover) {
+      if (isCurrentApprover) {
         buttons.push({ label: 'Unlock', variant: 'ghost', action: () => run(() => TaskAPI.unlock(id)) });
       }
       break;

--- a/frontend/src/components/tasks/detail/TaskTypeBlock.tsx
+++ b/frontend/src/components/tasks/detail/TaskTypeBlock.tsx
@@ -41,6 +41,7 @@ const REDUNDANT_ID_KEYS = new Set([
   // budget
   'current_approver', 'ad_channel', 'budget_pool_id', 'budget_pool_composite', 'is_escalated', 'status',
   'is_admin_override',
+  'admin_override',
   // asset
   'owner',
   // retrospective

--- a/frontend/src/components/tasks/detail/TaskTypeBlock.tsx
+++ b/frontend/src/components/tasks/detail/TaskTypeBlock.tsx
@@ -10,6 +10,7 @@ import { TASK_TYPE_CONFIG_STATIC } from '@/lib/taskTypeConfigRegistry';
 import TaskTypeFieldsSection from '@/components/tasks/new/TaskTypeFieldsSection';
 import { TaskAPI } from '@/lib/api/taskApi';
 import { loadFieldOptions } from '@/lib/tasks/typeFieldOptions';
+import { AdminOverrideBadge, stripAdminOverrideNotes } from '@/components/budget/AdminOverrideBadge';
 
 function prettyLabel(type?: string): string {
   if (!type) return 'Work type';
@@ -39,6 +40,7 @@ const HIDDEN_KEYS = new Set(['id', 'task', 'task_id', 'created_at', 'updated_at'
 const REDUNDANT_ID_KEYS = new Set([
   // budget
   'current_approver', 'ad_channel', 'budget_pool_id', 'budget_pool_composite', 'is_escalated', 'status',
+  'is_admin_override',
   // asset
   'owner',
   // retrospective
@@ -293,6 +295,16 @@ export default function TaskTypeBlock({
     displayObj = rest;
   }
 
+  if (typeof displayObj.notes === 'string') {
+    const cleaned = stripAdminOverrideNotes(displayObj.notes);
+    if (cleaned) {
+      displayObj = { ...displayObj, notes: cleaned };
+    } else {
+      const { notes: _notes, ...rest } = displayObj;
+      displayObj = rest;
+    }
+  }
+
   const rawEntries = flattenEntries(displayObj, task.type ?? undefined);
   const entries = task.status === 'DRAFT'
     ? rawEntries.filter(([k]) => k !== 'submitted_at')
@@ -416,10 +428,15 @@ export default function TaskTypeBlock({
 
   return (
     <section className="min-w-0 rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-100 sm:p-5">
-      <div className="mb-3 flex items-center justify-between">
-        <h2 className="text-[13px] font-semibold uppercase tracking-wide text-gray-900">
-          {prettyLabel(task.type)} details
-        </h2>
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <h2 className="text-[13px] font-semibold uppercase tracking-wide text-gray-900">
+            {prettyLabel(task.type)} details
+          </h2>
+          {task.type === 'budget' && Boolean(displayObj.is_admin_override) ? (
+            <AdminOverrideBadge />
+          ) : null}
+        </div>
         {!loading && !readOnly && config && schema && task.status === 'DRAFT' && (
           editing ? (
             <div className="flex gap-2">

--- a/frontend/src/lib/api/budgetApi.ts
+++ b/frontend/src/lib/api/budgetApi.ts
@@ -97,6 +97,8 @@ export interface BudgetTaskDetail {
   rejection_reason?: string | null;
   cancel_reason?: string | null;
   can: BudgetTaskCapabilities;
+  /** True when an org-admin decided outside the assigned chain (MED-240). */
+  is_admin_override?: boolean;
   submitted_at?: string | null;
   approved_at?: string | null;
   activated_at?: string | null;
@@ -115,6 +117,7 @@ export type BudgetRequestData = BudgetTaskDetail & {
   ad_channel?: string | number | null;
   ad_channel_detail?: { name?: string | null } | null;
   is_escalated?: boolean;
+  is_admin_override?: boolean;
   notes?: string | null;
 };
 

--- a/frontend/src/lib/api/budgetApi.ts
+++ b/frontend/src/lib/api/budgetApi.ts
@@ -40,6 +40,15 @@ export interface BudgetTaskCapabilities {
   cancel: boolean;
 }
 
+/** Org-admin override audit (MED-240). Parsed from notes / ApprovalRecord, no extra column. */
+export interface AdminOverrideAudit {
+  override_by_user_id: number | null;
+  override_type: "org_admin";
+  replaced_step: number | null;
+  override_timestamp: string | null;
+  final_outcome: "approve" | "reject" | null;
+}
+
 /** Nested pool on budget task (summary serializer). */
 export interface BudgetPoolSummary {
   id: number;
@@ -99,6 +108,8 @@ export interface BudgetTaskDetail {
   can: BudgetTaskCapabilities;
   /** True when an org-admin decided outside the assigned chain (MED-240). */
   is_admin_override?: boolean;
+  /** Structured override audit parsed from the notes marker (no extra DB column). */
+  admin_override?: AdminOverrideAudit | null;
   submitted_at?: string | null;
   approved_at?: string | null;
   activated_at?: string | null;
@@ -118,6 +129,7 @@ export type BudgetRequestData = BudgetTaskDetail & {
   ad_channel_detail?: { name?: string | null } | null;
   is_escalated?: boolean;
   is_admin_override?: boolean;
+  admin_override?: AdminOverrideAudit | null;
   notes?: string | null;
 };
 

--- a/frontend/src/lib/budget/orgAdminOverrideUi.ts
+++ b/frontend/src/lib/budget/orgAdminOverrideUi.ts
@@ -1,0 +1,52 @@
+import type { ProjectData } from '@/lib/api/projectApi';
+import type { TaskData } from '@/types/task';
+import type { User } from '@/types/auth';
+
+/** Org id for the signed-in user (current org, then legacy organization). */
+export function resolveUserOrgId(user: User | null | undefined): number | null {
+  const org = user?.current_organization ?? user?.organization;
+  if (org?.id == null) return null;
+  const id = Number(org.id);
+  return Number.isFinite(id) ? id : null;
+}
+
+/**
+ * Org id for the task's project when it matches the active project in the shell.
+ * Task API project summary has no organization field; activeProject does.
+ */
+export function resolveTaskProjectOrgId(
+  task: Pick<TaskData, 'project' | 'project_id'>,
+  activeProject: ProjectData | null | undefined,
+): number | null {
+  const taskProjectId = task.project?.id ?? task.project_id;
+  if (taskProjectId == null || !activeProject) return null;
+  if (String(activeProject.id) !== String(taskProjectId)) return null;
+
+  const orgId = activeProject.organization?.id ?? activeProject.organization_id;
+  if (orgId == null) return null;
+  const id = Number(orgId);
+  return Number.isFinite(id) ? id : null;
+}
+
+/**
+ * Whether to show org-admin override Approve/Reject on a budget task (UI only).
+ * Backend `user_may_process_budget_approval` is the real gate; this avoids
+ * showing buttons when we know the org-admin is in a different org context.
+ */
+export function canOrgAdminOverrideBudgetUi(
+  user: User | null | undefined,
+  task: Pick<TaskData, 'type' | 'project' | 'project_id'>,
+  activeProject: ProjectData | null | undefined,
+): boolean {
+  if (!user?.is_org_admin || task.type !== 'budget') return false;
+
+  const userOrgId = resolveUserOrgId(user);
+  const taskOrgId = resolveTaskProjectOrgId(task, activeProject);
+
+  if (userOrgId != null && taskOrgId != null) {
+    return userOrgId === taskOrgId;
+  }
+
+  // Unknown task org — keep legacy behaviour; backend still enforces same-org.
+  return true;
+}


### PR DESCRIPTION
## Summary
- Enable same-org **Organization Admin** users to approve/reject **budget** tasks from the task UI/API path even when they are not the current chain approver (`MED-240`).
- Preserve override auditability and UX clarity:
  - backend writes org-admin override markers/audit
  - frontend shows `Admin override` badge only when the decision was a true override
- Keep approval-chain semantics intact:
  - override approve replaces only the current step
  - if a next chain step exists, flow continues to the original next approver
  - if last/no chain step, it finalizes as approved

## What Changed

### Backend
- Added shared override access helpers for budget approval checks.
- Updated task approval endpoint (`make_approval`) to allow budget org-admin override (same org) while keeping non-budget behavior unchanged.
- Kept/extended override audit behavior and marker handling.
- Added/updated tests for:
  - org-admin override permission matrix
  - task API path (`make_approval`) for org-admin
  - chain auto-advance + final-step behavior

### Frontend
- Updated task FSM action gating so budget org-admin can see/use Approve/Reject when not current approver.
- Added override context/tooltips in action buttons.
- Kept badge behavior scoped to true override scenarios.
- Playwright coverage for badge visible/hidden paths.

## Test Plan

### Backend
- `docker compose -p mediajira-v2 -f docker-compose.dev.yml exec -T backend pytest budget_approval/tests/test_permissions.py::TestOrgAdminApprovalOverridePermissions -vv -n0 --no-cov`
- `docker compose -p mediajira-v2 -f docker-compose.dev.yml exec -T backend pytest budget_approval/tests/test_services.py -k "org_admin" -vv -n0 --no-cov`

### Frontend
- `docker compose -p mediajira-v2 -f docker-compose.dev.yml exec -T -e BASE_URL=http://127.0.0.1:3000 frontend npx playwright test e2e/budget/budget-admin-override.spec.ts --project=budget-mock --reporter=line --workers=1`

### Manual QA (frontend edge cases)
- EDGE1: org-admin not current approver → Approve succeeds + `Admin override` badge
- EDGE2: org-admin is current approver → Approve succeeds, **no** override badge
- EDGE3: regular member (non-admin, non-approver) → no Approve/Reject
- EDGE4: multi-step chain → org-admin approve advances to next chain approver (not admin-picked)

## Out of Scope
- Org-admin Start Review / Lock / Forward behaviors
- Cross-org override
- Non-budget override
- List STATUS dropdown clipping UX issue

## Notes
- Local QA fixture users/tasks are seed data only (not committed to repository).