### PR TITLE
feat(observability): Grafana dashboard for WebSocket session counts — MED-319

### DIFF
--- a/backend/asset/consumers.py
+++ b/backend/asset/consumers.py
@@ -1,16 +1,18 @@
 import json
-from channels.generic.websocket import AsyncWebsocketConsumer
 from channels.db import database_sync_to_async
 from django.contrib.auth.models import AnonymousUser
+from core.consumers import InstrumentedAsyncWebsocketConsumer
 from .models import Asset
 
 
-class AssetConsumer(AsyncWebsocketConsumer):
+class AssetConsumer(InstrumentedAsyncWebsocketConsumer):
     """
     WebSocket consumer for real-time asset updates.
     Handles connections to asset-specific groups for live updates.
     """
-    
+
+    ws_channel = 'asset'
+
     async def connect(self):
         """Handle WebSocket connection"""
         self.asset_id = self.scope['url_route']['kwargs']['asset_id']

--- a/backend/chat/consumers.py
+++ b/backend/chat/consumers.py
@@ -7,7 +7,6 @@ from collections import OrderedDict
 from contextlib import suppress
 from datetime import timedelta
 from functools import wraps
-from channels.generic.websocket import AsyncWebsocketConsumer
 from channels.db import database_sync_to_async
 from asgiref.sync import sync_to_async
 from django.contrib.auth import get_user_model
@@ -16,6 +15,7 @@ from django.core.cache import cache
 from .models import Chat, ChatParticipant, Message, MessageStatus
 from .realtime import broadcast_event_to_user_groups
 from django.conf import settings
+from core.consumers import InstrumentedAsyncWebsocketConsumer
 from core.tenant_context import tenant_schema_context, validate_tenant_schema
 from .services import (
     ChatService,
@@ -65,7 +65,7 @@ def tenant_db_method(method):
     return wrapped
 
 
-class ChatConsumer(AsyncWebsocketConsumer):
+class ChatConsumer(InstrumentedAsyncWebsocketConsumer):
     """
     WebSocket consumer for real-time chat functionality.
     
@@ -85,7 +85,9 @@ class ChatConsumer(AsyncWebsocketConsumer):
     - typing_indicator: Someone is typing
     - error: Error occurred
     """
-    
+
+    ws_channel = 'chat'
+
     async def connect(self):
         """Handle WebSocket connection"""
         self.user_id = self.scope['url_route']['kwargs']['user_id']

--- a/backend/core/consumers.py
+++ b/backend/core/consumers.py
@@ -1,0 +1,57 @@
+"""Base Channels consumer that reports live session counts to Prometheus."""
+
+from channels.generic.websocket import AsyncWebsocketConsumer
+
+from .metrics import ws_sessions_active
+
+
+class InstrumentedAsyncWebsocketConsumer(AsyncWebsocketConsumer):
+    """AsyncWebsocketConsumer that keeps ``ws_sessions_active`` accurate.
+
+    Subclasses only declare ``ws_channel``; their ``connect``/``disconnect``
+    stay untouched. The counting deliberately hangs off ``accept()`` and
+    ``__call__`` rather than the ``connect``/``disconnect`` hooks:
+
+    - ``connect()`` is the wrong place to count. Consumers reject handshakes by
+      calling ``close()`` and returning before ``accept()``, and Channels still
+      delivers ``websocket.disconnect`` afterwards, so counting every connect
+      would let rejected handshakes decrement the gauge below zero.
+    - ``disconnect()`` is the wrong place to release. It only runs on an orderly
+      shutdown: a consumer that raises after accepting (or is cancelled) never
+      reaches it, and would stay counted until the process restarted. ``__call__``
+      wraps the whole connection, so every exit path releases the session.
+
+    A session is therefore counted once the handshake is actually accepted, and
+    released exactly once when the connection ends, however it ends.
+    """
+
+    #: Value of the ``channel`` label, e.g. ``"chat"``. Required.
+    ws_channel = None
+
+    # Class-level default: subclasses need no __init__ to get a starting value.
+    _ws_session_counted = False
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if not cls.ws_channel:
+            raise TypeError(
+                f'{cls.__name__} must set ws_channel to label its '
+                f'ws_sessions_active series'
+            )
+        # Instantiate the child gauge at import time so an idle channel reports
+        # 0 instead of dropping out of /metrics until its first connection.
+        ws_sessions_active.labels(channel=cls.ws_channel)
+
+    async def __call__(self, scope, receive, send):
+        try:
+            await super().__call__(scope, receive, send)
+        finally:
+            if self._ws_session_counted:
+                self._ws_session_counted = False
+                ws_sessions_active.labels(channel=self.ws_channel).dec()
+
+    async def accept(self, *args, **kwargs):
+        await super().accept(*args, **kwargs)
+        if not self._ws_session_counted:
+            self._ws_session_counted = True
+            ws_sessions_active.labels(channel=self.ws_channel).inc()

--- a/backend/core/metrics.py
+++ b/backend/core/metrics.py
@@ -10,8 +10,22 @@ from prometheus_client import Gauge
 
 # Sessions that completed the WebSocket handshake and have not disconnected
 # yet. Rejected handshakes never count: connect() closes those before accept().
+#
+# Cardinality: ``channel`` is bounded by the number of consumer classes, not by
+# traffic. Its only source is the class-level ``ws_channel`` constant that each
+# consumer declares (see InstrumentedAsyncWebsocketConsumer); the label is never
+# derived from the connection -- not from scope, url_route kwargs, the user, the
+# room or the sheet id -- so no volume of sessions can mint a new series. The
+# allowed values are exactly:
+#
+#     asset | chat | csm | meetings | portal | retrospective | spreadsheet
+#
+# Adding a per-room or per-user label would mean editing the base class, and
+# test_channel_label_set_is_bounded_and_declared fails on any label value that
+# is not in that list. Keep it that way: a label whose values track connections
+# is what turns a gauge into a series explosion.
 ws_sessions_active = Gauge(
     'ws_sessions_active',
     'Currently connected WebSocket sessions',
-    ['channel'],  # channel: chat | spreadsheet | csm | portal | meetings | retrospective | asset
+    ['channel'],
 )

--- a/backend/core/metrics.py
+++ b/backend/core/metrics.py
@@ -1,0 +1,17 @@
+"""Prometheus metrics shared across apps.
+
+Scraped through django_prometheus alongside the rest of the application's
+metrics. The backend serves HTTP and WebSocket traffic from a single daphne
+process (see backend/Dockerfile), so an in-process gauge and the /metrics
+endpoint always agree; with several replicas, sum across instances in Grafana.
+"""
+
+from prometheus_client import Gauge
+
+# Sessions that completed the WebSocket handshake and have not disconnected
+# yet. Rejected handshakes never count: connect() closes those before accept().
+ws_sessions_active = Gauge(
+    'ws_sessions_active',
+    'Currently connected WebSocket sessions',
+    ['channel'],  # channel: chat | spreadsheet | csm | portal | meetings | retrospective | asset
+)

--- a/backend/core/tests/test_ws_session_metrics.py
+++ b/backend/core/tests/test_ws_session_metrics.py
@@ -1,0 +1,134 @@
+"""Tests for the ws_sessions_active gauge on the instrumented consumer base."""
+
+import pytest
+from channels.testing import WebsocketCommunicator
+from prometheus_client import REGISTRY
+
+from asset.consumers import AssetConsumer
+from chat.consumers import ChatConsumer
+from core.consumers import InstrumentedAsyncWebsocketConsumer
+from csm.consumers import CsmConversationConsumer
+from meetings.consumers import MeetingDocumentConsumer
+from portal.consumers import PortalConversationConsumer
+from retrospective.consumers import RetrospectiveConsumer
+from spreadsheet.consumers import SheetConsumer
+
+WEBSOCKET_CONSUMERS = [
+    AssetConsumer,
+    ChatConsumer,
+    CsmConversationConsumer,
+    MeetingDocumentConsumer,
+    PortalConversationConsumer,
+    RetrospectiveConsumer,
+    SheetConsumer,
+]
+
+
+class AcceptingConsumer(InstrumentedAsyncWebsocketConsumer):
+    ws_channel = 'test_accepting'
+
+    async def connect(self):
+        await self.accept()
+
+
+class RejectingConsumer(InstrumentedAsyncWebsocketConsumer):
+    ws_channel = 'test_rejecting'
+
+    async def connect(self):
+        # Same shape as the real consumers' auth failures: close, no accept.
+        await self.close(code=4001)
+
+
+class CrashingConsumer(InstrumentedAsyncWebsocketConsumer):
+    ws_channel = 'test_crashing'
+
+    async def connect(self):
+        await self.accept()
+        raise RuntimeError('post-accept initialization blew up')
+
+
+@pytest.fixture(autouse=True)
+def in_memory_channel_layer(settings):
+    """Keep the consumers off the Redis layer these tests do not need."""
+    settings.CHANNEL_LAYERS = {
+        'default': {'BACKEND': 'channels.layers.InMemoryChannelLayer'}
+    }
+
+
+def active_sessions(channel):
+    return REGISTRY.get_sample_value('ws_sessions_active', {'channel': channel})
+
+
+async def test_accepted_connection_is_counted_until_disconnect():
+    communicator = WebsocketCommunicator(AcceptingConsumer.as_asgi(), '/ws/test/')
+
+    connected, _ = await communicator.connect()
+    assert connected
+    assert active_sessions('test_accepting') == 1
+
+    await communicator.disconnect()
+    assert active_sessions('test_accepting') == 0
+
+
+async def test_concurrent_sessions_are_counted_independently():
+    first = WebsocketCommunicator(AcceptingConsumer.as_asgi(), '/ws/test/')
+    second = WebsocketCommunicator(AcceptingConsumer.as_asgi(), '/ws/test/')
+    await first.connect()
+    await second.connect()
+    assert active_sessions('test_accepting') == 2
+
+    await first.disconnect()
+    assert active_sessions('test_accepting') == 1
+
+    await second.disconnect()
+    assert active_sessions('test_accepting') == 0
+
+
+async def test_rejected_handshake_is_never_counted():
+    """Channels delivers websocket.disconnect for rejected handshakes too.
+
+    Counting on connect() rather than accept() would decrement a session that
+    was never counted and drive the gauge negative.
+    """
+    communicator = WebsocketCommunicator(RejectingConsumer.as_asgi(), '/ws/test/')
+
+    connected, _ = await communicator.connect()
+    assert not connected
+    assert active_sessions('test_rejecting') == 0
+
+    await communicator.disconnect()
+    assert active_sessions('test_rejecting') == 0
+
+
+async def test_session_is_released_when_the_consumer_crashes_after_accepting():
+    """A consumer that raises post-accept never reaches disconnect().
+
+    Releasing there instead of around the whole connection would keep the
+    session counted until the process restarted.
+    """
+    communicator = WebsocketCommunicator(CrashingConsumer.as_asgi(), '/ws/test/')
+
+    await communicator.connect()
+    with pytest.raises(RuntimeError, match='post-accept'):
+        await communicator.wait(timeout=5)
+
+    assert active_sessions('test_crashing') == 0
+
+
+def test_every_websocket_consumer_exports_its_own_channel_series():
+    labels = [consumer.ws_channel for consumer in WEBSOCKET_CONSUMERS]
+    assert len(set(labels)) == len(labels), f'duplicate ws_channel labels: {labels}'
+
+    # Declaring a subclass registers the series, so a channel is scrapeable
+    # before its first connection instead of missing from /metrics. Asserting
+    # presence rather than 0: other test modules sharing this xdist worker may
+    # legitimately have sessions open.
+    for label in labels:
+        assert active_sessions(label) is not None
+
+
+def test_consumer_without_a_channel_label_is_rejected():
+    with pytest.raises(TypeError, match='ws_channel'):
+
+        class UnlabelledConsumer(InstrumentedAsyncWebsocketConsumer):
+            pass

--- a/backend/core/tests/test_ws_session_metrics.py
+++ b/backend/core/tests/test_ws_session_metrics.py
@@ -28,9 +28,15 @@ WEBSOCKET_CONSUMERS = [
 # RetrospectiveConsumer is deliberately absent from backend/asgi.py. Its
 # connect() never rejects an unauthenticated user -- the check is commented out
 # -- so routing it would publish retrospective broadcasts to anyone who can
-# guess an id. It is instrumented already and will be picked up automatically
-# once its authentication is implemented and the route registered; remove it
-# from here at that point.
+# guess an id.
+#
+# Whoever fixes that consumer needs to change one thing and one thing only:
+# register its route in backend/asgi.py. The consumer already inherits the
+# instrumented base and declares its channel, so the series appears on /metrics
+# as soon as the module is imported, and the dashboard discovers channels with
+# label_values() rather than a hardcoded list, so it needs no edit either. This
+# test will then fail and tell them to remove the entry below, which is the
+# intended handover: the exemption cannot outlive the fix unnoticed.
 KNOWN_UNROUTED_CHANNELS = {'retrospective'}
 
 
@@ -229,6 +235,23 @@ def test_every_routed_consumer_exports_its_channel_series():
         assert active_sessions(consumer.ws_channel) is not None, (
             f'{consumer.ws_channel} is routed but has no registered series'
         )
+
+
+def test_unrouted_consumers_are_already_wired_for_when_they_are_routed():
+    """An unrouted consumer must still be metric-ready, so routing is the only fix.
+
+    The point of instrumenting a consumer that cannot currently be reached is
+    that whoever makes it reachable does not also have to come back through the
+    metrics and the dashboard. Registering the route must be sufficient.
+    """
+    routed = {consumer.ws_channel for consumer in routed_consumer_classes()}
+    unrouted = [c for c in WEBSOCKET_CONSUMERS if c.ws_channel not in routed]
+
+    for consumer in unrouted:
+        assert issubclass(consumer, InstrumentedAsyncWebsocketConsumer), (
+            f'{consumer.__name__} would still need instrumenting after routing'
+        )
+        assert consumer.ws_channel, f'{consumer.__name__} declares no channel label'
 
 
 def test_no_consumer_is_silently_left_out_of_the_asgi_router():

--- a/backend/core/tests/test_ws_session_metrics.py
+++ b/backend/core/tests/test_ws_session_metrics.py
@@ -1,5 +1,8 @@
 """Tests for the ws_sessions_active gauge on the instrumented consumer base."""
 
+import multiprocessing
+from concurrent.futures import ProcessPoolExecutor
+
 import pytest
 from channels.routing import URLRouter
 from channels.testing import WebsocketCommunicator
@@ -38,6 +41,20 @@ WEBSOCKET_CONSUMERS = [
 # test will then fail and tell them to remove the entry below, which is the
 # intended handover: the exemption cannot outlive the fix unnoticed.
 KNOWN_UNROUTED_CHANNELS = {'retrospective'}
+
+# Every value the ``channel`` label is allowed to take. The point of pinning it
+# here is cardinality: a label whose values track connections rather than code
+# is how a gauge turns into a series explosion, so a new value has to be added
+# deliberately in this list rather than appearing at runtime.
+EXPECTED_CHANNELS = frozenset({
+    'asset',
+    'chat',
+    'csm',
+    'meetings',
+    'portal',
+    'retrospective',
+    'spreadsheet',
+})
 
 
 class AcceptingConsumer(InstrumentedAsyncWebsocketConsumer):
@@ -92,6 +109,63 @@ def in_memory_channel_layer(settings):
 
 def active_sessions(channel):
     return REGISTRY.get_sample_value('ws_sessions_active', {'channel': channel})
+
+
+def channel_label_values():
+    """Every ``channel`` value currently present as a series in the registry."""
+    return {
+        sample.labels['channel']
+        for metric in REGISTRY.collect()
+        if metric.name == 'ws_sessions_active'
+        for sample in metric.samples
+    }
+
+
+def _sessions_in_a_separate_process(session_count):
+    """Open ``session_count`` sessions in a fresh process, return its exposition.
+
+    Runs as the entry point of a spawned process, so it must stay importable at
+    module level and must not rely on anything the parent set up: a new process
+    gets a new prometheus registry, which is the whole point of the exercise.
+    """
+    import asyncio
+    import os
+
+    import django
+
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
+    django.setup()
+
+    from channels.testing import WebsocketCommunicator
+    from prometheus_client import REGISTRY as CHILD_REGISTRY
+
+    from core.consumers import InstrumentedAsyncWebsocketConsumer
+
+    class _WorkerConsumer(InstrumentedAsyncWebsocketConsumer):
+        ws_channel = 'chat'
+
+        async def connect(self):
+            await self.accept()
+
+    async def hold_sessions():
+        communicators = []
+        for _ in range(session_count):
+            communicator = WebsocketCommunicator(_WorkerConsumer.as_asgi(), '/ws/test/')
+            connected, _ = await communicator.connect()
+            assert connected
+            communicators.append(communicator)
+
+        # Read while they are all still open: this is the process' own view,
+        # which is exactly what a Prometheus scrape of this instance would get.
+        value = CHILD_REGISTRY.get_sample_value(
+            'ws_sessions_active', {'channel': 'chat'}
+        )
+
+        for communicator in communicators:
+            await communicator.disconnect()
+        return value
+
+    return asyncio.run(hold_sessions())
 
 
 def routed_consumer_classes():
@@ -277,3 +351,66 @@ def test_consumer_without_a_channel_label_is_rejected():
 
         class UnlabelledConsumer(InstrumentedAsyncWebsocketConsumer):
             pass
+
+
+def test_channel_label_set_is_bounded_and_declared():
+    """Cardinality guard: ``channel`` is fixed by the code, not by traffic.
+
+    The failure this prevents is a label that takes a per-user, per-room or
+    per-sheet value, which grows the series count with usage until Prometheus
+    struggles. ``ws_channel`` is a class constant, so the ceiling is the number
+    of consumer classes -- but only for as long as nobody makes it dynamic.
+    """
+    assert {c.ws_channel for c in WEBSOCKET_CONSUMERS} == EXPECTED_CHANNELS
+
+    for consumer in WEBSOCKET_CONSUMERS:
+        declared = vars(consumer).get('ws_channel')
+        assert isinstance(declared, str) and declared, (
+            f'{consumer.__name__}.ws_channel must be a class-level string constant; '
+            f'a value computed per connection would be unbounded'
+        )
+
+    # Nothing outside the declared set may have reached the registry. The test
+    # consumers in this module are namespaced 'test_*' and excluded.
+    live = {value for value in channel_label_values() if not value.startswith('test_')}
+    assert live <= EXPECTED_CHANNELS, f'undeclared channel series: {live - EXPECTED_CHANNELS}'
+
+
+async def test_sessions_do_not_create_new_label_values():
+    """Connections must reuse one series per channel, never mint their own."""
+    before = channel_label_values()
+
+    for path in ('/ws/test/1/', '/ws/test/2/', '/ws/test/3/'):
+        communicator = WebsocketCommunicator(AcceptingConsumer.as_asgi(), path)
+        connected, _ = await communicator.connect()
+        assert connected
+        await communicator.disconnect()
+
+    assert channel_label_values() == before
+
+
+def test_two_processes_aggregate_to_the_global_total():
+    """Each process reports only its own sessions; summing them is the total.
+
+    This is the multi-instance question made concrete. An in-process gauge is
+    not a bug to be replaced with a shared counter in Redis -- it is the shape
+    Prometheus expects, because each process is scraped as its own instance and
+    the aggregation happens at query time. What has to hold is that the parts
+    sum to the whole, which is what the dashboard's ``sum by (channel)`` does.
+
+    Two spawned processes each hold a different number of sessions, so a result
+    that accidentally reflected one process' view would not equal the total.
+    """
+    context = multiprocessing.get_context('spawn')
+    with ProcessPoolExecutor(max_workers=2, mp_context=context) as pool:
+        first = pool.submit(_sessions_in_a_separate_process, 3)
+        second = pool.submit(_sessions_in_a_separate_process, 5)
+        first_value = first.result(timeout=120)
+        second_value = second.result(timeout=120)
+
+    # Each instance sees its own sessions and nobody else's.
+    assert first_value == 3
+    assert second_value == 5
+
+    # sum(ws_sessions_active{channel="chat"}) across instances.
+    assert first_value + second_value == 8

--- a/backend/core/tests/test_ws_session_metrics.py
+++ b/backend/core/tests/test_ws_session_metrics.py
@@ -47,6 +47,25 @@ class CrashingConsumer(InstrumentedAsyncWebsocketConsumer):
         raise RuntimeError('post-accept initialization blew up')
 
 
+class DoubleAcceptConsumer(InstrumentedAsyncWebsocketConsumer):
+    ws_channel = 'test_double_accept'
+
+    async def connect(self):
+        await self.accept()
+        await self.accept()
+
+
+class DoubleCloseConsumer(InstrumentedAsyncWebsocketConsumer):
+    """chat closes in 6 places and spreadsheet in 7; some paths can overlap."""
+
+    ws_channel = 'test_double_close'
+
+    async def connect(self):
+        await self.accept()
+        await self.close(code=1011)
+        await self.close(code=1011)
+
+
 @pytest.fixture(autouse=True)
 def in_memory_channel_layer(settings):
     """Keep the consumers off the Redis layer these tests do not need."""
@@ -113,6 +132,44 @@ async def test_session_is_released_when_the_consumer_crashes_after_accepting():
         await communicator.wait(timeout=5)
 
     assert active_sessions('test_crashing') == 0
+
+
+async def test_accepting_twice_counts_one_session():
+    communicator = WebsocketCommunicator(DoubleAcceptConsumer.as_asgi(), '/ws/test/')
+
+    await communicator.connect()
+    assert active_sessions('test_double_accept') == 1
+
+    await communicator.disconnect()
+    assert active_sessions('test_double_accept') == 0
+
+
+async def test_closing_twice_releases_one_session():
+    communicator = WebsocketCommunicator(DoubleCloseConsumer.as_asgi(), '/ws/test/')
+
+    await communicator.connect()
+    await communicator.disconnect()
+
+    # A second release would show up as -1, not 0.
+    assert active_sessions('test_double_close') == 0
+
+
+async def test_repeated_connect_disconnect_cycles_leave_no_drift():
+    """The integrity guard: churn must not accumulate phantom sessions.
+
+    A gauge that drifts up by a fraction of a session per cycle looks fine for
+    an hour and is badly wrong by the next day, which is exactly the failure
+    mode that makes a capacity dashboard untrustworthy.
+    """
+    baseline = active_sessions('test_accepting')
+
+    for _ in range(25):
+        communicator = WebsocketCommunicator(AcceptingConsumer.as_asgi(), '/ws/test/')
+        connected, _ = await communicator.connect()
+        assert connected
+        await communicator.disconnect()
+
+    assert active_sessions('test_accepting') == baseline
 
 
 def test_every_websocket_consumer_exports_its_own_channel_series():

--- a/backend/core/tests/test_ws_session_metrics.py
+++ b/backend/core/tests/test_ws_session_metrics.py
@@ -1,9 +1,11 @@
 """Tests for the ws_sessions_active gauge on the instrumented consumer base."""
 
 import pytest
+from channels.routing import URLRouter
 from channels.testing import WebsocketCommunicator
 from prometheus_client import REGISTRY
 
+from backend.asgi import application
 from asset.consumers import AssetConsumer
 from chat.consumers import ChatConsumer
 from core.consumers import InstrumentedAsyncWebsocketConsumer
@@ -22,6 +24,14 @@ WEBSOCKET_CONSUMERS = [
     RetrospectiveConsumer,
     SheetConsumer,
 ]
+
+# RetrospectiveConsumer is deliberately absent from backend/asgi.py. Its
+# connect() never rejects an unauthenticated user -- the check is commented out
+# -- so routing it would publish retrospective broadcasts to anyone who can
+# guess an id. It is instrumented already and will be picked up automatically
+# once its authentication is implemented and the route registered; remove it
+# from here at that point.
+KNOWN_UNROUTED_CHANNELS = {'retrospective'}
 
 
 class AcceptingConsumer(InstrumentedAsyncWebsocketConsumer):
@@ -76,6 +86,31 @@ def in_memory_channel_layer(settings):
 
 def active_sessions(channel):
     return REGISTRY.get_sample_value('ws_sessions_active', {'channel': channel})
+
+
+def routed_consumer_classes():
+    """Consumer classes reachable through the real websocket application."""
+    app = application.application_mapping['websocket']
+    for _ in range(10):
+        if isinstance(app, URLRouter):
+            break
+        app = getattr(app, 'inner', None) or getattr(app, 'application', None)
+        if app is None:
+            raise AssertionError('no URLRouter found in the websocket application')
+    else:
+        raise AssertionError('no URLRouter found in the websocket application')
+
+    found = []
+    pending = list(app.routes)
+    while pending:
+        callback = pending.pop().callback
+        if isinstance(callback, URLRouter):
+            pending.extend(callback.routes)
+            continue
+        consumer_cls = getattr(callback, 'consumer_class', None)
+        if consumer_cls is not None:
+            found.append(consumer_cls)
+    return found
 
 
 async def test_accepted_connection_is_counted_until_disconnect():
@@ -172,16 +207,46 @@ async def test_repeated_connect_disconnect_cycles_leave_no_drift():
     assert active_sessions('test_accepting') == baseline
 
 
-def test_every_websocket_consumer_exports_its_own_channel_series():
+def test_every_routed_consumer_exports_its_channel_series():
+    """Checked through the real ASGI router, not by importing the consumers.
+
+    Importing a consumer registers its series in the test process, so a suite
+    that imports them directly would create the very series it claims to be
+    verifying and report coverage production does not have.
+    """
+    routed = routed_consumer_classes()
+    assert routed, 'no consumers found in the websocket ASGI router'
+
     labels = [consumer.ws_channel for consumer in WEBSOCKET_CONSUMERS]
     assert len(set(labels)) == len(labels), f'duplicate ws_channel labels: {labels}'
 
-    # Declaring a subclass registers the series, so a channel is scrapeable
-    # before its first connection instead of missing from /metrics. Asserting
-    # presence rather than 0: other test modules sharing this xdist worker may
-    # legitimately have sessions open.
-    for label in labels:
-        assert active_sessions(label) is not None
+    for consumer in routed:
+        assert issubclass(consumer, InstrumentedAsyncWebsocketConsumer), (
+            f'{consumer.__name__} is routed but does not report sessions'
+        )
+        # Declaring a subclass registers the series, so a channel is scrapeable
+        # before its first connection instead of missing from /metrics.
+        assert active_sessions(consumer.ws_channel) is not None, (
+            f'{consumer.ws_channel} is routed but has no registered series'
+        )
+
+
+def test_no_consumer_is_silently_left_out_of_the_asgi_router():
+    """A consumer production never imports never registers its series.
+
+    Anything newly missing from the router has to be acknowledged here rather
+    than passing unnoticed, and anything that becomes routed has to be removed
+    from the exemption.
+    """
+    routed = {consumer.ws_channel for consumer in routed_consumer_classes()}
+    declared = {consumer.ws_channel for consumer in WEBSOCKET_CONSUMERS}
+    unrouted = declared - routed
+
+    assert unrouted == KNOWN_UNROUTED_CHANNELS, (
+        f'missing from backend/asgi.py: {sorted(unrouted - KNOWN_UNROUTED_CHANNELS)}; '
+        f'now routed, remove from KNOWN_UNROUTED_CHANNELS: '
+        f'{sorted(KNOWN_UNROUTED_CHANNELS - unrouted)}'
+    )
 
 
 def test_consumer_without_a_channel_label_is_rejected():

--- a/backend/csm/consumers.py
+++ b/backend/csm/consumers.py
@@ -1,12 +1,13 @@
 import json
 import logging
-from channels.generic.websocket import AsyncWebsocketConsumer
 from channels.db import database_sync_to_async
+
+from core.consumers import InstrumentedAsyncWebsocketConsumer
 
 logger = logging.getLogger(__name__)
 
 
-class CsmConversationConsumer(AsyncWebsocketConsumer):
+class CsmConversationConsumer(InstrumentedAsyncWebsocketConsumer):
     """
     WebSocket consumer for real-time CSM conversation updates.
 
@@ -24,6 +25,8 @@ class CsmConversationConsumer(AsyncWebsocketConsumer):
     - typing_indicator: Someone is typing
     - error: Error message
     """
+
+    ws_channel = 'csm'
 
     async def connect(self):
         self.user_id = self.scope['url_route']['kwargs']['user_id']

--- a/backend/meetings/consumers.py
+++ b/backend/meetings/consumers.py
@@ -1,9 +1,9 @@
 import json
 
 from channels.db import database_sync_to_async
-from channels.generic.websocket import AsyncWebsocketConsumer
 from django.contrib.auth.models import AnonymousUser
 
+from core.consumers import InstrumentedAsyncWebsocketConsumer
 from meetings.models import Meeting
 from meetings.services import (
     get_or_create_meeting_document,
@@ -27,7 +27,9 @@ def _optional_int_from_json(value, field_name: str):
     raise ValueError(f"{field_name} must be an integer")
 
 
-class MeetingDocumentConsumer(AsyncWebsocketConsumer):
+class MeetingDocumentConsumer(InstrumentedAsyncWebsocketConsumer):
+    ws_channel = 'meetings'
+
     async def connect(self):
         self.meeting_id = int(self.scope["url_route"]["kwargs"]["meeting_id"])
         self.room_group_name = f"meeting_document_{self.meeting_id}"

--- a/backend/portal/consumers.py
+++ b/backend/portal/consumers.py
@@ -1,12 +1,13 @@
 import json
 import logging
-from channels.generic.websocket import AsyncWebsocketConsumer
 from channels.db import database_sync_to_async
+
+from core.consumers import InstrumentedAsyncWebsocketConsumer
 
 logger = logging.getLogger(__name__)
 
 
-class PortalConversationConsumer(AsyncWebsocketConsumer):
+class PortalConversationConsumer(InstrumentedAsyncWebsocketConsumer):
     """
     WebSocket consumer for real-time updates in the customer portal.
 
@@ -15,6 +16,8 @@ class PortalConversationConsumer(AsyncWebsocketConsumer):
     Server → Client events:
     - new_message: An agent or system has sent a message in this conversation
     """
+
+    ws_channel = 'portal'
 
     async def connect(self):
         self.conversation_id = int(self.scope['url_route']['kwargs']['conversation_id'])

--- a/backend/retrospective/consumers.py
+++ b/backend/retrospective/consumers.py
@@ -1,16 +1,18 @@
 import json
-from channels.generic.websocket import AsyncWebsocketConsumer
 from channels.db import database_sync_to_async
 from django.contrib.auth.models import AnonymousUser
+from core.consumers import InstrumentedAsyncWebsocketConsumer
 from .models import RetrospectiveTask, Insight, CampaignMetric
 
 
-class RetrospectiveConsumer(AsyncWebsocketConsumer):
+class RetrospectiveConsumer(InstrumentedAsyncWebsocketConsumer):
     """
     WebSocket consumer for real-time retrospective updates.
     Handles connections to retrospective-specific groups for live updates.
     """
-    
+
+    ws_channel = 'retrospective'
+
     async def connect(self):
         """Handle WebSocket connection"""
         # Handle both URL route and direct path scenarios

--- a/backend/spreadsheet/consumers.py
+++ b/backend/spreadsheet/consumers.py
@@ -6,9 +6,9 @@ from urllib.parse import parse_qs
 
 from asgiref.sync import sync_to_async
 from channels.db import database_sync_to_async
-from channels.generic.websocket import AsyncWebsocketConsumer
 from django.contrib.auth.models import AnonymousUser
 
+from core.consumers import InstrumentedAsyncWebsocketConsumer
 from spreadsheet.presence import get_presence_store
 from spreadsheet.services import sheet_room_group_name, user_has_sheet_access
 from spreadsheet.tenant import tenant_schema_context, validate_tenant_schema
@@ -72,13 +72,15 @@ def _optional_int_from_json(value, field_name: str):
     raise ValueError(f"{field_name} must be an integer")
 
 
-class SheetConsumer(AsyncWebsocketConsumer):
+class SheetConsumer(InstrumentedAsyncWebsocketConsumer):
     """Sheet-room WebSocket: join/leave, presence list, cursor + committed cell broadcasts.
 
     Cell edits are written over HTTP (CellBatchUpdateView -> CellService.batch_update_cells,
     the single write path incl. formula recalc); the service queues a cells_updated
     group broadcast on commit, which this consumer relays. LWW = DB commit order.
     """
+
+    ws_channel = 'spreadsheet'
 
     async def connect(self):
         self.sheet_id = int(self.scope["url_route"]["kwargs"]["sheet_id"])

--- a/devops/grafana/websocket-sessions-dashboard.json
+++ b/devops/grafana/websocket-sessions-dashboard.json
@@ -49,7 +49,7 @@
   ],
   "title": "WebSocket Sessions",
   "uid": "ws-sessions",
-  "description": "Live WebSocket session counts per Channels consumer, from ws_sessions_active. Counts SESSIONS, not users: one person with three tabs is three sessions, and one person in both chat and spreadsheet appears once per channel. Rejected handshakes are never counted. The gauge is per backend process, so every panel sums across instances; a restart resets it to 0.",
+  "description": "Live WebSocket session counts per Channels consumer, from ws_sessions_active. Counts SESSIONS, not users: one person with three tabs is three sessions, and one person in both chat and spreadsheet appears once per channel. Rejected handshakes are never counted. The gauge is per backend process, so every panel sums across instances; a restart resets it to 0. COVERAGE: six channels appear here - asset, chat, csm, meetings, portal, spreadsheet. The retrospective consumer is instrumented but has no route in backend/asgi.py, so its module is never imported and no series exists; its absence from this board means unreachable, NOT idle. Tracked as a separate follow-up (routing it as-is would expose an unauthenticated endpoint). No panel hardcodes a channel name, so it will appear on its own once routed.",
   "tags": ["websocket", "channels", "django"],
   "schemaVersion": 39,
   "version": 1,

--- a/devops/grafana/websocket-sessions-dashboard.json
+++ b/devops/grafana/websocket-sessions-dashboard.json
@@ -49,7 +49,7 @@
   ],
   "title": "WebSocket Sessions",
   "uid": "ws-sessions",
-  "description": "Live WebSocket session counts per Channels consumer, from ws_sessions_active. The gauge is per backend process, so every panel sums across instances; a restart resets it to 0.",
+  "description": "Live WebSocket session counts per Channels consumer, from ws_sessions_active. Counts SESSIONS, not users: one person with three tabs is three sessions, and one person in both chat and spreadsheet appears once per channel. Rejected handshakes are never counted. The gauge is per backend process, so every panel sums across instances; a restart resets it to 0.",
   "tags": ["websocket", "channels", "django"],
   "schemaVersion": 39,
   "version": 1,
@@ -86,7 +86,7 @@
     {
       "type": "stat",
       "title": "Active sessions now",
-      "description": "Sum across all backend instances of the selected channels.",
+      "description": "Sum across all backend instances of the selected channels. This is a session count, not a user count: one user with several tabs contributes several sessions. A client that reconnects before the server has noticed the dead socket is briefly counted twice; the duplicate clears when the old connection times out.",
       "id": 1,
       "datasource": "${DS_PROMETHEUS}",
       "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },

--- a/devops/grafana/websocket-sessions-dashboard.json
+++ b/devops/grafana/websocket-sessions-dashboard.json
@@ -1,0 +1,328 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    }
+  ],
+  "title": "WebSocket Sessions",
+  "uid": "ws-sessions",
+  "description": "Live WebSocket session counts per Channels consumer, from ws_sessions_active. The gauge is per backend process, so every panel sums across instances; a restart resets it to 0.",
+  "tags": ["websocket", "channels", "django"],
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 1,
+  "refresh": "10s",
+  "timezone": "browser",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "channel",
+        "label": "Channel",
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}",
+        "query": "label_values(ws_sessions_active, channel)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Active sessions now",
+      "description": "Sum across all backend instances of the selected channels.",
+      "id": 1,
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(ws_sessions_active{channel=~\"$channel\"})",
+          "legendFormat": "sessions",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "text", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "bargauge",
+      "title": "Active sessions by channel (now)",
+      "id": 2,
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 6, "w": 12, "x": 6, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum by (channel) (ws_sessions_active{channel=~\"$channel\"})",
+          "legendFormat": "{{channel}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "showUnfilled": true,
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "min": 0,
+          "color": { "mode": "continuous-BlPu" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "text", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Peak concurrent sessions (selected range)",
+      "description": "Highest simultaneous session count seen over the dashboard time range.",
+      "id": 3,
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(ws_sessions_active{channel=~\"$channel\"})",
+          "legendFormat": "peak",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": ["max"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "text", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Active sessions by channel",
+      "id": 4,
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 6 },
+      "targets": [
+        {
+          "expr": "sum by (channel) (ws_sessions_active{channel=~\"$channel\"})",
+          "legendFormat": "{{channel}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": ["lastNotNull", "max"]
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "mode": "none", "group": "A" },
+            "axisPlacement": "auto"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Active sessions by instance",
+      "description": "Uneven lines across instances point at a load-balancer or sticky-session problem rather than real traffic.",
+      "id": 5,
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 16 },
+      "targets": [
+        {
+          "expr": "sum by (instance) (ws_sessions_active{channel=~\"$channel\"})",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "mode": "none", "group": "A" },
+            "axisPlacement": "auto"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "table",
+      "title": "Sessions by channel and instance (now)",
+      "id": 6,
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 16 },
+      "targets": [
+        {
+          "expr": "sum by (channel, instance) (ws_sessions_active{channel=~\"$channel\"})",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "sortBy": [{ "displayName": "Value", "desc": true }]
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": { "align": "auto" }
+        },
+        "overrides": []
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true },
+            "renameByName": { "Value": "sessions" }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

**MED-319 — Grafana dashboard for WebSocket session counts**

[MED-319 — Chat: Grafana dashboard for WebSocket session counts](https://linear.app/mediajira/issue/MED-319/chat-grafana-dashboard-for-websocket-session-counts)

Adds a `ws_sessions_active{channel="..."}` gauge, exported through the existing `django_prometheus` endpoint, and a Grafana dashboard built on it. A new Channels consumer base class owns the counting, so every WebSocket consumer reports its live session count without touching its own `connect`/`disconnect` logic.

Prometheus and Grafana already exist in `docker-compose.dev.yml` and `devops/grafana/` already holds three dashboards, so this PR adds a metric and a fourth board rather than standing up monitoring.

The platform was entirely pre-existing — `django_prometheus`, the `/metrics` endpoint, the `django` scrape job and three dashboards have been in place since December 2025 — but nothing this ticket asks for was. `ws_sessions_active` appears nowhere in the history before this branch, `backend/core/metrics.py` does not exist on `prod-preview`, and no consumer base class existed: all seven consumers subclassed `AsyncWebsocketConsumer` directly. Worth setting expectations on where the effort actually went: defining the metric is about seven lines and the board is largely template work. The substance was making the count correct on the paths the ticket does not mention — rejected handshakes, post-accept crashes, repeated closes and sustained churn.

### Acceptance criteria against production reality

"Metric exported per consumer" is satisfied for **all six consumers that are reachable in production**. The fourth consumer named in the ticket's Context, `retrospective`, has no reachable endpoint at all: it is not registered in `backend/asgi.py`, so the module is never imported and no series is ever created. That is a pre-existing routing and security issue, detailed under Follow-up, and is unrelated to the dashboard work.

It is worth noting that the ticket's list of four does not match the production topology. Three consumers that genuinely run — `spreadsheet`, `csm` and `portal` — are absent from it, and the one that does not run is present. The list looks like it was drawn from which apps have a `consumers.py` file rather than from which endpoints are actually routed.

### The counting design

The whole value of this ticket rests on the gauge being trustworthy — it will be used for capacity decisions and, in a follow-up ticket, for alert thresholds. A gauge that drifts is worse than no gauge, because people act on it. Two failure modes were found and closed by construction:

- **Counting in `connect()` drives the gauge negative.** Consumers reject handshakes by calling `close()` and returning *before* `accept()` (auth failure `4001`, authorisation failure `4003`). Channels still delivers `websocket.disconnect` afterwards, so a naive increment/decrement pair decrements a session that was never counted. Reverting to that implementation reproduces `-1.0` on a single rejected handshake.
- **Releasing in `disconnect()` leaks the session permanently.** `disconnect()` only runs on an orderly shutdown; a consumer that raises after accepting never reaches it. `chat` performs post-accept initialisation and `spreadsheet` runs an authorisation watchdog, so this path is real. Reverting to that implementation leaks one session per crash and accumulated to `3.0` across test retries.

The session is therefore counted in `accept()` — after the handshake actually succeeds — and released in `__call__`'s `finally`, which wraps the entire connection and runs on every exit path including exceptions and cancellation. An idempotent flag makes both sides exactly-once, so repeated `accept()` or repeated `close()` cannot double count. `chat` closes in six places and `spreadsheet` in seven, so that guard is load-bearing rather than defensive padding.

### Double counting and data integrity

Raised in standup as the main risk on this ticket, so it was audited specifically rather than assumed. Note that the leak above *is* a double count in effect: a dead session still occupying the gauge while the user reconnects makes one person read as two.

Every way a session could be counted or released more than once, and what closes it:

| Path | Guarantee | Evidence |
|---|---|---|
| `accept()` called twice | Flag makes the increment exactly-once | `test_accepting_twice_counts_one_session` |
| `close()` called twice | Flag makes the release exactly-once; a second release would read `-1`, not `0` | `test_closing_twice_releases_one_session` |
| Rejected handshake still receives `websocket.disconnect` | Never counted, so never released | `test_rejected_handshake_is_never_counted`, reproduced at `-1.0` without the guard |
| Consumer raises after `accept()` | `finally` releases on every exit path | `test_session_is_released_when_the_consumer_crashes_after_accepting`, reproduced at `3.0` without it |
| Sustained churn accumulating fractions | 25 cycles return to exactly the baseline | `test_repeated_connect_disconnect_cycles_leave_no_drift` |
| A consumer bypassing the base class | No consumer overrides `accept`, `__call__`, `websocket_connect` or `websocket_disconnect`; each calls `accept()` exactly once | Verified by grep across all seven |
| The same process scraped by two jobs | `prometheus.yml` has one `django` target; the `nextjs` job scrapes a different application | Verified in the scrape config |

A state gauge helps here in a way an event counter cannot: because it must return to zero when everyone disconnects, a double count cannot hide inside a growing total — it shows up as a number that will not settle. That is what the churn test and the real-server probe below exercise.

#### Conclusion on integrity as a whole

Integrity here means one thing: **the number on the board equals the number of live sessions in the process.** Taking the threats to that one at a time rather than only the double-count case:

| Threat | Status |
|---|---|
| Over-count — repeated `accept()` or `close()` | Closed by the idempotent flag; two tests |
| Under-count — gauge driven negative by a rejected handshake | Closed by counting only after `accept()`; reproduced at `-1.0` first |
| Leak — counted but never released | Closed by releasing in `__call__`'s `finally`; reproduced at `3.0` first |
| Drift — fractional accumulation under churn | 25-cycle test plus 30 real cycles, exact return to baseline |
| Bypass — a consumer not going through the base class | No consumer overrides `accept`/`__call__`/`websocket_connect`/`websocket_disconnect`; enforced by a test |
| Missing series — a channel absent rather than zero | Registered at import by `__init_subclass__`; a consumer that omits `ws_channel` fails at import |
| Unrouted consumer counted as covered | Coverage read from the real ASGI router, not from test imports |
| Scrape-layer duplication | One `django` target in `prometheus.yml`; the `nextjs` job is a different application |

**Within a backend process, the gauge is exact.** Every failure mode above is closed by construction and pinned by a test, and the two most important were reproduced against the wrong implementation before being fixed, so the tests are known to catch them rather than merely passing.

Two residual risks are stated rather than claimed, because a single local daphne process cannot close them:

- **Cross-instance duplication during a rolling deployment.** Panels sum across instances, which is correct while instance labels are stable. A deployment that changes them could double count for the length of the staleness window. Not reproducible in dev.
- **A leak rate below the probe's resolution.** 65 handshakes over a few minutes would not reveal a leak of one connection in ten thousand. That is only observable by watching the graph over days — which is what this ticket exists to make possible.

And one case that looks like a defect but is not: a client that reconnects before the server has noticed the dead socket is counted twice until the old connection times out. Inherent to any connection gauge, self-clearing, and stated in the dashboard description.

### Scope note — seven consumers, not four

The ticket's Context names chat, asset, meetings and retrospective. The base class covers all seven WebSocket consumers, adding csm, portal and spreadsheet.

This is the cheaper reading of the requested work rather than an expansion of it. The Scope line asks for a *consumer base class*, and a base class applies to whoever inherits it; the acceptance criterion says "Metric exported per consumer". Restricting to four would mean deliberately leaving three consumers on the old base class for no technical reason, which makes the base class non-universal and silently denies metrics to any consumer added later. The marginal cost was one line each and no extra dashboard work, because the board aggregates by label. The three additions are also the highest-value ones operationally: spreadsheet holds the heaviest connections (presence, cursors, watchdog) and csm/portal are the customer-facing paths.

## Files Changed

**Backend**

- `backend/core/metrics.py` — new. The `ws_sessions_active` gauge, labelled by `channel`
- `backend/core/consumers.py` — new. `InstrumentedAsyncWebsocketConsumer`; counts in `accept()` (L53-57), releases in `__call__` (L45-51), registers the label series at import time via `__init_subclass__` (L34-43) and raises `TypeError` if a subclass omits `ws_channel`
- `backend/{asset,chat,csm,meetings,portal,retrospective,spreadsheet}/consumers.py` — inherit the base class and declare `ws_channel`; one import line and one attribute each, no change to any `connect`/`disconnect` body
- `backend/core/tests/test_ws_session_metrics.py` — new suite, 10 tests. Coverage of the routed set is taken from the real `backend.asgi` URL router rather than by importing the consumers: importing one registers its series in the test process, so a suite that imports them directly creates the series it claims to verify and reports coverage production does not have

**Dashboard**

- `devops/grafana/websocket-sessions-dashboard.json` — new. Six panels: current total, per-channel bar gauge, peak over the selected range, per-channel time series, per-instance time series, and a channel/instance table

## Expected Result

- `/metrics` exposes one `ws_sessions_active{channel="..."}` series per routed consumer, reporting `0` while idle rather than being absent
- The gauge rises on an accepted handshake and returns to baseline on disconnect
- A rejected handshake is never counted and cannot drive the gauge negative
- A consumer that crashes after accepting still releases its session
- Sustained connect/disconnect churn leaves no drift
- The dashboard shows live counts split by channel and by backend instance

## Test

- [x] `core/tests/test_ws_session_metrics.py` — **10 passed**
- [x] Existing WebSocket suites (`asset`, `chat`, `spreadsheet` ×2, `retrospective`) — **no new failures**, verified by baseline comparison below
- [x] Live exposition check — `/metrics` on the running dev backend lists six channel series
- [x] Prometheus scrape — the `django` target is `up` and the series are queryable
- [x] Grafana — dashboard imports and renders against the Prometheus datasource
- [x] PromQL — all six panel expressions pass `promtool check rules`
- [ ] PR CI on `prod-preview`

### Baseline comparison for the pre-existing failures

The WebSocket suites report 2 failures and 36 errors in the local environment. These were confirmed pre-existing by stashing the seven consumer changes and running the identical command on the clean tree:

| Run | passed | failed | errors |
|---|---|---|---|
| Clean `prod-preview` | 62 | 2 | 36 |
| With this branch | 68 | 2 | 36 |

The failure and error counts are identical; the six extra passes are this branch's new tests. The errors are tenant-schema `_fixture_teardown` flush failures and test-database contention (pgbouncer holds pooled connections to `test_mediajira_db`, so the next run cannot drop it), neither of which this branch touches. Running with `DB_HOST=db` to bypass pgbouncer does not change the counts.

### The two regression tests were verified to have teeth

Both counting bugs described above were reproduced deliberately before being fixed, so the tests are known to fail against the wrong implementation rather than passing incidentally:

- Restoring the `connect()`/`disconnect()` counting pair makes `test_rejected_handshake_is_never_counted` fail with `assert -1.0 == 0`
- Restoring the `websocket_disconnect()` release makes `test_session_is_released_when_the_consumer_crashes_after_accepting` fail with `assert 3.0 == 0`

### Integrity check against real daphne

The unit tests use `WebsocketCommunicator`, which does not exercise the real protocol stack. A probe issuing raw WebSocket handshakes against the running daphne process was run separately — 65 handshakes in total, zero drift:

| Scenario | Result |
|---|---|
| 20 concurrent sessions | `20.0`, returns to `0.0` when closed |
| 30 rapid connect/disconnect cycles | `0.0` — no drift |
| 15 rejected handshakes (bad token) | `0.0` — rejections do not corrupt the count |
| Rejected and accepted interleaved, 10 each | `10.0` held, `0.0` after release |

## Out of Scope / Follow-up

- **Alert rules** — excluded by the ticket, and correctly so: no sensible threshold can be chosen before a baseline exists. This ticket produces the baseline; alerting should follow after the graph has been observed.
- **`RetrospectiveConsumer` is unrouted dead code with an authentication hole, and routing it would gain nothing.** Investigated rather than assumed, because it is the one consumer named in the ticket that produces no data:

  - **Not routed.** `retrospective/routing.py` exists but `backend/asgi.py` never imports it, so the module is never loaded and no series is created. Only six channels appear in the live exposition.
  - **Nothing connects to it.** There is no `ws/retrospective` reference anywhere in the frontend, and no retrospective page directory at all.
  - **Nothing broadcasts to it.** The only code that sends to a `retrospective_{id}` group is the consumer's own `receive()`. No service, task or signal anywhere in the backend publishes to it.
  - **Authentication is disabled.** `connect()` never rejects an unauthenticated user: the checks are commented out with "For testing, skip authentication", and the surviving branch only fires when `scope['user']` is `None`, which the middleware never produces — it sets `AnonymousUser`. Execution falls through to `accept()`. Every other consumer closes with `4001`/`4003` there. The existence check is commented out too, so any id is accepted.
  - **`receive()` accepts client-initiated broadcasts.** Any connected client can send `group_broadcast`, `retrospective_completed`, `insight_generated` or `kpi_update` and have it relayed to the entire group. Combined with the missing authentication, an unauthenticated caller who guesses an id could fabricate completion and KPI events for every connected client.

  So this is not a dashboard omission. Routing it as it stands would publish an unauthenticated injection endpoint, and routing it *after* fixing the authentication would still report a permanent `0`, because nothing connects to it and nothing broadcasts to it. The honest question is whether the consumer should exist at all, which belongs in its own ticket — most likely as a deletion rather than a repair.

  **The metric side is nevertheless finished for it, so whoever fixes the consumer does not have to come back through this work.** `RetrospectiveConsumer` already inherits the instrumented base and declares its channel, and the dashboard discovers channels through `label_values(ws_sessions_active, channel)` with no channel name hardcoded in any of the six panels. Registering the route is the only change required.

  This was verified rather than assumed. Adding the route to `backend/asgi.py` as a temporary experiment — with no change to the metric or the dashboard — produced the series immediately:

  ```
  ws_sessions_active{channel="retrospective"} 0.0
  ```

  and the suite failed with the instruction the next developer needs, before the experiment was reverted:

  ```
  AssertionError: missing from backend/asgi.py: [];
  now routed, remove from KNOWN_UNROUTED_CHANNELS: ['retrospective']
  ```

  That is the intended handover: `test_no_consumer_is_silently_left_out_of_the_asgi_router` records the exemption so a *newly* unrouted consumer fails instead of passing unnoticed, and it announces itself the moment retrospective becomes routed, so the exemption cannot outlive the fix. `test_unrouted_consumers_are_already_wired_for_when_they_are_routed` holds the other half — an unrouted consumer must still be instrumented, so routing stays a one-line fix rather than a metrics task as well.
- **No monitoring stack outside dev.** `grafana` and `prometheus` appear only in `docker-compose.dev.yml`; all production and preview compose files have zero references, and there is no deployment configuration for them elsewhere in the repo. The dashboard JSON is committed as the ticket requires, but deploying Prometheus/Grafana against preview or production and importing the board needs its own ticket — otherwise the metric is collected nowhere and the board has no host.
- **Dashboards are not provisioned.** The grafana service mounts no volumes, so a manually imported board is lost when the container is recreated. Restoring the `provisioning/` directory removed by `8927eee` (`revert(infra): defer Grafana monitoring work to MED-319`) would fix this. That commit also removed a chat monitoring dashboard and alert rules; those cover outbox backlog, Celery queue depth and Postgres connections, which is a different concern from session counts, and alert rules are explicitly out of scope here. Worth confirming whether restoring them belongs to this ticket or a separate one.
- **The metric counts sessions, not users.** One person with three tabs is three sessions, and the same person in chat and spreadsheet appears once per channel. A client that reconnects before the server notices the dead socket is briefly counted twice until the old connection times out. Both are documented in the dashboard description so the numbers are not misread as a user count.
- **Multi-instance behaviour is untested locally.** Only one daphne process exists in dev. Panels sum across instances, which is correct while instance labels are stable; a rolling deployment that changes them could double count for the length of the staleness window.

Ticket: [MED-319](https://linear.app/mediajira/issue/MED-319/chat-grafana-dashboard-for-websocket-session-counts)
