### PR TITLE
MED-346: Resolve outstanding pip-audit findings

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
-Django==4.2.23
+Django==4.2.30
 psycopg2-binary==2.9.10
-gunicorn==21.2.0
+gunicorn==22.0.0
 whitenoise==6.6.0
 python-decouple==3.8
 django-cors-headers==4.3.1
@@ -10,12 +10,12 @@ djangorestframework-simplejwt
 django-fsm==2.8.1
 channels==4.0.0
 channels-redis==4.1.0
-daphne==4.0.0
+daphne==4.2.2
 celery==5.3.4
 clamd==1.0.2
 requests==2.31.0 
-Pillow==10.4.0
-cryptography==41.0.7
+Pillow==12.3.0
+cryptography==50.0.0
 stripe==13.0.0
 redis==5.0.1
 django-redis==5.4.0
@@ -40,7 +40,7 @@ httpx==0.25.2
 # Reporting / Export dependencies
 matplotlib==3.9.2
 beautifulsoup4==4.12.3
-WeasyPrint==62.3
+WeasyPrint==68.0
 
 # Monitor
 django-prometheus==2.2.0
@@ -73,14 +73,14 @@ deprecated
 opentelemetry-exporter-jaeger-thrift
 
 # Kafka
-kafka-python==2.0.2
+kafka-python==2.3.2
 
 # Google auth & OAuth
-google-auth==2.23.0
+google-auth==2.24.0
 google-auth-oauthlib==1.1.0
 google-auth-httplib2==0.1.1
 requests-oauthlib==1.3.1  # OAuth2Session for token exchange
-PyJWT==2.8.0  # JWT verification with clock tolerance (leeway)
+PyJWT==2.13.0  # JWT verification with clock tolerance (leeway)
 
 # AI Agent
 anthropic>=0.40.0
@@ -88,3 +88,8 @@ openpyxl>=3.1.0
 pymupdf>=1.24.0
 python-docx>=1.1.0
 croniter>=2.0.0  # For scheduled workflow triggers
+
+# Transitive dependency
+Twisted==26.4.0
+urllib3==2.7.0
+pyOpenSSL==26.4.0


### PR DESCRIPTION


## 1️⃣ Scope & Intent

- **What problem does this solve?**  
  The CI pipeline reported known vulnerabilities in the backend Python dependencies through pip-audit.

  The original report contained:

  - 165 resolved Python dependencies
  - 110 vulnerability records
  - 79 unique advisories after deduplication
  - 14 affected packages

  MED-346 triages these findings and updates the dependency versions required to remove all High and Critical vulnerabilities.

- **In scope for this ticket:**

  - Triage the existing pip-audit findings
  - Upgrade vulnerable backend Python packages
  - Pin vulnerable transitive dependencies where necessary
  - Resolve dependency-version conflicts introduced by the security upgrades
  - Rebuild the backend environment
  - Validate the dependency graph with pip check
  - Rerun backend vulnerability scanning
  - Perform frontend npm audit triage where reasonable
  - Run the complete backend test suite used by CI
  - Run frontend lint, build and tests

- **Out of scope:**

  - Long-tail Low and Medium findings




## 2️⃣ Implementation Summary

All implementation changes are located in:

`backend/requirements.txt`

A total of 12 dependency changes were made:

- 8 direct dependency upgrades
- 3 explicit transitive dependency pins
- 1 compatibility upgrade
- 12 dependency changes in total

### 8 direct dependency upgrades

| Package | Previous Version | Updated Version |
|---|---:|---:|
| Django | 4.2.23 | 4.2.30 |
| gunicorn | 21.2.0 | 22.0.0 |
| Daphne | 4.0.0 | 4.2.2 |
| Pillow | 10.4.0 | 12.3.0 |
| cryptography | 41.0.7 | 50.0.0 |
| WeasyPrint | 62.3 | 68.0 |
| kafka-python | 2.0.2 | 2.3.2 |
| PyJWT | 2.8.0 | 2.13.0 |

## 3 explicit transitive dependency pins

- `Twisted==26.4.0`
- `urllib3==2.7.0`
- `pyOpenSSL==26.4.0`

These packages were previously installed as transitive dependencies rather than being explicitly pinned in `requirements.txt`.

They were pinned to ensure that the dependency resolver consistently installs the required secure versions.

### 1 compatibility upgrade

```text
google-auth==2.23.0
→
google-auth==2.24.0
```

The previous google-auth 2.23.0 dependency metadata required:

```text
urllib3 < 2.0
```

However, the secure urllib3 version selected for this ticket is:

```text
urllib3==2.7.0
```

Therefore, google-auth also needed to be upgraded so that the secure urllib3 version could be installed without a dependency conflict.

No application code, database migrations, or frontend source files were changed.

---

## 3️⃣ Dependency Analysis

The dependency relationships were checked in the running backend Docker environment.

### Daphne / Twisted dependency chain

The installed dependency metadata confirmed:

```text
Daphne
→ Twisted[tls]
→ pyOpenSSL
→ cryptography
```

Daphne requires:

```text
twisted[tls]
```

The Twisted TLS extra requires:

```text
pyOpenSSL
```

And pyOpenSSL depends on:

```text
cryptography
```

This is why Twisted and pyOpenSSL were relevant to the security update even though they were originally transitive dependencies.

### urllib3 dependency relationship

The environment also confirmed:

```text
requests
→ urllib3
```

The previous environment additionally contained:

```text
google-auth 2.23.0
→ urllib3 < 2.0
```

This old google-auth restriction prevented the use of the secure urllib3 2.7.0 version.

Therefore, google-auth was upgraded as a compatibility change.

---

## 4️⃣ Dependency Compatibility Verification

### Backend clean rebuild

The backend container was rebuilt using the updated `requirements.txt`.

`docker compose -f docker-compose.dev.yml --env-file .env up -d --build backend`

Result:

- Backend image rebuilt successfully
- Updated dependencies installed successfully

### pip check

Dependency consistency was then checked inside the rebuilt backend container.

`docker compose -f docker-compose.dev.yml --env-file .env exec backend python -m pip check`

Result:

```text
No broken requirements found.
```

- pip check passed
- No broken dependency requirements were found

This confirms that the selected dependency versions can coexist successfully.

---

## 5️⃣ Backend Vulnerability Verification

### pip-audit

A new pip-audit scan was performed after the dependency updates.

The new report contains:

- 13 remaining findings
- 5 affected packages

The standard pip-audit output provides package names, versions, advisory IDs and fixed versions, but it does not directly display Low, Moderate, High or Critical severity labels.

Therefore, the remaining advisory IDs were separately reviewed against their security advisory records.

### Remaining findings

| Package | Remaining Findings | Severity |
|---|---:|---|
| Django 4.2.30 | 7 | 4 Low, 3 Moderate |
| Django REST Framework 3.14.0 | 1 | Moderate |
| requests 2.31.0 | 3 | Moderate |
| pytest 7.4.3 | 1 | Moderate |
| WeasyPrint 68.0 | 1 | Moderate |
| **Total** | **13** | **4 Low, 9 Moderate** |

Final severity result:

```text
Critical: 0
High:     0
Moderate: 9
Low:      4
```

- Critical findings: 0
- High findings: 0
- Remaining findings were triaged
- Remaining findings are Low / Moderate only

The remaining Low and Moderate findings are outside the scope of MED-346.

### Important interpretation

The ticket does not require the pip-audit report to contain zero findings.

The acceptance criterion requires:

```text
No High / Critical findings
```

Therefore:

```text
13 remaining findings
≠
MED-346 failed
```

Because all 13 residual findings are Low or Moderate.

---

## 6️⃣ OSV-Scanner Cross-Check

OSV-Scanner was also used as an additional cross-check during vulnerability triage.

During this process, the previous Daphne version:

```text
Daphne==4.0.0
```

was displayed by OSV-Scanner with a High finding.

Daphne was therefore upgraded to:

```text
Daphne==4.2.2
```

After the final dependency update, the displayed Python dependency results showed:

```text
Critical: 0
High:     0
```

- OSV-Scanner used as an additional cross-check
- Daphne updated from 4.0.0 to 4.2.2
- Displayed OSV Python results contain no High / Critical findings


---

## 7️⃣ Frontend Vulnerability Verification

The ticket requests frontend npm-audit triage in the same PR where reasonable.

Command:

`npm.cmd audit --prefix frontend --audit-level=high --json`

Result:

```text
Critical: 4
High:     43
Moderate: 48
Low:      9
Total:    104
```

- [x] Frontend npm-audit triage completed
- [x] The reported frontend findings were reviewed separately from the backend pip-audit acceptance criterion
- [x] Several automated fixes require major dependency upgrades
- [x] Some findings, including the direct `xlsx` finding, do not have a direct npm fix available
- [x] No frontend dependency changes were included in this minimal backend security update

The MED-346 acceptance criterion specifically requires no High or Critical findings in `pip-audit`. Frontend remediation is conditional on being reasonable within the same PR. The frontend findings require broader dependency upgrades or package replacement and should be handled separately.

---

## 8️⃣ Backend Test Verification

The current CI uses pytest as the main backend test runner.

### Main pytest suite

Command:

`docker compose -f docker-compose.dev.yml --env-file .env exec backend pytest -v`

Result:

```text
5864 passed
24 skipped
1 failed
2 rerun
```

The only failure was:

```text
google_docs_integration/tests.py::TestGoogleDocsConnectView::test_missing_oauth_settings_returns_400
```

The test expects the Google OAuth settings to be empty, but the local Docker environment contained configured Google OAuth values.

The failed test was rerun with the relevant environment variables cleared only for the test process:

```powershell
docker compose -f docker-compose.dev.yml --env-file .env exec -T `
  -e GOOGLE_CLIENT_ID= `
  -e GOOGLE_CLIENT_SECRET= `
  -e GOOGLE_OAUTH_CLIENT_ID= `
  -e GOOGLE_OAUTH_CLIENT_SECRET= `
  -e GOOGLE_OAUTH_REDIRECT_URI= `
  -e GOOGLE_REDIRECT_URI= `
  backend pytest -n 0 --no-cov --reruns 0 -q `
  google_docs_integration/tests.py::TestGoogleDocsConnectView::test_missing_oauth_settings_returns_400
```

Focused rerun result:

```text
1 passed in 139.27s
```

- [x] Main pytest suite completed
- [x] 5864 tests passed
- [x] The only failed test was identified as local OAuth environment interference
- [x] The affected test passed when executed with its expected empty OAuth settings
- [ ] Final clean-environment test result will be confirmed by PR CI

### Additional serial tests

The CI also executes several integration, task and concurrency tests separately.

Command:

```powershell
docker compose -f docker-compose.dev.yml --env-file .env exec backend `
  pytest -v -o addopts='' `
  --ds=backend.settings `
  --timeout=600 `
  metric_upload/tests/integration `
  asset/tests/test_tasks.py `
  budget_approval/tests/test_concurrency.py
```

Result:

```text
93 passed in 261.63s (0:04:21)
```

- [x] File-upload integration tests passed
- [x] Asset task tests passed
- [x] Budget-approval concurrency tests passed
- [x] All 93 additional serial tests passed

---

## 9️⃣ Frontend Lint, Build and Test Verification

Command:
```
docker compose -f docker-compose.dev.yml --env-file .env exec -T frontend sh -c "npx next lint --max-warnings 9999 && npm run build && npm test -- --maxWorkers=2"
```
The command runs frontend lint, build and tests sequentially. Because each step is connected with &&, the frontend tests run only when both lint and build complete successfully.
Result:
Frontend lint:  Passed
Frontend build: Passed

Test Suites: 1 skipped, 144 passed, 144 of 145 total
Tests:       2 skipped, 1002 passed, 1004 total
Snapshots:   0 total
Time:        34.617 s
Ran all test suites.
- Frontend lint passed
- Frontend production build passed
- 144 frontend test suites passed
- 1002 frontend tests passed
- Skipped tests were reported and are not failures
- All executed frontend test suites passed


##  Final Acceptance Criteria

- [x] Vulnerable backend Python packages are upgraded or explicitly pinned in `backend/requirements.txt`
- [x] `pip check` reports no broken dependency requirements
- [x] The final local `pip-audit` result contains no High findings
- [x] The final local `pip-audit` result contains no Critical findings
- [x] Remaining Low and Moderate backend findings are documented as outside the scope of MED-346
- [x] Frontend `npm audit` triage is completed and the findings are documented
- [x] The main backend Pytest suite completed with 5864 passing tests
- [x] The only local OAuth environment-sensitive failure passed its focused rerun
- [x] All 93 additional serial backend tests passed
- [x] Frontend lint passed
- [x] Frontend production build passed
- [x] Frontend tests passed with 144 suites and 1002 tests passing
- [x] The CI workflow is configured to archive the final `pip-audit` report