### PR TITLE
Kevinhuangtaowen/med 353 deploy single instance app to google cloud compute engine

### DIFF
--- a/.github/workflows/mediajira-ci.yml
+++ b/.github/workflows/mediajira-ci.yml
@@ -505,9 +505,11 @@ jobs:
       - name: Trigger deploy (main)
         env:
           DEPLOY_WEBHOOK_URL: ${{ secrets.MEDIAJIRA_DEPLOY_WEBHOOK_URL_MAIN }}
+          DEPLOY_TOKEN: ${{ secrets.MEDIAJIRA_DEPLOY_TOKEN }}
         run: |
           curl -fsSL -X POST "$DEPLOY_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
+            -H "X-Deploy-Token: $DEPLOY_TOKEN" \
             -d '{"action": "deploy", "source": "github"}'
 
       - name: Verify production health after deploy

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ dev.sh
 DOCKER_README.md
 env.example
 setup_local_db.sh
+fetch-secrets.sh
+recompose.sh
+ops/webhook/deploy_listener.py
 mediaJira/
 *test*.sh
 /node_modules/

--- a/backend/agent/gemini_client.py
+++ b/backend/agent/gemini_client.py
@@ -17,7 +17,7 @@ from agent.log_redaction import redact_string
 logger = logging.getLogger(__name__)
 
 GEMINI_MODEL = "gemini-2.5-flash-lite"
-_GEMINI_BASE = "https://aiplatform.googleapis.com/v1/publishers/google/models"
+_GEMINI_BASE = "https://aiplatform.googleapis.com/v1/projects/406201877905/locations/global/publishers/google/models"
 
 # Retries for HTTP 429 (rate limit) before surfacing to callers.
 _RATE_LIMIT_MAX_ATTEMPTS = 4

--- a/docker-compose.pro.single.yml
+++ b/docker-compose.pro.single.yml
@@ -209,6 +209,8 @@ services:
       - ./nginx/nginx.conf.pro:/etc/nginx/nginx.conf:ro
       - /etc/letsencrypt/live/zmarkio.com:/etc/letsencrypt/live/zmarkio.com:ro
       - /etc/letsencrypt/archive/zmarkio.com:/etc/letsencrypt/archive/zmarkio.com:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       backend:
         condition: service_started

--- a/docker-compose.pro.single.yml
+++ b/docker-compose.pro.single.yml
@@ -29,7 +29,9 @@ services:
       context: ./pgbackrest
       dockerfile: Dockerfile
     container_name: pgbackrest
-    restart: always    
+    restart: always
+    environment:
+      PGBACKREST_PG1_USER: ${POSTGRES_USER:-postgres}
     volumes:
       - pgdata:/var/lib/postgresql/data
       - pgbackups:/var/lib/pgbackrest

--- a/nginx/nginx.conf.pro
+++ b/nginx/nginx.conf.pro
@@ -65,6 +65,13 @@ http {
     # reload on deploy if keepalive to the backend matters under load.
 
 
+    # Redirect all plain HTTP traffic to HTTPS
+    server {
+        listen 80;
+        server_name zmarkio.com;
+        return 301 https://$host$request_uri;
+    }
+
     server {
         listen 443 ssl;
         server_name zmarkio.com;

--- a/nginx/nginx.conf.pro
+++ b/nginx/nginx.conf.pro
@@ -85,6 +85,12 @@ http {
         # resolver per request (picks up container IP changes without reload).
         set $backend_host "backend:8000";
         set $frontend_host "frontend:3000";
+        # deploy_listener runs on the VM host, not in Compose, so it's reached
+        # via the host-gateway IP rather than a service name. Using the literal
+        # IP (not the host.docker.internal hostname) avoids a lookup against
+        # the resolver below, which only knows Docker service names and can't
+        # resolve host.docker.internal (verified: "could not be resolved").
+        set $deploy_host "172.17.0.1:9000";
 
         # Enhanced health check endpoint for monitoring
         location = /health {
@@ -305,6 +311,18 @@ http {
             proxy_send_timeout 60s;
             proxy_read_timeout 60s;
             proxy_set_header Connection "";
+        }
+
+        # GitHub Actions deploy webhook -- proxied straight to deploy_listener
+        # on the host. Token auth (X-Deploy-Token) is enforced by the
+        # listener itself; nginx just forwards the request as-is.
+        location = /deploy {
+            proxy_pass http://$deploy_host$request_uri;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_connect_timeout 5s;
+            proxy_send_timeout 10s;
+            proxy_read_timeout 10s;
         }
 
         # Frontend routes (catch-all - must be last)


### PR DESCRIPTION
1. Add http redirect and secret management to deployment — Introduces fetch-secrets.sh, a script that pulls secrets (likely from GCP Secret Manager) at deploy time, and wires those secrets into docker-compose.pro.single.yml. Also adds an HTTP→HTTPS redirect rule to nginx/nginx.conf.pro, plus a small fix in backend/agent/gemini_client.py.

2. Implement Github Action listener — Adds ops/webhook/deploy_listener.py, a webhook server that listens for deploy triggers from GitHub Actions and redeploys the stack on the VM, along with recompose.sh to rebuild/restart the docker-compose services. The CI workflow (.github/workflows/mediajira-ci.yml) is updated to call this webhook after a successful build, nginx.conf.pro is extended to route to the listener, and fetch-secrets.sh gains an additional secret needed by it.