### PR TITLE
Feature/med 315 budget approval playwright e2e

### DIFF
--- a/.github/workflows/mediajira-ci.yml
+++ b/.github/workflows/mediajira-ci.yml
@@ -555,6 +555,139 @@ jobs:
               npm test
             "
 
+      # Budget approval Playwright E2E (MED-315): real backend via nginx, isolated fixtures per test.
+      - name: Wait for nginx (budget E2E)
+        run: |
+          echo "Waiting for nginx to serve the stack..."
+          timeout=120
+          counter=0
+          while [ $counter -lt $timeout ]; do
+            if curl -fsS http://localhost/health > /dev/null 2>&1; then
+              echo "nginx is ready!"
+              exit 0
+            fi
+            echo "nginx not ready yet, waiting... ($counter/$timeout)"
+            sleep 2
+            counter=$((counter + 2))
+          done
+          echo "nginx failed to become healthy within ${timeout}s"
+          docker compose logs nginx
+          exit 1
+
+      - name: Provision budget E2E anchor user
+        run: |
+          docker compose exec -T backend sh <<'EOS'
+          set -e
+          python manage.py shell <<'PY'
+          from django.contrib.auth import get_user_model
+          from django.db.models.signals import post_save
+
+          from core.models import Organization, OrganizationMembership, Project, ProjectMember
+          from core.services.tenant import provision_tenant_schema, slug_to_schema_name
+          from core.tenant_context import tenant_schema_context
+          from stripe_meta.signals import create_default_subscription
+
+          User = get_user_model()
+          ANCHOR_EMAIL = "ci-budget-anchor@example.com"
+          ORG_SLUG = "ci-budget-e2e-org"
+
+          post_save.disconnect(create_default_subscription, sender=Organization)
+          try:
+              org, _ = Organization.objects.get_or_create(
+                  slug=ORG_SLUG,
+                  defaults={"name": "CI Budget E2E Org", "is_active": True},
+              )
+              provision_tenant_schema(org.slug)
+
+              anchor, _ = User.objects.get_or_create(
+                  email=ANCHOR_EMAIL,
+                  defaults={
+                      "username": "ci-budget-anchor",
+                      "organization": org,
+                      "current_organization": org,
+                      "is_verified": True,
+                      "password_set": True,
+                  },
+              )
+              anchor.organization = org
+              anchor.current_organization = org
+              anchor.is_verified = True
+              anchor.password_set = True
+              anchor.set_password("password123!")
+              anchor.save()
+
+              OrganizationMembership.objects.update_or_create(
+                  user=anchor,
+                  organization=org,
+                  defaults={"role": "admin", "is_active": True},
+              )
+
+              schema = slug_to_schema_name(org.slug)
+              with tenant_schema_context(schema):
+                  project, _ = Project.objects.get_or_create(
+                      organization=org,
+                      name="CI Budget Anchor Project",
+                      defaults={"owner": anchor},
+                  )
+                  ProjectMember.objects.update_or_create(
+                      user=anchor,
+                      project=project,
+                      defaults={"role": "owner", "is_active": True},
+                  )
+              anchor.active_project = project
+              anchor.save(update_fields=["active_project"])
+              print("budget E2E anchor ready:", anchor.email, "project_id=", project.id)
+          finally:
+              post_save.connect(create_default_subscription, sender=Organization)
+          PY
+          EOS
+
+      - name: Generate budget E2E fixtures
+        run: |
+          set -e
+          mkdir -p frontend/e2e/budget/fixtures
+          docker compose exec -T backend python manage.py issue_budget_e2e_fixtures \
+            --allow-outside-debug \
+            --anchor-email=ci-budget-anchor@example.com \
+            > frontend/e2e/budget/fixtures/budget-e2e-fixtures.json
+          python3 -c "
+          import json
+          data = json.load(open('frontend/e2e/budget/fixtures/budget-e2e-fixtures.json'))
+          assert data.get('users', {}).get('requester', {}).get('access_token'), 'missing requester access_token'
+          print('budget E2E fixtures ready for org', data.get('organization_slug'))
+          "
+
+      - name: Set up Node for budget Playwright E2E
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install Playwright (Chromium only)
+        working-directory: frontend
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Run budget approval Playwright E2E
+        working-directory: frontend
+        env:
+          CI: true
+          BASE_URL: http://localhost
+          E2E_USE_EXISTING_SERVER: "1"
+        run: npm run test:e2e:budget
+
+      - name: Upload budget E2E Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: budget-e2e-playwright-${{ github.sha }}
+          path: |
+            frontend/playwright-report/
+            frontend/test-results/
+          if-no-files-found: ignore
+
       # Cleanup containers and volumes
       - name: Cleanup containers
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ backend/celerybeat.pid
 # run_timestamp every test run; nothing reads it as a baseline).
 backend/benchmarks/retrospective.json
 test-results/chat-load/
+frontend/e2e/budget/fixtures/budget-e2e-fixtures.json
 
 # Debug/scratch scripts — never tracked
 frontend/.scratch/

--- a/backend/agent/tests/test_spreadsheet_security.py
+++ b/backend/agent/tests/test_spreadsheet_security.py
@@ -66,7 +66,9 @@ class SpreadsheetInsightsSecurityTests(TestCase):
 
     def test_insights_allowed_after_per_spreadsheet_consent(self):
         grant_ai_consent(self.user, self.spreadsheet)
-        with patch("agent.services._call_gemini_spreadsheet_insights") as mock_call:
+        with patch("core.services.gemini_client._get_api_key", return_value="test-key"), patch(
+            "agent.services._call_gemini_spreadsheet_insights"
+        ) as mock_call:
             mock_call.return_value = {
                 "summary": "ok", "recommendations": [], "anomalies": [],
                 "recommended_tasks": [],
@@ -74,8 +76,9 @@ class SpreadsheetInsightsSecurityTests(TestCase):
             chunks = self._run_insights()
         self.assertFalse([c for c in chunks if c["type"] == "error"])
 
+    @patch("core.services.gemini_client._get_api_key", return_value="test-key")
     @patch("agent.services._call_gemini_spreadsheet_insights")
-    def test_insights_routes_through_call_llm_and_audits(self, mock_call):
+    def test_insights_routes_through_call_llm_and_audits(self, mock_call, _mock_key):
         grant_ai_consent(self.user, self.spreadsheet)
         mock_call.return_value = {
             "summary": "ok", "recommendations": [], "anomalies": [],

--- a/backend/budget_approval/management/commands/issue_budget_e2e_fixtures.py
+++ b/backend/budget_approval/management/commands/issue_budget_e2e_fixtures.py
@@ -142,6 +142,8 @@ class Command(BaseCommand):
             "project_id": project.id,
             "project_slug": project.slug,
             "project_name": project.name,
+            "team_id": team.id,
+            "role_name": ROLE_NAME,
             "budget_pool_id": pool.id,
             "ad_channel_id": channel.id,
             "budget_pool_composite": composite,

--- a/backend/budget_approval/management/commands/issue_budget_e2e_fixtures.py
+++ b/backend/budget_approval/management/commands/issue_budget_e2e_fixtures.py
@@ -1,0 +1,313 @@
+"""Provision deterministic users, pool, and approval chain for budget Playwright E2E."""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.utils import timezone
+
+from access_control.models import Role, RolePermission, UserRole
+from budget_approval.models import BudgetPool
+from core.admin_utils import assign_org_admin
+from core.models import AdChannel, Organization, OrganizationMembership, Permission, Project, ProjectMember, Team
+from core.services.auth_tokens import build_user_refresh_token
+from core.services.tenant import provision_tenant_schema, slug_to_schema_name
+from core.tenant_context import tenant_schema_context
+from stripe_meta.permissions import generate_organization_access_token
+from task.models import ApprovalChain, ApprovalChainStep
+
+User = get_user_model()
+
+E2E_PASSWORD = "password123!"
+CHAIN_NAME = "E2E Budget Chain (A → B → C)"
+POOL_NAME = "E2E Budget Pool"
+CHANNEL_NAME = "E2E Meta"
+TEAM_NAME = "E2E Budget Team"
+ROLE_NAME = "E2E Budget Approver"
+
+USER_SPECS = (
+    ("requester", "e2e-budget-requester@example.com", False),
+    ("approver_a", "e2e-budget-approver-a@example.com", False),
+    ("approver_b", "e2e-budget-approver-b@example.com", False),
+    ("approver_c", "e2e-budget-approver-c@example.com", False),
+    ("org_admin", "e2e-budget-org-admin@example.com", True),
+    ("regular", "e2e-budget-regular@example.com", False),
+)
+
+
+class Command(BaseCommand):
+    help = (
+        "Create deterministic budget E2E users, pool, and a 3-step approval chain. "
+        "Prints JSON fixtures for Playwright (tokens, ids, pool composite)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--anchor-email",
+            default="devuser@example.com",
+            help="Existing user whose org/project anchors the E2E fixtures.",
+        )
+        parser.add_argument(
+            "--project-id",
+            type=int,
+            help="Optional project id (must belong to the anchor user's org).",
+        )
+        parser.add_argument(
+            "--allow-outside-debug",
+            action="store_true",
+            help="Required when DEBUG is False (disposable environments only).",
+        )
+
+    def handle(self, *args, **options):
+        if not settings.DEBUG and not options["allow_outside_debug"]:
+            raise CommandError(
+                "Refusing to run with DEBUG=False: this command creates verified "
+                "accounts and writes valid JWTs. Pass --allow-outside-debug on "
+                "disposable stacks only."
+            )
+
+        try:
+            anchor = User.objects.get(email=options["anchor_email"], is_active=True)
+        except User.DoesNotExist as exc:
+            raise CommandError(
+                f"Anchor user {options['anchor_email']!r} not found. "
+                "Log in locally first or pass --anchor-email."
+            ) from exc
+
+        organization = getattr(anchor, "current_organization", None) or getattr(
+            anchor, "organization", None
+        )
+        if organization is None:
+            raise CommandError("Anchor user has no organization.")
+
+        try:
+            from django.db.models.signals import post_save
+            from stripe_meta.signals import create_default_subscription
+
+            post_save.disconnect(create_default_subscription, sender=Organization)
+            try:
+                provision_tenant_schema(organization.slug)
+            finally:
+                post_save.connect(create_default_subscription, sender=Organization)
+        except ImportError:
+            provision_tenant_schema(organization.slug)
+
+        tenant_schema = slug_to_schema_name(organization.slug)
+        with tenant_schema_context(tenant_schema):
+            payload = self._provision(anchor, organization, options.get("project_id"))
+        self.stdout.write(json.dumps(payload, separators=(",", ":")))
+
+    @transaction.atomic
+    def _provision(self, anchor, organization, project_id):
+        project = self._resolve_project(anchor, organization, project_id)
+        team = self._ensure_team(organization)
+        role = self._ensure_budget_role(organization)
+        users = self._ensure_users(organization, project, team, role)
+        pool, channel = self._ensure_pool_and_channel(project)
+        single_project = self._ensure_single_approver_project(organization, anchor, team, role, users)
+        single_pool, single_channel = self._ensure_pool_and_channel(single_project)
+        chain = self._ensure_approval_chain(
+            project,
+            users["approver_a"],
+            users["approver_b"],
+            users["approver_c"],
+        )
+
+        for user in users.values():
+            user.active_project = project
+            user.save(update_fields=["active_project"])
+
+        composite = f"{pool.id}:{channel.id}:{pool.currency}"
+        single_composite = f"{single_pool.id}:{single_channel.id}:{single_pool.currency}"
+        tokens = {}
+        for key, user in users.items():
+            refresh = build_user_refresh_token(user)
+            tokens[key] = {
+                "user_id": user.id,
+                "email": user.email,
+                "username": user.username,
+                "access_token": str(refresh.access_token),
+                "refresh_token": str(refresh),
+                "organization_access_token": generate_organization_access_token(user),
+            }
+
+        return {
+            "organization_id": organization.id,
+            "organization_slug": organization.slug,
+            "project_id": project.id,
+            "project_slug": project.slug,
+            "project_name": project.name,
+            "budget_pool_id": pool.id,
+            "ad_channel_id": channel.id,
+            "budget_pool_composite": composite,
+            "approval_chain_id": chain.id,
+            "approval_chain_name": chain.name,
+            "single_approver_project_id": single_project.id,
+            "single_approver_project_slug": single_project.slug,
+            "single_approver_project_name": single_project.name,
+            "single_approver_budget_pool_composite": single_composite,
+            "password": E2E_PASSWORD,
+            "users": tokens,
+        }
+
+    def _resolve_project(self, anchor, organization, project_id):
+        if project_id is not None:
+            try:
+                project = Project.objects.get(pk=project_id, is_deleted=False)
+            except Project.DoesNotExist as exc:
+                raise CommandError(f"Project {project_id} not found.") from exc
+            if project.organization_id != organization.id:
+                raise CommandError("Project does not belong to the anchor user's organization.")
+            return project
+
+        membership = (
+            ProjectMember.objects.filter(user=anchor, is_active=True, project__is_deleted=False)
+            .select_related("project")
+            .order_by("project_id")
+            .first()
+        )
+        if membership is None:
+            raise CommandError(
+                "Anchor user has no active project membership. "
+                "Create a project or pass --project-id."
+            )
+        return membership.project
+
+    def _ensure_team(self, organization):
+        team, _ = Team.objects.get_or_create(
+            organization=organization,
+            name=TEAM_NAME,
+            defaults={"desc": "Playwright budget E2E"},
+        )
+        return team
+
+    def _ensure_budget_role(self, organization):
+        role, _ = Role.objects.get_or_create(
+            organization=organization,
+            name=ROLE_NAME,
+            defaults={"level": 5},
+        )
+        permission_specs = [
+            ("BUDGET_REQUEST", "VIEW"),
+            ("BUDGET_REQUEST", "EDIT"),
+            ("BUDGET_REQUEST", "APPROVE"),
+            ("BUDGET_POOL", "VIEW"),
+            ("BUDGET_POOL", "EDIT"),
+        ]
+        for module, action in permission_specs:
+            permission, _ = Permission.objects.get_or_create(module=module, action=action)
+            RolePermission.objects.get_or_create(role=role, permission=permission)
+        return role
+
+    def _ensure_users(self, organization, project, team, role):
+        users = {}
+        for key, email, make_org_admin in USER_SPECS:
+            user, created = User.objects.get_or_create(
+                email=email,
+                defaults={
+                    "username": email.split("@")[0],
+                    "organization": organization,
+                    "current_organization": organization,
+                    "is_verified": True,
+                    "password_set": True,
+                },
+            )
+            user.organization = organization
+            user.current_organization = organization
+            user.is_verified = True
+            user.password_set = True
+            user.set_password(E2E_PASSWORD)
+            user.save()
+
+            OrganizationMembership.objects.update_or_create(
+                user=user,
+                organization=organization,
+                defaults={"role": "admin" if make_org_admin else "member", "is_active": True},
+            )
+            ProjectMember.objects.update_or_create(
+                user=user,
+                project=project,
+                defaults={"role": "member", "is_active": True},
+            )
+
+            if make_org_admin:
+                assign_org_admin(user, organization)
+            elif key != "regular":
+                UserRole.objects.update_or_create(
+                    user=user,
+                    role=role,
+                    team=team,
+                    defaults={"valid_from": timezone.now(), "valid_to": None},
+                )
+
+            users[key] = user
+        return users
+
+    def _ensure_pool_and_channel(self, project):
+        channel, _ = AdChannel.objects.get_or_create(
+            project=project,
+            name=CHANNEL_NAME,
+        )
+        pool, _ = BudgetPool.objects.get_or_create(
+            project=project,
+            ad_channel=channel,
+            name=POOL_NAME,
+            currency="AUD",
+            defaults={
+                "total_amount": Decimal("100000.00"),
+                "used_amount": Decimal("0.00"),
+            },
+        )
+        if pool.total_amount < Decimal("50000.00"):
+            pool.total_amount = Decimal("100000.00")
+            pool.save(update_fields=["total_amount", "updated_at"])
+        return pool, channel
+
+    def _ensure_single_approver_project(self, organization, anchor, team, role, users):
+        project, _ = Project.objects.get_or_create(
+            organization=organization,
+            name="E2E Budget Single Approver",
+            defaults={"owner": anchor},
+        )
+        for user in users.values():
+            ProjectMember.objects.update_or_create(
+                user=user,
+                project=project,
+                defaults={"role": "member", "is_active": True},
+            )
+            if user.email != users["regular"].email:
+                UserRole.objects.update_or_create(
+                    user=user,
+                    role=role,
+                    team=team,
+                    defaults={"valid_from": timezone.now(), "valid_to": None},
+                )
+        return project
+
+    def _ensure_approval_chain(self, project, approver_a, approver_b, approver_c):
+        chain, _ = ApprovalChain.objects.get_or_create(
+            project=project,
+            task_type="budget",
+            defaults={"name": CHAIN_NAME},
+        )
+        if chain.name != CHAIN_NAME:
+            chain.name = CHAIN_NAME
+            chain.save(update_fields=["name", "updated_at"])
+
+        step_specs = (
+            (1, approver_a),
+            (2, approver_b),
+            (3, approver_c),
+        )
+        for order, approver in step_specs:
+            ApprovalChainStep.objects.update_or_create(
+                chain=chain,
+                order=order,
+                defaults={"approver": approver},
+            )
+        return chain

--- a/backend/budget_approval/services.py
+++ b/backend/budget_approval/services.py
@@ -88,11 +88,14 @@ class BudgetRequestService:
         budget_request.save(update_fields=['notes'])
 
     @staticmethod
-    def _resolve_next_from_approval_chain(budget_request):
-        """Next chain step after the task's current step, or None (legacy / last step).
+    def _resolve_next_from_approval_chain(budget_request, from_step=None):
+        """Next chain step after *from_step* (or the task's current step), or None.
 
         Org-admin override must continue the *original* ApprovalChain — the admin
         does not pick the next approver. Returns (approver_user, next_step_number).
+
+        When make_approval has already advanced the task along the chain, pass
+        replaced_step as from_step so we do not double-advance.
         """
         task = getattr(budget_request, 'task', None)
         if task is None or not getattr(task, 'approval_chain_id', None):
@@ -102,7 +105,9 @@ class BudgetRequestService:
         if chain is None:
             return None, None
 
-        current_step = task.current_approval_step or 1
+        current_step = (
+            from_step if from_step is not None else (task.current_approval_step or 1)
+        )
         next_step_num = current_step + 1
         next_step = chain.get_step(next_step_num)
         if next_step is None:
@@ -260,8 +265,15 @@ class BudgetRequestService:
         # the original ApprovalChain (not a client-supplied next_approver).
         # Legacy / no remaining steps → finalize (effective_next stays None).
         if is_override and is_approved:
+            base_step = replaced_step
+            if base_step is None:
+                task = getattr(budget_request, 'task', None)
+                base_step = getattr(task, 'current_approval_step', None) if task else None
             effective_next, next_step_num = (
-                BudgetRequestService._resolve_next_from_approval_chain(budget_request)
+                BudgetRequestService._resolve_next_from_approval_chain(
+                    budget_request,
+                    from_step=base_step,
+                )
             )
         else:
             effective_next = next_approver

--- a/backend/budget_approval/tests/test_issue_budget_e2e_fixtures.py
+++ b/backend/budget_approval/tests/test_issue_budget_e2e_fixtures.py
@@ -43,6 +43,7 @@ def test_issue_budget_e2e_fixtures_round_trip():
         "issue_budget_e2e_fixtures",
         anchor_email=anchor.email,
         project_id=project.id,
+        allow_outside_debug=True,
         stdout=out,
     )
     payload = json.loads(out.getvalue())

--- a/backend/budget_approval/tests/test_issue_budget_e2e_fixtures.py
+++ b/backend/budget_approval/tests/test_issue_budget_e2e_fixtures.py
@@ -1,0 +1,62 @@
+"""Tests for budget Playwright E2E fixture provisioning."""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+
+from access_control.models import UserRole
+from budget_approval.models import BudgetPool
+from core.models import Organization, Project, ProjectMember
+from core.services.tenant import provision_tenant_schema, slug_to_schema_name
+from core.tenant_context import tenant_schema_context
+from task.models import ApprovalChain, ApprovalChainStep
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_issue_budget_e2e_fixtures_round_trip():
+    org = Organization.objects.create(name="Budget E2E Org", email_domain="budget-e2e.test")
+    provision_tenant_schema(org.slug)
+
+    anchor = User.objects.create_user(
+        username="budget-e2e-anchor",
+        email="budget-e2e-anchor@test.com",
+        password="password123!",
+        organization=org,
+        current_organization=org,
+        is_verified=True,
+    )
+
+    tenant_schema = slug_to_schema_name(org.slug)
+    with tenant_schema_context(tenant_schema):
+        project = Project.objects.create(name="Anchor Project", organization=org, owner=anchor)
+        ProjectMember.objects.create(user=anchor, project=project, role="owner", is_active=True)
+
+    out = StringIO()
+    call_command(
+        "issue_budget_e2e_fixtures",
+        anchor_email=anchor.email,
+        project_id=project.id,
+        stdout=out,
+    )
+    payload = json.loads(out.getvalue())
+
+    assert payload["project_id"] == project.id
+    assert payload["users"]["requester"]["email"] == "e2e-budget-requester@example.com"
+    assert payload["users"]["approver_a"]["access_token"]
+    assert payload["single_approver_project_id"] != project.id
+    assert payload["budget_pool_composite"]
+    assert payload["single_approver_budget_pool_composite"]
+
+    with tenant_schema_context(tenant_schema):
+        chain = ApprovalChain.objects.get(id=payload["approval_chain_id"])
+        assert chain.steps.count() == 3
+        assert BudgetPool.objects.filter(project_id=project.id).exists()
+        assert UserRole.objects.filter(user__email="e2e-budget-requester@example.com").exists()
+        assert ApprovalChainStep.objects.filter(chain=chain, order=1).exists()

--- a/backend/budget_approval/tests/test_issue_budget_e2e_fixtures.py
+++ b/backend/budget_approval/tests/test_issue_budget_e2e_fixtures.py
@@ -48,6 +48,8 @@ def test_issue_budget_e2e_fixtures_round_trip():
     payload = json.loads(out.getvalue())
 
     assert payload["project_id"] == project.id
+    assert payload["team_id"]
+    assert payload["role_name"] == "E2E Budget Approver"
     assert payload["users"]["requester"]["email"] == "e2e-budget-requester@example.com"
     assert payload["users"]["approver_a"]["access_token"]
     assert payload["single_approver_project_id"] != project.id

--- a/backend/budget_approval/tests/test_services.py
+++ b/backend/budget_approval/tests/test_services.py
@@ -401,6 +401,70 @@ class TestProcessApproval:
         assert audit['replaced_step'] == 1
         assert 'replaced_step=1' in (result.notes or "")
 
+    def test_org_admin_override_does_not_double_advance_after_task_sync(
+        self, budget_request_under_review, org_admin, user2, user3, project
+    ):
+        """make_approval advances the task before budget sync; override must not skip a step."""
+        from budget_approval.approver_access import format_org_admin_override_marker
+        from task.models import ApprovalChain, ApprovalChainStep, ApprovalRecord, Task
+
+        task = budget_request_under_review.task
+        chain = ApprovalChain.objects.create(
+            name="Buyer → Lead → Client",
+            project=project,
+            task_type="budget",
+        )
+        ApprovalChainStep.objects.create(chain=chain, order=1, approver=user2)
+        ApprovalChainStep.objects.create(chain=chain, order=2, approver=user3)
+        task.approval_chain = chain
+        task.current_approval_step = 1
+        task.current_approver = user2
+        if task.status == Task.Status.DRAFT:
+            task.submit()
+            task.start_review()
+        elif task.status == Task.Status.SUBMITTED:
+            task.start_review()
+        task.save(
+            update_fields=['approval_chain', 'current_approval_step', 'current_approver', 'status']
+        )
+        assert task.status == Task.Status.UNDER_REVIEW
+
+        # Simulate task.views.make_approval: record step 1 override, then advance task.
+        marker = format_org_admin_override_marker(
+            user_id=org_admin.id,
+            decision='approve',
+            replaced_step=1,
+        )
+        ApprovalRecord.objects.create(
+            task=task,
+            approved_by=org_admin,
+            is_approved=True,
+            comment=marker,
+            step_number=1,
+        )
+        task.approve()
+        task.forward_to_next()
+        task.current_approver = user3
+        task.current_approval_step = 2
+        task.save(update_fields=['current_approver', 'current_approval_step', 'status'])
+
+        with patch('budget_approval.services.budget_notifications'):
+            result = BudgetRequestService.process_approval(
+                budget_request_under_review,
+                org_admin,
+                is_approved=True,
+                comment="Override step 1",
+                next_approver=user3,
+            )
+
+        assert result.status == BudgetRequestStatus.UNDER_REVIEW
+        assert result.current_approver_id == user3.id
+        task_row = task.__class__.objects.filter(pk=task.pk).values(
+            'current_approval_step', 'current_approver_id'
+        ).get()
+        assert task_row['current_approval_step'] == 2
+        assert task_row['current_approver_id'] == user3.id
+
     def test_stale_step1_approver_conflicts_after_override_advances(
         self, budget_request_under_review, org_admin, user2, user3, project
     ):

--- a/backend/task/views.py
+++ b/backend/task/views.py
@@ -1379,7 +1379,14 @@ class TaskViewSet(SlugLookupViewSetMixin, viewsets.ModelViewSet):
                             is_org_admin_override_action,
                             user_may_process_budget_approval,
                         )
+                        from budget_approval.models import BudgetRequest
                         br = task.linked_object or task.budget_requests.first()
+                        if br is None:
+                            br = (
+                                BudgetRequest.objects.filter(task_id=task.pk)
+                                .order_by('-id')
+                                .first()
+                            )
                         if br is not None and user_may_process_budget_approval(request.user, br):
                             is_admin_override = is_org_admin_override_action(request.user, br)
                         else:

--- a/frontend/e2e/budget/budget-admin-override-real.spec.ts
+++ b/frontend/e2e/budget/budget-admin-override-real.spec.ts
@@ -8,13 +8,13 @@ import {
   fetchTaskJson,
   postTaskAction,
   requireBudgetE2EFixtures,
+  submitBudgetTaskViaApi,
 } from './fixtures/budget-fixtures';
 import {
   approveWithComment,
+  expectAdminOverrideBadge,
   openTaskDetail,
-  openTaskDrawer,
   startReviewOnDetail,
-  submitBudgetTaskFromDrawer,
 } from './fixtures/budget-helpers';
 import { fixtureEmail, openBudgetUserSession } from './fixtures/budget-users';
 
@@ -32,8 +32,7 @@ test.describe('Budget org-admin override (real backend)', () => {
     });
 
     try {
-      await openTaskDrawer(requester.page, task.projectId, task.id);
-      await submitBudgetTaskFromDrawer(requester.page);
+      await submitBudgetTaskViaApi(requester.page, task, fixtureEmail('requester'));
 
       await openTaskDetail(approverA.page, task.slug, task.projectId);
       await startReviewOnDetail(approverA.page);
@@ -41,11 +40,10 @@ test.describe('Budget org-admin override (real backend)', () => {
       await openTaskDetail(orgAdmin.page, task.slug, task.projectId);
       await approveWithComment(orgAdmin.page, 'E2E org-admin override step 1');
 
-      await expect(orgAdmin.page.getByTestId('admin-override-badge').first()).toBeVisible({
-        timeout: 15_000,
-      });
+      await expectAdminOverrideBadge(orgAdmin.page);
 
-      let taskData = await fetchTaskJson(requester.page, task.id);
+      let taskData = await fetchTaskJson(orgAdmin.page, task.id, fixtureEmail('org_admin'));
+      expect(taskData.linked_object?.is_admin_override).toBe(true);
       expect(taskData.status).toBe('UNDER_REVIEW');
       expect(taskData.current_approver?.id ?? taskData.current_approver_id).toBe(
         fixtures.users.approver_b.user_id,
@@ -76,8 +74,7 @@ test.describe('Budget org-admin override (real backend)', () => {
     });
 
     try {
-      await openTaskDrawer(requester.page, task.projectId, task.id);
-      await submitBudgetTaskFromDrawer(requester.page);
+      await submitBudgetTaskViaApi(requester.page, task, fixtureEmail('requester'));
 
       await openTaskDetail(approverA.page, task.slug, task.projectId);
       await startReviewOnDetail(approverA.page);

--- a/frontend/e2e/budget/budget-admin-override-real.spec.ts
+++ b/frontend/e2e/budget/budget-admin-override-real.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * MED-315 / MED-240: org-admin override against a real backend (not mocked).
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  createIsolatedBudgetTask,
+  fetchTaskJson,
+  postTaskAction,
+  requireBudgetE2EFixtures,
+} from './fixtures/budget-fixtures';
+import {
+  approveWithComment,
+  openTaskDetail,
+  openTaskDrawer,
+  startReviewOnDetail,
+  submitBudgetTaskFromDrawer,
+} from './fixtures/budget-helpers';
+import { fixtureEmail, openBudgetUserSession } from './fixtures/budget-users';
+
+test.describe('Budget org-admin override (real backend)', () => {
+  test('org admin overrides step 1 and chain advances to step 2 approver', async ({ browser }) => {
+    const fixtures = requireBudgetE2EFixtures();
+    const requester = await openBudgetUserSession(browser, fixtureEmail('requester'));
+    const orgAdmin = await openBudgetUserSession(browser, fixtureEmail('org_admin'));
+    const approverA = await openBudgetUserSession(browser, fixtureEmail('approver_a'));
+    const approverB = await openBudgetUserSession(browser, fixtureEmail('approver_b'));
+
+    const task = await createIsolatedBudgetTask(requester.page, `E2E org override ${Date.now()}`, {
+      approverId: fixtures.users.approver_a.user_id,
+      projectKind: 'chain',
+    });
+
+    try {
+      await openTaskDrawer(requester.page, task.projectId, task.id);
+      await submitBudgetTaskFromDrawer(requester.page);
+
+      await openTaskDetail(approverA.page, task.slug, task.projectId);
+      await startReviewOnDetail(approverA.page);
+
+      await openTaskDetail(orgAdmin.page, task.slug, task.projectId);
+      await approveWithComment(orgAdmin.page, 'E2E org-admin override step 1');
+
+      await expect(orgAdmin.page.getByTestId('admin-override-badge').first()).toBeVisible({
+        timeout: 15_000,
+      });
+
+      let taskData = await fetchTaskJson(requester.page, task.id);
+      expect(taskData.status).toBe('UNDER_REVIEW');
+      expect(taskData.current_approver?.id ?? taskData.current_approver_id).toBe(
+        fixtures.users.approver_b.user_id,
+      );
+
+      await openTaskDetail(approverB.page, task.slug, task.projectId);
+      await expect(
+        approverB.page.getByRole('button', { name: 'Approve', exact: true }),
+      ).toBeVisible({ timeout: 10_000 });
+    } finally {
+      await task.cleanup();
+      await requester.close();
+      await orgAdmin.close();
+      await approverA.close();
+      await approverB.close();
+    }
+  });
+
+  test('regular member cannot override approve', async ({ browser }) => {
+    const fixtures = requireBudgetE2EFixtures();
+    const requester = await openBudgetUserSession(browser, fixtureEmail('requester'));
+    const regular = await openBudgetUserSession(browser, fixtureEmail('regular'));
+    const approverA = await openBudgetUserSession(browser, fixtureEmail('approver_a'));
+
+    const task = await createIsolatedBudgetTask(requester.page, `E2E override denied ${Date.now()}`, {
+      approverId: fixtures.users.approver_a.user_id,
+      projectKind: 'chain',
+    });
+
+    try {
+      await openTaskDrawer(requester.page, task.projectId, task.id);
+      await submitBudgetTaskFromDrawer(requester.page);
+
+      await openTaskDetail(approverA.page, task.slug, task.projectId);
+      await startReviewOnDetail(approverA.page);
+      await approverA.close();
+
+      const attempt = await postTaskAction(
+        regular.page,
+        task,
+        'make-approval',
+        fixtureEmail('regular'),
+        { action: 'approve', comment: 'should fail' },
+      );
+      expect([403, 400]).toContain(attempt.status);
+
+      const taskData = await fetchTaskJson(requester.page, task.id);
+      expect(taskData.status).toBe('UNDER_REVIEW');
+      expect(taskData.current_approver?.id ?? taskData.current_approver_id).toBe(
+        fixtures.users.approver_a.user_id,
+      );
+    } finally {
+      await task.cleanup();
+      await requester.close();
+      await regular.close();
+    }
+  });
+});

--- a/frontend/e2e/budget/budget-multi-step-chain.spec.ts
+++ b/frontend/e2e/budget/budget-multi-step-chain.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * MED-315: isolated multi-step approval chain (A → B → C).
+ *
+ * Requires backend fixtures:
+ *   python manage.py issue_budget_e2e_fixtures > frontend/e2e/budget/fixtures/budget-e2e-fixtures.json
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  createIsolatedBudgetTask,
+  fetchTaskJson,
+  requireBudgetE2EFixtures,
+} from './fixtures/budget-fixtures';
+import {
+  approveWithComment,
+  openTaskDetail,
+  startReviewOnDetail,
+  submitBudgetTaskFromDrawer,
+  openTaskDrawer,
+  expectApprovalChainProgress,
+  expectStatusChip,
+} from './fixtures/budget-helpers';
+import { fixtureEmail, openBudgetUserSession } from './fixtures/budget-users';
+
+test.describe('Budget multi-step approval chain', () => {
+  test('three approvers advance the chain until APPROVED', async ({ browser }) => {
+    const fixtures = requireBudgetE2EFixtures();
+    const requester = await openBudgetUserSession(browser, fixtureEmail('requester'));
+    const approverA = await openBudgetUserSession(browser, fixtureEmail('approver_a'));
+    const approverB = await openBudgetUserSession(browser, fixtureEmail('approver_b'));
+    const approverC = await openBudgetUserSession(browser, fixtureEmail('approver_c'));
+
+    const task = await createIsolatedBudgetTask(requester.page, `E2E chain ${Date.now()}`, {
+      approverId: fixtures.users.approver_a.user_id,
+    });
+
+    try {
+      await openTaskDrawer(requester.page, task.projectId, task.id);
+      await submitBudgetTaskFromDrawer(requester.page);
+
+      await openTaskDetail(approverA.page, task.slug, task.projectId);
+      await startReviewOnDetail(approverA.page);
+      await expectApprovalChainProgress(approverA.page, fixtures.approval_chain_name);
+
+      let taskData = await fetchTaskJson(requester.page, task.id);
+      expect(taskData.status).toBe('UNDER_REVIEW');
+      expect(taskData.current_approver?.id ?? taskData.current_approver_id).toBe(
+        fixtures.users.approver_a.user_id,
+      );
+
+      await approveWithComment(approverA.page, 'E2E step 1 approved');
+      await expectStatusChip(approverA.page, /under.?review/i);
+
+      taskData = await fetchTaskJson(requester.page, task.id);
+      expect(taskData.current_approver?.id ?? taskData.current_approver_id).toBe(
+        fixtures.users.approver_b.user_id,
+      );
+
+      await openTaskDetail(approverB.page, task.slug, task.projectId);
+      await approveWithComment(approverB.page, 'E2E step 2 approved');
+      taskData = await fetchTaskJson(requester.page, task.id);
+      expect(taskData.current_approver?.id ?? taskData.current_approver_id).toBe(
+        fixtures.users.approver_c.user_id,
+      );
+
+      await openTaskDetail(approverC.page, task.slug, task.projectId);
+      await approveWithComment(approverC.page, 'E2E final approval');
+      await expectStatusChip(approverC.page, /approved/i);
+
+      taskData = await fetchTaskJson(requester.page, task.id);
+      expect(taskData.status).toBe('APPROVED');
+    } finally {
+      await task.cleanup();
+      await requester.close();
+      await approverA.close();
+      await approverB.close();
+      await approverC.close();
+    }
+  });
+
+  test('non-current approver cannot approve out of turn', async ({ browser }) => {
+    const fixtures = requireBudgetE2EFixtures();
+    const requester = await openBudgetUserSession(browser, fixtureEmail('requester'));
+    const approverB = await openBudgetUserSession(browser, fixtureEmail('approver_b'));
+
+    const task = await createIsolatedBudgetTask(requester.page, `E2E chain guard ${Date.now()}`, {
+      approverId: fixtures.users.approver_a.user_id,
+    });
+
+    try {
+      await openTaskDrawer(requester.page, task.projectId, task.id);
+      await submitBudgetTaskFromDrawer(requester.page);
+
+      const approverA = await openBudgetUserSession(browser, fixtureEmail('approver_a'));
+      try {
+        await openTaskDetail(approverA.page, task.slug, task.projectId);
+        await startReviewOnDetail(approverA.page);
+      } finally {
+        await approverA.close();
+      }
+
+      await openTaskDetail(approverB.page, task.slug, task.projectId);
+      await expect(
+        approverB.page.getByRole('button', { name: 'Approve', exact: true }),
+      ).not.toBeVisible({ timeout: 5_000 });
+    } finally {
+      await task.cleanup();
+      await requester.close();
+      await approverB.close();
+    }
+  });
+});

--- a/frontend/e2e/budget/budget-multi-step-chain.spec.ts
+++ b/frontend/e2e/budget/budget-multi-step-chain.spec.ts
@@ -10,14 +10,12 @@ import {
   createIsolatedBudgetTask,
   fetchTaskJson,
   requireBudgetE2EFixtures,
+  submitBudgetTaskViaApi,
 } from './fixtures/budget-fixtures';
 import {
   approveWithComment,
   openTaskDetail,
   startReviewOnDetail,
-  submitBudgetTaskFromDrawer,
-  openTaskDrawer,
-  expectApprovalChainProgress,
   expectStatusChip,
 } from './fixtures/budget-helpers';
 import { fixtureEmail, openBudgetUserSession } from './fixtures/budget-users';
@@ -35,12 +33,10 @@ test.describe('Budget multi-step approval chain', () => {
     });
 
     try {
-      await openTaskDrawer(requester.page, task.projectId, task.id);
-      await submitBudgetTaskFromDrawer(requester.page);
+      await submitBudgetTaskViaApi(requester.page, task, fixtureEmail('requester'));
 
       await openTaskDetail(approverA.page, task.slug, task.projectId);
       await startReviewOnDetail(approverA.page);
-      await expectApprovalChainProgress(approverA.page, fixtures.approval_chain_name);
 
       let taskData = await fetchTaskJson(requester.page, task.id);
       expect(taskData.status).toBe('UNDER_REVIEW');
@@ -88,8 +84,7 @@ test.describe('Budget multi-step approval chain', () => {
     });
 
     try {
-      await openTaskDrawer(requester.page, task.projectId, task.id);
-      await submitBudgetTaskFromDrawer(requester.page);
+      await submitBudgetTaskViaApi(requester.page, task, fixtureEmail('requester'));
 
       const approverA = await openBudgetUserSession(browser, fixtureEmail('approver_a'));
       try {

--- a/frontend/e2e/budget/budget-reject-reopen-flow.spec.ts
+++ b/frontend/e2e/budget/budget-reject-reopen-flow.spec.ts
@@ -1,259 +1,91 @@
 /**
- * E2E tests for MED-238 — the legal recovery path after rejection:
- *   create → submit → review → REJECT → (approve/lock hidden) → Revise (reopen)
- *   → resubmit → review → APPROVE
- *
- * Also pins the governance rule end-to-end: while a budget task is REJECTED,
- * the UI offers no Approve/Lock action and the lock endpoint refuses with 400.
- *
- * Tests run serially so each step can rely on the task mutated by the previous one.
+ * MED-315 / MED-238: reject → revise → resubmit → approve with isolated fixtures.
  */
 
-import { test, expect, type Page } from '@playwright/test';
-import { waitForTasksPageReady, deleteTaskById } from '../tasks/tasks-helpers';
+import { test, expect } from '@playwright/test';
+import {
+  createIsolatedBudgetTask,
+  fetchTaskJson,
+  postTaskAction,
+  requireBudgetE2EFixtures,
+} from './fixtures/budget-fixtures';
+import {
+  approveWithComment,
+  clickFsmButton,
+  openTaskDetail,
+  openTaskDrawer,
+  rejectWithComment,
+  startReviewOnDetail,
+  submitBudgetTaskFromDrawer,
+  expectStatusChip,
+} from './fixtures/budget-helpers';
+import { fixtureEmail, openBudgetUserSession } from './fixtures/budget-users';
 
-// ---------------------------------------------------------------------------
-// Helpers (mirrors budget-task-flow.spec.ts)
-// ---------------------------------------------------------------------------
+test.describe('Budget reject → reopen → approve', () => {
+  test('rejected task hides illegal actions, revises, and completes approval', async ({ browser }) => {
+    const fixtures = requireBudgetE2EFixtures();
+    const requester = await openBudgetUserSession(browser, fixtureEmail('requester'), undefined, 'single');
+    const approver = await openBudgetUserSession(browser, fixtureEmail('approver_a'), undefined, 'single');
 
-/** Get the JWT token stored in localStorage by the auth layer. */
-async function getToken(page: Page): Promise<string | null> {
-  return page.evaluate(() => {
+    const task = await createIsolatedBudgetTask(requester.page, `E2E reject reopen ${Date.now()}`, {
+      approverId: fixtures.users.approver_a.user_id,
+      projectKind: 'single',
+    });
+
     try {
-      const raw = localStorage.getItem('auth-storage-v1');
-      return raw ? (JSON.parse(raw) as any)?.state?.token ?? null : null;
-    } catch {
-      return null;
+      await openTaskDrawer(requester.page, task.projectId, task.id);
+      await submitBudgetTaskFromDrawer(requester.page);
+
+      await openTaskDetail(approver.page, task.slug, task.projectId);
+      await startReviewOnDetail(approver.page);
+      await rejectWithComment(approver.page, 'E2E: rejecting to test reopen path');
+
+      let taskData = await fetchTaskJson(requester.page, task.id);
+      expect(taskData.status).toBe('REJECTED');
+
+      await expect(approver.page.getByRole('button', { name: 'Approve', exact: true })).not.toBeVisible({
+        timeout: 3_000,
+      });
+      await expect(approver.page.getByRole('button', { name: 'Reject', exact: true })).not.toBeVisible({
+        timeout: 3_000,
+      });
+      await expect(approver.page.getByRole('button', { name: 'Lock', exact: true })).not.toBeVisible({
+        timeout: 3_000,
+      });
+      await expect(approver.page.getByRole('button', { name: 'Revise', exact: true })).toBeVisible({
+        timeout: 10_000,
+      });
+
+      const lockAttempt = await postTaskAction(
+        approver.page,
+        task,
+        'lock',
+        fixtureEmail('approver_a'),
+      );
+      expect(lockAttempt.status).toBe(400);
+      taskData = await fetchTaskJson(requester.page, task.id);
+      expect(taskData.status).toBe('REJECTED');
+
+      await clickFsmButton(approver.page, 'Revise');
+      await expectStatusChip(approver.page, /draft/i);
+      taskData = await fetchTaskJson(requester.page, task.id);
+      expect(taskData.status).toBe('DRAFT');
+
+      await openTaskDetail(requester.page, task.slug, task.projectId);
+      await clickFsmButton(requester.page, 'Submit');
+      await expectStatusChip(requester.page, /submitted/i);
+
+      await openTaskDetail(approver.page, task.slug, task.projectId);
+      await startReviewOnDetail(approver.page);
+      await approveWithComment(approver.page, 'E2E: approving revised request');
+      await expectStatusChip(approver.page, /approved/i);
+
+      taskData = await fetchTaskJson(requester.page, task.id);
+      expect(taskData.status).toBe('APPROVED');
+    } finally {
+      await task.cleanup();
+      await requester.close();
+      await approver.close();
     }
-  });
-}
-
-/** Wait until the task drawer is visible and skeletons settled. */
-async function waitForDrawerReady(page: Page) {
-  await expect(page.getByTestId('task-drawer')).toBeVisible({ timeout: 15_000 });
-  await page.waitForFunction(
-    () => !document.querySelector('.animate-pulse'),
-    { timeout: 15_000 },
-  );
-}
-
-/** Click an FSM action button (Submit, Start Review, Approve, …). */
-async function clickFsmButton(page: Page, label: string) {
-  const btn = page.getByRole('button', { name: label, exact: true });
-  await expect(btn).toBeVisible({ timeout: 10_000 });
-  await expect(btn).toBeEnabled();
-  await btn.click();
-}
-
-/** Fetch a task via the REST API and return its JSON. */
-async function fetchTask(page: Page, taskId: number): Promise<any> {
-  const token = await getToken(page);
-  const origin = new URL(page.url()).origin;
-  const resp = await page.request.get(`${origin}/api/tasks/${taskId}/`, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  return resp.json();
-}
-
-/** Drive a fresh budget task to UNDER_REVIEW through the UI.
- *
- * A budget task created with current_approver_id starts life SUBMITTED, so
- * usually only "Start Review" is needed; the DRAFT branch (fill details,
- * submit) is kept as a fallback.
- */
-async function bringTaskUnderReview(page: Page, projectId: number, taskId: number): Promise<boolean> {
-  await page.goto(`/tasks?project_id=${projectId}&drawerTaskId=${taskId}`);
-  await waitForDrawerReady(page);
-
-  const startReviewBtn = page.getByRole('button', { name: 'Start Review', exact: true });
-  if (!(await startReviewBtn.isVisible({ timeout: 5_000 }).catch(() => false))) {
-    // DRAFT fallback: fill required budget details (pool + amount) and submit
-    const section = page.locator('section', { hasText: 'Budget details' });
-    await section.getByRole('button', { name: 'Edit' }).click();
-    const poolSelect = page.locator('#task-field-budget-budget_pool_composite');
-    await expect(poolSelect).toBeVisible({ timeout: 10_000 });
-
-    let chosenPool = '';
-    for (const opt of await poolSelect.locator('option').all()) {
-      const val = await opt.getAttribute('value');
-      if (val && val.trim()) { chosenPool = val; break; }
-    }
-    if (!chosenPool) return false; // no pools in this environment
-
-    await poolSelect.selectOption(chosenPool);
-    await page.locator('#task-field-budget-amount').fill('100');
-    await section.getByRole('button', { name: 'Save' }).click();
-    await expect(page.getByText(/details (updated|saved)/i)).toBeVisible({ timeout: 10_000 });
-
-    await clickFsmButton(page, 'Submit');
-    await expect(page.getByText(/submitted/i).first()).toBeVisible({ timeout: 10_000 });
-  }
-
-  await clickFsmButton(page, 'Start Review');
-  await expect(page.getByText(/under.?review/i).first()).toBeVisible({ timeout: 10_000 });
-  return true;
-}
-
-// ---------------------------------------------------------------------------
-// Test suite
-// ---------------------------------------------------------------------------
-
-test.describe('Budget task reject → reopen → approve (MED-238)', () => {
-  test.describe.configure({ mode: 'serial' });
-
-  let projectId: number;
-  let taskId: number | null = null;
-  let flowReady = false;
-
-  test.beforeAll(async ({ browser }) => {
-    const ctx = await browser.newContext({ storageState: 'e2e/.auth/user.json' });
-    const pg = await ctx.newPage();
-    // Go straight to an app page: the project store auto-selects the first
-    // project only once the app shell (OnboardingContext) is mounted, which
-    // never happens on the marketing landing page.
-    await pg.goto('/tasks');
-    await waitForTasksPageReady(pg);
-    await pg.waitForFunction(() => {
-      try {
-        const raw = localStorage.getItem('project-storage-v1');
-        return Boolean(raw && (JSON.parse(raw) as any)?.state?.activeProject?.id);
-      } catch {
-        return false;
-      }
-    }, { timeout: 30_000 });
-    projectId = await pg.evaluate(() => {
-      const raw = localStorage.getItem('project-storage-v1');
-      return (JSON.parse(raw!) as any).state.activeProject.id as number;
-    });
-    await ctx.close();
-  });
-
-  test.afterAll(async ({ browser }) => {
-    if (taskId == null) return;
-    const ctx = await browser.newContext({ storageState: 'e2e/.auth/user.json' });
-    const pg = await ctx.newPage();
-    await pg.goto('/tasks');
-    await waitForTasksPageReady(pg);
-    await deleteTaskById(pg, taskId).catch(() => {});
-    await ctx.close();
-  });
-
-  test('1. create a budget task and bring it under review', async ({ page }) => {
-    await page.goto(`/tasks?project_id=${projectId}`);
-    await waitForTasksPageReady(page);
-
-    const token = await getToken(page);
-    const origin = new URL(page.url()).origin;
-    const approverId = await page.evaluate(() => {
-      try {
-        const raw = localStorage.getItem('auth-storage-v1');
-        return raw ? (JSON.parse(raw) as any)?.state?.user?.id ?? null : null;
-      } catch {
-        return null;
-      }
-    });
-    const createResp = await page.request.post(`${origin}/api/tasks/`, {
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-      data: JSON.stringify({
-        summary: 'E2E MED-238 Reject Reopen Flow',
-        type: 'budget',
-        project: projectId,
-        current_approver_id: approverId,
-      }),
-    });
-    expect(createResp.ok()).toBeTruthy();
-    taskId = (await createResp.json()).id;
-    expect(taskId).toBeTruthy();
-
-    flowReady = await bringTaskUnderReview(page, projectId, taskId!);
-    if (!flowReady) {
-      test.info().annotations.push({ type: 'skip', description: 'No budget pools available in this environment' });
-    }
-  });
-
-  test('2. reject the task with a comment (UNDER_REVIEW → REJECTED)', async ({ page }) => {
-    test.skip(!flowReady, 'Flow prerequisites unavailable');
-
-    // The review section (comment + Approve/Reject) lives on the full task
-    // detail page, not in the drawer.
-    await page.goto(`/tasks/${taskId}?project_id=${projectId}`);
-    await page.waitForLoadState('networkidle');
-
-    await expect(page.locator('#review-comment')).toBeVisible({ timeout: 15_000 });
-    await page.locator('#review-comment').fill('E2E: rejecting to test the reopen path');
-    await clickFsmButton(page, 'Reject');
-
-    await expect(page.getByText(/rejected/i).first()).toBeVisible({ timeout: 10_000 });
-  });
-
-  test('3. while REJECTED, the UI hides Approve/Reject/Lock and offers Revise', async ({ page }) => {
-    test.skip(!flowReady, 'Flow prerequisites unavailable');
-
-    await page.goto(`/tasks/${taskId}?project_id=${projectId}`);
-    await page.waitForLoadState('networkidle');
-
-    const taskData = await fetchTask(page, taskId!);
-    expect(taskData.status).toBe('REJECTED');
-
-    // Illegal actions are hidden…
-    await expect(page.getByRole('button', { name: 'Approve', exact: true })).not.toBeVisible({ timeout: 3_000 });
-    await expect(page.getByRole('button', { name: 'Reject', exact: true })).not.toBeVisible({ timeout: 3_000 });
-    await expect(page.getByRole('button', { name: 'Lock', exact: true })).not.toBeVisible({ timeout: 3_000 });
-
-    // …and the only way forward is Revise
-    await expect(page.getByRole('button', { name: 'Revise', exact: true })).toBeVisible({ timeout: 10_000 });
-  });
-
-  test('4. lock endpoint refuses a REJECTED task with 400 (no pool deduction)', async ({ page }) => {
-    test.skip(!flowReady, 'Flow prerequisites unavailable');
-
-    await page.goto(`/tasks/${taskId}?project_id=${projectId}`);
-    await page.waitForLoadState('networkidle');
-
-    const token = await getToken(page);
-    const origin = new URL(page.url()).origin;
-    const lockResp = await page.request.post(`${origin}/api/tasks/${taskId}/lock/`, {
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-      data: '{}',
-    });
-    expect(lockResp.status()).toBe(400);
-
-    // Status must remain REJECTED — the request never reached LOCKED
-    const taskData = await fetchTask(page, taskId!);
-    expect(taskData.status).toBe('REJECTED');
-  });
-
-  test('5. revise reopens the task as a draft (REJECTED → DRAFT)', async ({ page }) => {
-    test.skip(!flowReady, 'Flow prerequisites unavailable');
-
-    await page.goto(`/tasks/${taskId}?project_id=${projectId}`);
-    await page.waitForLoadState('networkidle');
-
-    await clickFsmButton(page, 'Revise');
-    await expect(page.getByText(/draft/i).first()).toBeVisible({ timeout: 10_000 });
-
-    const taskData = await fetchTask(page, taskId!);
-    expect(taskData.status).toBe('DRAFT');
-  });
-
-  test('6. resubmit and approve the revised draft (happy path completes)', async ({ page }) => {
-    test.skip(!flowReady, 'Flow prerequisites unavailable');
-
-    await page.goto(`/tasks/${taskId}?project_id=${projectId}`);
-    await page.waitForLoadState('networkidle');
-
-    await clickFsmButton(page, 'Submit');
-    await expect(page.getByText(/submitted/i).first()).toBeVisible({ timeout: 10_000 });
-
-    await clickFsmButton(page, 'Start Review');
-    await expect(page.getByText(/under.?review/i).first()).toBeVisible({ timeout: 10_000 });
-
-    await expect(page.locator('#review-comment')).toBeVisible({ timeout: 15_000 });
-    await page.locator('#review-comment').fill('E2E: approving the revised request');
-    await clickFsmButton(page, 'Approve');
-    await expect(page.getByText(/approved/i).first()).toBeVisible({ timeout: 10_000 });
-
-    const taskData = await fetchTask(page, taskId!);
-    expect(taskData.status).toBe('APPROVED');
   });
 });

--- a/frontend/e2e/budget/budget-reject-reopen-flow.spec.ts
+++ b/frontend/e2e/budget/budget-reject-reopen-flow.spec.ts
@@ -8,15 +8,14 @@ import {
   fetchTaskJson,
   postTaskAction,
   requireBudgetE2EFixtures,
+  submitBudgetTaskViaApi,
 } from './fixtures/budget-fixtures';
 import {
   approveWithComment,
   clickFsmButton,
   openTaskDetail,
-  openTaskDrawer,
   rejectWithComment,
   startReviewOnDetail,
-  submitBudgetTaskFromDrawer,
   expectStatusChip,
 } from './fixtures/budget-helpers';
 import { fixtureEmail, openBudgetUserSession } from './fixtures/budget-users';
@@ -33,14 +32,18 @@ test.describe('Budget reject → reopen → approve', () => {
     });
 
     try {
-      await openTaskDrawer(requester.page, task.projectId, task.id);
-      await submitBudgetTaskFromDrawer(requester.page);
+      await submitBudgetTaskViaApi(
+        requester.page,
+        task,
+        fixtureEmail('requester'),
+        'single',
+      );
 
       await openTaskDetail(approver.page, task.slug, task.projectId);
       await startReviewOnDetail(approver.page);
       await rejectWithComment(approver.page, 'E2E: rejecting to test reopen path');
 
-      let taskData = await fetchTaskJson(requester.page, task.id);
+      let taskData = await fetchTaskJson(requester.page, task.id, undefined, 'single');
       expect(taskData.status).toBe('REJECTED');
 
       await expect(approver.page.getByRole('button', { name: 'Approve', exact: true })).not.toBeVisible({
@@ -61,14 +64,16 @@ test.describe('Budget reject → reopen → approve', () => {
         task,
         'lock',
         fixtureEmail('approver_a'),
+        {},
+        'single',
       );
       expect(lockAttempt.status).toBe(400);
-      taskData = await fetchTaskJson(requester.page, task.id);
+      taskData = await fetchTaskJson(requester.page, task.id, undefined, 'single');
       expect(taskData.status).toBe('REJECTED');
 
       await clickFsmButton(approver.page, 'Revise');
       await expectStatusChip(approver.page, /draft/i);
-      taskData = await fetchTaskJson(requester.page, task.id);
+      taskData = await fetchTaskJson(requester.page, task.id, undefined, 'single');
       expect(taskData.status).toBe('DRAFT');
 
       await openTaskDetail(requester.page, task.slug, task.projectId);
@@ -80,7 +85,7 @@ test.describe('Budget reject → reopen → approve', () => {
       await approveWithComment(approver.page, 'E2E: approving revised request');
       await expectStatusChip(approver.page, /approved/i);
 
-      taskData = await fetchTaskJson(requester.page, task.id);
+      taskData = await fetchTaskJson(requester.page, task.id, undefined, 'single');
       expect(taskData.status).toBe('APPROVED');
     } finally {
       await task.cleanup();

--- a/frontend/e2e/budget/budget-single-approver.spec.ts
+++ b/frontend/e2e/budget/budget-single-approver.spec.ts
@@ -7,13 +7,12 @@ import {
   createIsolatedBudgetTask,
   fetchTaskJson,
   requireBudgetE2EFixtures,
+  submitBudgetTaskViaApi,
 } from './fixtures/budget-fixtures';
 import {
   approveWithComment,
   openTaskDetail,
-  openTaskDrawer,
   startReviewOnDetail,
-  submitBudgetTaskFromDrawer,
   expectStatusChip,
 } from './fixtures/budget-helpers';
 import { fixtureEmail, openBudgetUserSession } from './fixtures/budget-users';
@@ -30,18 +29,22 @@ test.describe('Budget single-approver happy path', () => {
     });
 
     try {
-      await openTaskDrawer(requester.page, task.projectId, task.id);
-      await expect(
-        requester.page.locator('section', { hasText: 'Budget details' }),
-      ).toBeVisible({ timeout: 10_000 });
-      await submitBudgetTaskFromDrawer(requester.page);
+      await submitBudgetTaskViaApi(
+        requester.page,
+        task,
+        fixtureEmail('requester'),
+        'single',
+      );
+
+      let taskData = await fetchTaskJson(requester.page, task.id, undefined, 'single');
+      expect(taskData.status).toBe('SUBMITTED');
 
       await openTaskDetail(approver.page, task.slug, task.projectId);
       await startReviewOnDetail(approver.page);
       await approveWithComment(approver.page, 'E2E single-step approval');
       await expectStatusChip(approver.page, /approved/i);
 
-      const taskData = await fetchTaskJson(requester.page, task.id);
+      taskData = await fetchTaskJson(requester.page, task.id, undefined, 'single');
       expect(taskData.status).toBe('APPROVED');
       expect(taskData.current_approver?.id ?? taskData.current_approver_id).toBe(
         fixtures.users.approver_a.user_id,

--- a/frontend/e2e/budget/budget-single-approver.spec.ts
+++ b/frontend/e2e/budget/budget-single-approver.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * MED-315: single-approver happy path with distinct requester and approver roles.
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  createIsolatedBudgetTask,
+  fetchTaskJson,
+  requireBudgetE2EFixtures,
+} from './fixtures/budget-fixtures';
+import {
+  approveWithComment,
+  openTaskDetail,
+  openTaskDrawer,
+  startReviewOnDetail,
+  submitBudgetTaskFromDrawer,
+  expectStatusChip,
+} from './fixtures/budget-helpers';
+import { fixtureEmail, openBudgetUserSession } from './fixtures/budget-users';
+
+test.describe('Budget single-approver happy path', () => {
+  test('requester submits and designated approver approves', async ({ browser }) => {
+    const fixtures = requireBudgetE2EFixtures();
+    const requester = await openBudgetUserSession(browser, fixtureEmail('requester'), undefined, 'single');
+    const approver = await openBudgetUserSession(browser, fixtureEmail('approver_a'), undefined, 'single');
+
+    const task = await createIsolatedBudgetTask(requester.page, `E2E single approver ${Date.now()}`, {
+      approverId: fixtures.users.approver_a.user_id,
+      projectKind: 'single',
+    });
+
+    try {
+      await openTaskDrawer(requester.page, task.projectId, task.id);
+      await expect(
+        requester.page.locator('section', { hasText: 'Budget details' }),
+      ).toBeVisible({ timeout: 10_000 });
+      await submitBudgetTaskFromDrawer(requester.page);
+
+      await openTaskDetail(approver.page, task.slug, task.projectId);
+      await startReviewOnDetail(approver.page);
+      await approveWithComment(approver.page, 'E2E single-step approval');
+      await expectStatusChip(approver.page, /approved/i);
+
+      const taskData = await fetchTaskJson(requester.page, task.id);
+      expect(taskData.status).toBe('APPROVED');
+      expect(taskData.current_approver?.id ?? taskData.current_approver_id).toBe(
+        fixtures.users.approver_a.user_id,
+      );
+
+      await openTaskDetail(requester.page, task.slug, task.projectId);
+      await expect(
+        requester.page.getByRole('button', { name: 'Approve', exact: true }),
+      ).not.toBeVisible({ timeout: 3_000 });
+    } finally {
+      await task.cleanup();
+      await requester.close();
+      await approver.close();
+    }
+  });
+});

--- a/frontend/e2e/budget/fixtures/budget-e2e-types.ts
+++ b/frontend/e2e/budget/fixtures/budget-e2e-types.ts
@@ -1,0 +1,45 @@
+export type BudgetE2EUserFixture = {
+  user_id: number;
+  email: string;
+  username: string;
+  access_token: string;
+  refresh_token: string;
+  organization_access_token: string;
+};
+
+export type BudgetE2EFixturePayload = {
+  organization_id: number;
+  organization_slug: string;
+  project_id: number;
+  project_slug: string;
+  project_name: string;
+  budget_pool_id: number;
+  ad_channel_id: number;
+  budget_pool_composite: string;
+  approval_chain_id: number;
+  approval_chain_name: string;
+  single_approver_project_id: number;
+  single_approver_project_slug: string;
+  single_approver_project_name: string;
+  single_approver_budget_pool_composite: string;
+  password: string;
+  users: {
+    requester: BudgetE2EUserFixture;
+    approver_a: BudgetE2EUserFixture;
+    approver_b: BudgetE2EUserFixture;
+    approver_c: BudgetE2EUserFixture;
+    org_admin: BudgetE2EUserFixture;
+    regular: BudgetE2EUserFixture;
+  };
+};
+
+export const BUDGET_E2E_EMAILS = {
+  requester: 'e2e-budget-requester@example.com',
+  approver_a: 'e2e-budget-approver-a@example.com',
+  approver_b: 'e2e-budget-approver-b@example.com',
+  approver_c: 'e2e-budget-approver-c@example.com',
+  org_admin: 'e2e-budget-org-admin@example.com',
+  regular: 'e2e-budget-regular@example.com',
+} as const;
+
+export const BUDGET_E2E_DEFAULT_PASSWORD = 'password123!';

--- a/frontend/e2e/budget/fixtures/budget-e2e-types.ts
+++ b/frontend/e2e/budget/fixtures/budget-e2e-types.ts
@@ -22,6 +22,8 @@ export type BudgetE2EFixturePayload = {
   single_approver_project_slug: string;
   single_approver_project_name: string;
   single_approver_budget_pool_composite: string;
+  team_id: number;
+  role_name: string;
   password: string;
   users: {
     requester: BudgetE2EUserFixture;
@@ -43,3 +45,59 @@ export const BUDGET_E2E_EMAILS = {
 } as const;
 
 export const BUDGET_E2E_DEFAULT_PASSWORD = 'password123!';
+
+export const BUDGET_E2E_DEFAULT_ROLE_NAME = 'E2E Budget Approver';
+
+export function resolveBudgetRbacHeaders(
+  fixtures: BudgetE2EFixturePayload,
+  email: string,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+
+  if (email === fixtures.users.org_admin.email) {
+    headers['x-user-role'] = 'Org Admin';
+    return headers;
+  }
+
+  if (email === fixtures.users.regular.email) {
+    headers['x-user-role'] = 'Member';
+    return headers;
+  }
+
+  const teamId = fixtures.team_id;
+  if (!teamId) {
+    throw new Error(
+      'Budget E2E fixtures missing team_id. Re-run issue_budget_e2e_fixtures to regenerate budget-e2e-fixtures.json.',
+    );
+  }
+
+  headers['x-user-role'] = fixtures.role_name ?? BUDGET_E2E_DEFAULT_ROLE_NAME;
+  headers['x-team-id'] = String(teamId);
+  return headers;
+}
+
+export function resolveBudgetRbacAuthState(
+  fixtures: BudgetE2EFixturePayload,
+  email: string,
+): { roles: string[]; userTeams: number[]; selectedTeamId: number | null } {
+  if (email === fixtures.users.org_admin.email) {
+    return { roles: ['Org Admin'], userTeams: [], selectedTeamId: null };
+  }
+
+  if (email === fixtures.users.regular.email) {
+    return { roles: ['Member'], userTeams: [], selectedTeamId: null };
+  }
+
+  const teamId = fixtures.team_id;
+  if (!teamId) {
+    throw new Error(
+      'Budget E2E fixtures missing team_id. Re-run issue_budget_e2e_fixtures to regenerate budget-e2e-fixtures.json.',
+    );
+  }
+
+  return {
+    roles: [fixtures.role_name ?? BUDGET_E2E_DEFAULT_ROLE_NAME],
+    userTeams: [teamId],
+    selectedTeamId: teamId,
+  };
+}

--- a/frontend/e2e/budget/fixtures/budget-fixtures.ts
+++ b/frontend/e2e/budget/fixtures/budget-fixtures.ts
@@ -297,7 +297,7 @@ export async function fetchTaskJson(
 
 export async function postTaskAction(
   page: Page,
-  taskRef: { id: number; slug: string } | number | string,
+  taskRef: { slug: string } | number | string,
   action: string,
   email: string,
   body: Record<string, unknown> = {},

--- a/frontend/e2e/budget/fixtures/budget-fixtures.ts
+++ b/frontend/e2e/budget/fixtures/budget-fixtures.ts
@@ -1,0 +1,293 @@
+import fs from 'fs';
+import path from 'path';
+import { type APIRequestContext, type Page, expect } from '@playwright/test';
+import { deleteTaskById } from '../../tasks/tasks-helpers';
+import {
+  BUDGET_E2E_DEFAULT_PASSWORD,
+  BUDGET_E2E_EMAILS,
+  type BudgetE2EFixturePayload,
+} from './budget-e2e-types';
+
+const FIXTURE_FILE = path.join(__dirname, 'budget-e2e-fixtures.json');
+
+let cachedFixtures: BudgetE2EFixturePayload | null | undefined;
+
+export function loadBudgetE2EFixtures(): BudgetE2EFixturePayload | null {
+  if (cachedFixtures !== undefined) {
+    return cachedFixtures;
+  }
+
+  const fromEnv = process.env.E2E_BUDGET_FIXTURES;
+  if (fromEnv && fs.existsSync(fromEnv)) {
+    cachedFixtures = JSON.parse(fs.readFileSync(fromEnv, 'utf-8')) as BudgetE2EFixturePayload;
+    return cachedFixtures;
+  }
+
+  if (fs.existsSync(FIXTURE_FILE)) {
+    cachedFixtures = JSON.parse(fs.readFileSync(FIXTURE_FILE, 'utf-8')) as BudgetE2EFixturePayload;
+    return cachedFixtures;
+  }
+
+  cachedFixtures = null;
+  return null;
+}
+
+export function requireBudgetE2EFixtures(): BudgetE2EFixturePayload {
+  const fixtures = loadBudgetE2EFixtures();
+  if (!fixtures) {
+    throw new Error(
+      'Budget E2E fixtures not found. Run:\n' +
+        '  docker compose -p mediajira-v2 -f docker-compose.dev.yml exec backend ' +
+        'python manage.py issue_budget_e2e_fixtures > frontend/e2e/budget/fixtures/budget-e2e-fixtures.json',
+    );
+  }
+  return fixtures;
+}
+
+export type BudgetTaskFixture = {
+  id: number;
+  slug: string;
+  projectId: number;
+  cleanup: () => Promise<void>;
+};
+
+function apiOrigin(page: Page): string {
+  return process.env.BASE_URL || new URL(page.url()).origin || 'http://localhost';
+}
+
+function projectRef(
+  fixtures: BudgetE2EFixturePayload,
+  projectKind: 'chain' | 'single' = 'chain',
+): { id: number; slug: string } {
+  if (projectKind === 'single') {
+    return {
+      id: fixtures.single_approver_project_id,
+      slug: fixtures.single_approver_project_slug,
+    };
+  }
+  return { id: fixtures.project_id, slug: fixtures.project_slug };
+}
+
+async function ensureActiveProject(
+  request: APIRequestContext,
+  headers: Record<string, string>,
+  project: { id: number; slug: string },
+): Promise<void> {
+  const origin = process.env.BASE_URL || 'http://localhost';
+  for (const key of [project.slug, String(project.id)]) {
+    const resp = await request.post(
+      `${origin}/api/core/projects/${encodeURIComponent(key)}/set_active/`,
+      { headers },
+    );
+    if (resp.ok()) {
+      return;
+    }
+  }
+  throw new Error(
+    `Failed to set active project (id=${project.id}, slug=${project.slug}). ` +
+      'Re-run issue_budget_e2e_fixtures if memberships are stale.',
+  );
+}
+
+export async function apiAuthHeaders(
+  request: APIRequestContext,
+  email: string,
+  password: string = BUDGET_E2E_DEFAULT_PASSWORD,
+): Promise<Record<string, string>> {
+  const origin = process.env.BASE_URL || 'http://localhost';
+  const loginResp = await request.post(`${origin}/auth/login/`, {
+    headers: { 'Content-Type': 'application/json' },
+    data: { email, password },
+  });
+  if (!loginResp.ok()) {
+    throw new Error(`Login failed for ${email} (${loginResp.status()}): ${await loginResp.text()}`);
+  }
+  const body = await loginResp.json();
+  const token = body.token as string;
+  const user = body.user as { roles?: string[]; team_id?: number };
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+  if (body.organization_access_token) {
+    headers['X-Organization-Token'] = body.organization_access_token;
+  }
+  if (user?.roles?.length) {
+    headers['x-user-role'] = user.roles[0];
+  }
+  if (user?.team_id) {
+    headers['x-team-id'] = String(user.team_id);
+  }
+  return headers;
+}
+
+export async function createBudgetTaskViaApi(
+  page: Page,
+  projectId: number,
+  summary: string,
+  overrides: Record<string, unknown> = {},
+  projectKind: 'chain' | 'single' = 'chain',
+): Promise<{ id: number; slug: string }> {
+  const fixtures = loadBudgetE2EFixtures();
+  const origin = apiOrigin(page);
+  const headers = await apiAuthHeaders(
+    page.request,
+    fixtures?.users.requester.email ?? BUDGET_E2E_EMAILS.requester,
+    fixtures?.password ?? BUDGET_E2E_DEFAULT_PASSWORD,
+  );
+  if (fixtures) {
+    await ensureActiveProject(page.request, headers, projectRef(fixtures, projectKind));
+  }
+
+  const createTaskResp = await page.request.post(`${origin}/api/tasks/`, {
+    headers,
+    data: {
+      project_id: projectId,
+      type: 'budget',
+      summary,
+      priority: 'MEDIUM',
+      create_as_draft: true,
+      ...overrides,
+    },
+  });
+  if (!createTaskResp.ok()) {
+    throw new Error(`Failed to create budget task (${createTaskResp.status()}): ${await createTaskResp.text()}`);
+  }
+  const task = await createTaskResp.json();
+  if (!task?.id || !task?.slug) {
+    throw new Error('Budget task response missing id/slug');
+  }
+  return { id: task.id as number, slug: task.slug as string };
+}
+
+export async function attachBudgetDetailsViaApi(
+  page: Page,
+  taskId: number,
+  opts: {
+    amount?: string;
+    approverId?: number;
+    composite?: string;
+    notes?: string;
+    projectKind?: 'chain' | 'single';
+  } = {},
+): Promise<void> {
+  const fixtures = requireBudgetE2EFixtures();
+  const origin = apiOrigin(page);
+  const headers = await apiAuthHeaders(page.request, fixtures.users.requester.email, fixtures.password);
+  await ensureActiveProject(
+    page.request,
+    headers,
+    projectRef(fixtures, opts.projectKind ?? 'chain'),
+  );
+  const composite =
+    opts.composite ??
+    (opts.projectKind === 'single'
+      ? fixtures.single_approver_budget_pool_composite
+      : fixtures.budget_pool_composite);
+  const parts = composite.split(':');
+  if (parts.length < 3) {
+    throw new Error(`Invalid budget_pool_composite: ${composite}`);
+  }
+  const [poolId, channelId, currency] = parts;
+  const approverId = opts.approverId ?? fixtures.users.approver_a.user_id;
+
+  const resp = await page.request.post(`${origin}/api/budgets/requests/`, {
+    headers,
+    data: {
+      task: taskId,
+      amount: opts.amount ?? '100.00',
+      currency,
+      ad_channel: Number(channelId),
+      budget_pool_id: Number(poolId),
+      notes: opts.notes ?? '',
+      current_approver: approverId,
+    },
+  });
+  if (!resp.ok()) {
+    throw new Error(`Failed to attach budget details (${resp.status()}): ${await resp.text()}`);
+  }
+}
+
+export async function createIsolatedBudgetTask(
+  page: Page,
+  summary: string,
+  opts: {
+    amount?: string;
+    approverId?: number;
+    taskOverrides?: Record<string, unknown>;
+    projectKind?: 'chain' | 'single';
+  } = {},
+): Promise<BudgetTaskFixture> {
+  const fixtures = requireBudgetE2EFixtures();
+  const projectId =
+    opts.projectKind === 'single' ? fixtures.single_approver_project_id : fixtures.project_id;
+  const task = await createBudgetTaskViaApi(
+    page,
+    projectId,
+    summary,
+    opts.taskOverrides ?? {},
+    opts.projectKind ?? 'chain',
+  );
+  await attachBudgetDetailsViaApi(page, task.id, {
+    amount: opts.amount,
+    approverId: opts.approverId,
+    projectKind: opts.projectKind,
+  });
+
+  return {
+    id: task.id,
+    slug: task.slug,
+    projectId,
+    cleanup: async () => {
+      await deleteTaskById(page, task.id).catch(() => {});
+    },
+  };
+}
+
+export async function fetchTaskJson(
+  page: Page,
+  taskId: number,
+  email?: string,
+  projectKind: 'chain' | 'single' = 'chain',
+): Promise<any> {
+  const fixtures = loadBudgetE2EFixtures();
+  const origin = apiOrigin(page);
+  const loginEmail = email ?? fixtures?.users.requester.email ?? BUDGET_E2E_EMAILS.requester;
+  const headers = await apiAuthHeaders(
+    page.request,
+    loginEmail,
+    fixtures?.password ?? BUDGET_E2E_DEFAULT_PASSWORD,
+  );
+  if (fixtures) {
+    await ensureActiveProject(page.request, headers, projectRef(fixtures, projectKind));
+  }
+  const resp = await page.request.get(`${origin}/api/tasks/${taskId}/`, { headers });
+  expect(resp.ok()).toBeTruthy();
+  return resp.json();
+}
+
+export async function postTaskAction(
+  page: Page,
+  taskRef: { id: number; slug: string } | number | string,
+  action: string,
+  email: string,
+  body: Record<string, unknown> = {},
+  projectKind: 'chain' | 'single' = 'chain',
+): Promise<any> {
+  const fixtures = loadBudgetE2EFixtures();
+  const origin = apiOrigin(page);
+  const headers = await apiAuthHeaders(
+    page.request,
+    email,
+    fixtures?.password ?? BUDGET_E2E_DEFAULT_PASSWORD,
+  );
+  if (fixtures) {
+    await ensureActiveProject(page.request, headers, projectRef(fixtures, projectKind));
+  }
+  const key = typeof taskRef === 'object' ? taskRef.slug : String(taskRef);
+  const resp = await page.request.post(`${origin}/api/tasks/${key}/${action}/`, {
+    headers,
+    data: body,
+  });
+  return { status: resp.status(), body: await resp.json().catch(() => ({})) };
+}

--- a/frontend/e2e/budget/fixtures/budget-fixtures.ts
+++ b/frontend/e2e/budget/fixtures/budget-fixtures.ts
@@ -5,6 +5,7 @@ import { deleteTaskById } from '../../tasks/tasks-helpers';
 import {
   BUDGET_E2E_DEFAULT_PASSWORD,
   BUDGET_E2E_EMAILS,
+  resolveBudgetRbacHeaders,
   type BudgetE2EFixturePayload,
 } from './budget-e2e-types';
 
@@ -48,6 +49,7 @@ export type BudgetTaskFixture = {
   id: number;
   slug: string;
   projectId: number;
+  projectSlug: string;
   cleanup: () => Promise<void>;
 };
 
@@ -104,7 +106,6 @@ export async function apiAuthHeaders(
   }
   const body = await loginResp.json();
   const token = body.token as string;
-  const user = body.user as { roles?: string[]; team_id?: number };
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
     'Content-Type': 'application/json',
@@ -112,12 +113,20 @@ export async function apiAuthHeaders(
   if (body.organization_access_token) {
     headers['X-Organization-Token'] = body.organization_access_token;
   }
-  if (user?.roles?.length) {
-    headers['x-user-role'] = user.roles[0];
+
+  const fixtures = loadBudgetE2EFixtures();
+  if (fixtures) {
+    Object.assign(headers, resolveBudgetRbacHeaders(fixtures, email));
+  } else {
+    const user = body.user as { roles?: string[]; team_id?: number };
+    if (user?.roles?.length) {
+      headers['x-user-role'] = user.roles[0];
+    }
+    if (user?.team_id) {
+      headers['x-team-id'] = String(user.team_id);
+    }
   }
-  if (user?.team_id) {
-    headers['x-team-id'] = String(user.team_id);
-  }
+
   return headers;
 }
 
@@ -219,29 +228,49 @@ export async function createIsolatedBudgetTask(
   } = {},
 ): Promise<BudgetTaskFixture> {
   const fixtures = requireBudgetE2EFixtures();
+  const projectKind = opts.projectKind ?? 'chain';
   const projectId =
-    opts.projectKind === 'single' ? fixtures.single_approver_project_id : fixtures.project_id;
+    projectKind === 'single' ? fixtures.single_approver_project_id : fixtures.project_id;
+  const projectSlug =
+    projectKind === 'single' ? fixtures.single_approver_project_slug : fixtures.project_slug;
+  const approverId = opts.approverId ?? fixtures.users.approver_a.user_id;
   const task = await createBudgetTaskViaApi(
     page,
     projectId,
     summary,
-    opts.taskOverrides ?? {},
-    opts.projectKind ?? 'chain',
+    {
+      current_approver_id: approverId,
+      ...(opts.taskOverrides ?? {}),
+    },
+    projectKind,
   );
   await attachBudgetDetailsViaApi(page, task.id, {
     amount: opts.amount,
-    approverId: opts.approverId,
-    projectKind: opts.projectKind,
+    approverId,
+    projectKind,
   });
 
   return {
     id: task.id,
     slug: task.slug,
     projectId,
+    projectSlug,
     cleanup: async () => {
       await deleteTaskById(page, task.id).catch(() => {});
     },
   };
+}
+
+export async function submitBudgetTaskViaApi(
+  page: Page,
+  task: { slug: string },
+  requesterEmail: string,
+  projectKind: 'chain' | 'single' = 'chain',
+): Promise<void> {
+  const result = await postTaskAction(page, task, 'submit', requesterEmail, {}, projectKind);
+  if (result.status < 200 || result.status >= 300) {
+    throw new Error(`Failed to submit budget task (${result.status}): ${JSON.stringify(result.body)}`);
+  }
 }
 
 export async function fetchTaskJson(

--- a/frontend/e2e/budget/fixtures/budget-helpers.ts
+++ b/frontend/e2e/budget/fixtures/budget-helpers.ts
@@ -1,4 +1,7 @@
 import { expect, type Page } from '@playwright/test';
+import { waitForTasksPageReady } from '../../tasks/tasks-helpers';
+
+const gotoOpts = { waitUntil: 'domcontentloaded' as const };
 
 export async function waitForTaskDrawerReady(page: Page): Promise<void> {
   await expect(page.getByTestId('task-drawer')).toBeVisible({ timeout: 15_000 });
@@ -9,19 +12,30 @@ export async function waitForTaskDrawerReady(page: Page): Promise<void> {
 }
 
 export async function openTaskDetail(page: Page, taskSlug: string, projectId: number): Promise<void> {
-  await page.goto(`/tasks/${encodeURIComponent(taskSlug)}?project_id=${projectId}`);
-  await page.waitForLoadState('networkidle');
+  await page.goto(`/tasks/${encodeURIComponent(taskSlug)}?project_id=${projectId}`, gotoOpts);
+  await waitForTasksPageReady(page);
+  await expect(page).toHaveURL(new RegExp(`/tasks/${escapeRegex(taskSlug)}(?:\\?|$)`), {
+    timeout: 20_000,
+  });
+  await expect(page.getByRole('heading', { name: /budget details/i })).toBeVisible({
+    timeout: 20_000,
+  });
 }
 
-export async function openTaskDrawer(page: Page, projectId: number, taskId: number): Promise<void> {
-  await page.goto(`/tasks?project_id=${projectId}&drawerTaskId=${taskId}`);
+export async function openTaskDrawer(page: Page, projectId: number, taskSlug: string): Promise<void> {
+  await page.goto(
+    `/tasks?project_id=${projectId}&drawerTask=${encodeURIComponent(taskSlug)}`,
+    gotoOpts,
+  );
+  await waitForTasksPageReady(page);
+  await page.getByTestId('tab-tasks').click().catch(() => {});
   await waitForTaskDrawerReady(page);
 }
 
 export async function clickFsmButton(page: Page, label: string): Promise<void> {
   const btn = page.getByRole('button', { name: label, exact: true });
-  await expect(btn).toBeVisible({ timeout: 10_000 });
-  await expect(btn).toBeEnabled();
+  await expect(btn).toBeVisible({ timeout: 15_000 });
+  await expect(btn).toBeEnabled({ timeout: 15_000 });
   await btn.click();
 }
 
@@ -42,32 +56,43 @@ export async function startReviewOnDetail(page: Page): Promise<void> {
   });
   await clickFsmButton(page, 'Start Review');
   await responsePromise;
-  await expect(page.getByText(/under.?review/i).first()).toBeVisible({ timeout: 10_000 });
+  await expectStatusChip(page, /under.?review/i);
 }
 
-export async function approveWithComment(page: Page, comment: string): Promise<void> {
-  await expect(page.locator('#review-comment')).toBeVisible({ timeout: 15_000 });
-  await page.locator('#review-comment').fill(comment);
-  const responsePromise = page.waitForResponse((resp) => {
+export async function approveWithComment(page: Page, _comment?: string): Promise<void> {
+  const approvalPromise = page.waitForResponse((resp) => {
     const url = new URL(resp.url()).pathname;
     return url.includes('/make-approval') && resp.request().method() === 'POST';
   });
+  const reloadPromise = page.waitForResponse((resp) => {
+    const url = new URL(resp.url()).pathname;
+    return /\/api\/tasks\/[^/]+\/?$/.test(url) && resp.request().method() === 'GET';
+  });
   await clickFsmButton(page, 'Approve');
-  await responsePromise;
+  const approvalResp = await approvalPromise;
+  expect(approvalResp.ok()).toBeTruthy();
+  await reloadPromise.catch(() => {});
+}
+
+export async function expectAdminOverrideBadge(page: Page): Promise<void> {
+  await expect(page.getByTestId('admin-override-badge').first()).toBeVisible({
+    timeout: 15_000,
+  });
 }
 
 export async function rejectWithComment(page: Page, comment: string): Promise<void> {
-  await expect(page.locator('#review-comment')).toBeVisible({ timeout: 15_000 });
-  await page.locator('#review-comment').fill(comment);
   await clickFsmButton(page, 'Reject');
-  await expect(page.getByText(/rejected/i).first()).toBeVisible({ timeout: 10_000 });
-}
-
-export async function expectApprovalChainProgress(page: Page, chainName: string): Promise<void> {
-  await expect(page.getByText(/approval chain/i)).toBeVisible({ timeout: 10_000 });
-  await expect(page.getByText(chainName)).toBeVisible({ timeout: 10_000 });
+  const textarea = page.getByPlaceholder(/explain why you're rejecting/i);
+  await expect(textarea).toBeVisible({ timeout: 10_000 });
+  await textarea.fill(comment);
+  await page.getByRole('button', { name: 'Confirm reject', exact: true }).click();
+  await expectStatusChip(page, /rejected/i);
 }
 
 export async function expectStatusChip(page: Page, pattern: RegExp): Promise<void> {
   await expect(page.getByText(pattern).first()).toBeVisible({ timeout: 10_000 });
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/frontend/e2e/budget/fixtures/budget-helpers.ts
+++ b/frontend/e2e/budget/fixtures/budget-helpers.ts
@@ -1,0 +1,73 @@
+import { expect, type Page } from '@playwright/test';
+
+export async function waitForTaskDrawerReady(page: Page): Promise<void> {
+  await expect(page.getByTestId('task-drawer')).toBeVisible({ timeout: 15_000 });
+  await page.waitForFunction(
+    () => !document.querySelector('.animate-pulse'),
+    { timeout: 15_000 },
+  );
+}
+
+export async function openTaskDetail(page: Page, taskSlug: string, projectId: number): Promise<void> {
+  await page.goto(`/tasks/${encodeURIComponent(taskSlug)}?project_id=${projectId}`);
+  await page.waitForLoadState('networkidle');
+}
+
+export async function openTaskDrawer(page: Page, projectId: number, taskId: number): Promise<void> {
+  await page.goto(`/tasks?project_id=${projectId}&drawerTaskId=${taskId}`);
+  await waitForTaskDrawerReady(page);
+}
+
+export async function clickFsmButton(page: Page, label: string): Promise<void> {
+  const btn = page.getByRole('button', { name: label, exact: true });
+  await expect(btn).toBeVisible({ timeout: 10_000 });
+  await expect(btn).toBeEnabled();
+  await btn.click();
+}
+
+export async function submitBudgetTaskFromDrawer(page: Page): Promise<void> {
+  const responsePromise = page.waitForResponse((resp) => {
+    const url = new URL(resp.url()).pathname;
+    return url.includes('/submit') && resp.request().method() === 'POST';
+  });
+  await clickFsmButton(page, 'Submit');
+  await responsePromise;
+  await expect(page.getByText(/submitted/i).first()).toBeVisible({ timeout: 10_000 });
+}
+
+export async function startReviewOnDetail(page: Page): Promise<void> {
+  const responsePromise = page.waitForResponse((resp) => {
+    const url = new URL(resp.url()).pathname;
+    return url.includes('/start-review') && resp.request().method() === 'POST';
+  });
+  await clickFsmButton(page, 'Start Review');
+  await responsePromise;
+  await expect(page.getByText(/under.?review/i).first()).toBeVisible({ timeout: 10_000 });
+}
+
+export async function approveWithComment(page: Page, comment: string): Promise<void> {
+  await expect(page.locator('#review-comment')).toBeVisible({ timeout: 15_000 });
+  await page.locator('#review-comment').fill(comment);
+  const responsePromise = page.waitForResponse((resp) => {
+    const url = new URL(resp.url()).pathname;
+    return url.includes('/make-approval') && resp.request().method() === 'POST';
+  });
+  await clickFsmButton(page, 'Approve');
+  await responsePromise;
+}
+
+export async function rejectWithComment(page: Page, comment: string): Promise<void> {
+  await expect(page.locator('#review-comment')).toBeVisible({ timeout: 15_000 });
+  await page.locator('#review-comment').fill(comment);
+  await clickFsmButton(page, 'Reject');
+  await expect(page.getByText(/rejected/i).first()).toBeVisible({ timeout: 10_000 });
+}
+
+export async function expectApprovalChainProgress(page: Page, chainName: string): Promise<void> {
+  await expect(page.getByText(/approval chain/i)).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText(chainName)).toBeVisible({ timeout: 10_000 });
+}
+
+export async function expectStatusChip(page: Page, pattern: RegExp): Promise<void> {
+  await expect(page.getByText(pattern).first()).toBeVisible({ timeout: 10_000 });
+}

--- a/frontend/e2e/budget/fixtures/budget-users.ts
+++ b/frontend/e2e/budget/fixtures/budget-users.ts
@@ -1,0 +1,155 @@
+import { type Browser, type BrowserContext, type Page } from '@playwright/test';
+import { waitForTasksPageReady } from '../../tasks/tasks-helpers';
+import { BUDGET_E2E_DEFAULT_PASSWORD, type BudgetE2EFixturePayload } from './budget-e2e-types';
+import { loadBudgetE2EFixtures } from './budget-fixtures';
+
+type LoginPayload = {
+  token: string;
+  refresh: string;
+  user: Record<string, unknown>;
+  organization_access_token?: string | null;
+};
+
+type ProjectSeed = {
+  id: number;
+  slug?: string;
+  name?: string;
+};
+
+export type BudgetUserSession = {
+  email: string;
+  context: BrowserContext;
+  page: Page;
+  close: () => Promise<void>;
+};
+
+async function loginRequest(
+  page: Page,
+  email: string,
+  password: string,
+): Promise<LoginPayload> {
+  const origin = process.env.BASE_URL || 'http://localhost';
+  const response = await page.request.post(`${origin}/auth/login/`, {
+    headers: { 'Content-Type': 'application/json' },
+    data: { email, password },
+  });
+  if (!response.ok()) {
+    throw new Error(`Budget E2E login failed for ${email} (${response.status()}): ${await response.text()}`);
+  }
+  return response.json() as Promise<LoginPayload>;
+}
+
+async function seedAuthStorage(
+  page: Page,
+  auth: LoginPayload,
+  project: ProjectSeed,
+): Promise<void> {
+  await page.goto('/login', { waitUntil: 'domcontentloaded' });
+  await page.evaluate(
+    ({ authState, activeProject }) => {
+      localStorage.setItem(
+        'auth-storage-v1',
+        JSON.stringify({
+          state: {
+            token: authState.token,
+            refreshToken: authState.refresh,
+            organizationAccessToken: authState.organization_access_token ?? null,
+            user: authState.user,
+            isAuthenticated: true,
+            userTeams: [],
+            selectedTeamId: null,
+            loading: false,
+            initialized: true,
+            hasHydrated: true,
+          },
+          version: 0,
+        }),
+      );
+      localStorage.setItem(
+        'project-storage-v1',
+        JSON.stringify({
+          state: {
+            activeProject,
+            activeProjectIds: [activeProject.id],
+            inactiveProjectIds: [],
+            completedProjectIds: [],
+          },
+          version: 0,
+        }),
+      );
+    },
+    { authState: auth, activeProject: project },
+  );
+}
+
+export async function openBudgetUserSession(
+  browser: Browser,
+  email: string,
+  password: string = BUDGET_E2E_DEFAULT_PASSWORD,
+  projectKind: 'chain' | 'single' = 'chain',
+): Promise<BudgetUserSession> {
+  const fixtures = loadBudgetE2EFixtures();
+  if (!fixtures) {
+    throw new Error('Budget E2E fixtures file missing — run issue_budget_e2e_fixtures first.');
+  }
+
+  const project =
+    projectKind === 'single'
+      ? {
+          id: fixtures.single_approver_project_id,
+          slug: fixtures.single_approver_project_slug,
+          name: fixtures.single_approver_project_name,
+        }
+      : {
+          id: fixtures.project_id,
+          slug: fixtures.project_slug,
+          name: fixtures.project_name,
+        };
+
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const auth = await loginRequest(page, email, password);
+  const origin = process.env.BASE_URL || 'http://localhost';
+  const setActiveKey = project.slug ?? String(project.id);
+  const setActiveResp = await page.request.post(
+    `${origin}/api/core/projects/${encodeURIComponent(setActiveKey)}/set_active/`,
+    {
+      headers: {
+        Authorization: `Bearer ${auth.token}`,
+        'Content-Type': 'application/json',
+        ...(auth.organization_access_token
+          ? { 'X-Organization-Token': auth.organization_access_token }
+          : {}),
+      },
+    },
+  );
+  if (!setActiveResp.ok()) {
+    throw new Error(
+      `Failed to set active project for ${email} (${setActiveResp.status()}): ${await setActiveResp.text()}`,
+    );
+  }
+  await seedAuthStorage(page, auth, {
+    id: project.id,
+    slug: project.slug,
+    name: project.name,
+  });
+  await page.goto('/tasks', { waitUntil: 'domcontentloaded' });
+  await waitForTasksPageReady(page);
+
+  return {
+    email,
+    context,
+    page,
+    close: async () => {
+      await context.close();
+    },
+  };
+}
+
+export function fixtureEmail(role: keyof BudgetE2EFixturePayload['users']): string {
+  const fixtures = loadBudgetE2EFixtures();
+  if (!fixtures) {
+    throw new Error('Budget E2E fixtures file missing.');
+  }
+  return fixtures.users[role].email;
+}

--- a/frontend/e2e/budget/fixtures/budget-users.ts
+++ b/frontend/e2e/budget/fixtures/budget-users.ts
@@ -1,6 +1,6 @@
 import { type Browser, type BrowserContext, type Page } from '@playwright/test';
 import { waitForTasksPageReady } from '../../tasks/tasks-helpers';
-import { BUDGET_E2E_DEFAULT_PASSWORD, type BudgetE2EFixturePayload } from './budget-e2e-types';
+import { BUDGET_E2E_DEFAULT_PASSWORD, resolveBudgetRbacAuthState, type BudgetE2EFixturePayload } from './budget-e2e-types';
 import { loadBudgetE2EFixtures } from './budget-fixtures';
 
 type LoginPayload = {
@@ -43,10 +43,11 @@ async function seedAuthStorage(
   page: Page,
   auth: LoginPayload,
   project: ProjectSeed,
+  rbac: { roles: string[]; userTeams: number[]; selectedTeamId: number | null },
 ): Promise<void> {
   await page.goto('/login', { waitUntil: 'domcontentloaded' });
   await page.evaluate(
-    ({ authState, activeProject }) => {
+    ({ authState, activeProject, rbacState }) => {
       localStorage.setItem(
         'auth-storage-v1',
         JSON.stringify({
@@ -54,10 +55,14 @@ async function seedAuthStorage(
             token: authState.token,
             refreshToken: authState.refresh,
             organizationAccessToken: authState.organization_access_token ?? null,
-            user: authState.user,
+            user: {
+              ...authState.user,
+              roles: rbacState.roles,
+              team_id: rbacState.selectedTeamId ?? undefined,
+            },
             isAuthenticated: true,
-            userTeams: [],
-            selectedTeamId: null,
+            userTeams: rbacState.userTeams,
+            selectedTeamId: rbacState.selectedTeamId,
             loading: false,
             initialized: true,
             hasHydrated: true,
@@ -78,7 +83,7 @@ async function seedAuthStorage(
         }),
       );
     },
-    { authState: auth, activeProject: project },
+    { authState: auth, activeProject: project, rbacState: rbac },
   );
 }
 
@@ -132,7 +137,7 @@ export async function openBudgetUserSession(
     id: project.id,
     slug: project.slug,
     name: project.name,
-  });
+  }, resolveBudgetRbacAuthState(fixtures, email));
   await page.goto('/tasks', { waitUntil: 'domcontentloaded' });
   await waitForTasksPageReady(page);
 
@@ -141,7 +146,7 @@ export async function openBudgetUserSession(
     context,
     page,
     close: async () => {
-      await context.close();
+      await context.close().catch(() => {});
     },
   };
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "build-storybook": "storybook build",
     "chromatic": "chromatic --exit-zero-on-changes",
     "test:e2e": "playwright test",
+    "test:e2e:budget": "playwright test --project=budget-e2e",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:cypress": "cypress run",
     "test:e2e:cypress:open": "cypress open",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "build-storybook": "storybook build",
     "chromatic": "chromatic --exit-zero-on-changes",
     "test:e2e": "playwright test",
-    "test:e2e:budget": "playwright test --project=budget-e2e",
+    "test:e2e:budget": "playwright test --project=budget-e2e --workers=1",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:cypress": "cypress run",
     "test:e2e:cypress:open": "cypress open",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -157,8 +157,11 @@ export default defineConfig({
     {
       /* Real-backend budget flows: multi-user login via issue_budget_e2e_fixtures. */
       name: 'budget-e2e',
+      timeout: 90_000,
       use: {
         ...devices['Desktop Chrome'],
+        actionTimeout: 20_000,
+        navigationTimeout: 45_000,
       },
       testMatch: budgetRealE2eSpecs,
     },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -44,7 +44,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: process.env.CI ? [['html', { open: 'never' }], ['github']] : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`. Next.js dev runs on 3000. */

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -12,6 +12,13 @@ const useExistingServer =
   process.env.E2E_USE_EXISTING_SERVER === '1' ||
   process.env.E2E_USE_EXISTING_SERVER === 'true';
 
+const budgetRealE2eSpecs = [
+  /e2e[\\/]budget[\\/]budget-multi-step-chain\.spec\.ts$/,
+  /e2e[\\/]budget[\\/]budget-single-approver\.spec\.ts$/,
+  /e2e[\\/]budget[\\/]budget-reject-reopen-flow\.spec\.ts$/,
+  /e2e[\\/]budget[\\/]budget-admin-override-real\.spec\.ts$/,
+];
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -47,8 +54,8 @@ export default defineConfig({
       : undefined,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
-    
+    trace: process.env.CI ? 'retain-on-failure' : 'on-first-retry',
+    screenshot: 'only-on-failure',
   },
 
   /* Configure projects */
@@ -64,7 +71,7 @@ export default defineConfig({
         storageState: 'e2e/.auth/user.json',
       },
       dependencies: ['setup'],
-      testIgnore: /e2e[\\/]auth[\\/]/,
+      testIgnore: [/e2e[\\/]auth[\\/]/, ...budgetRealE2eSpecs],
     },
     {
       name: 'firefox',
@@ -73,7 +80,7 @@ export default defineConfig({
         storageState: 'e2e/.auth/user.json',
       },
       dependencies: ['setup'],
-      testIgnore: /e2e[\\/]auth[\\/]/,
+      testIgnore: [/e2e[\\/]auth[\\/]/, ...budgetRealE2eSpecs],
     },
     {
       name: 'webkit',
@@ -82,7 +89,7 @@ export default defineConfig({
         storageState: 'e2e/.auth/user.json',
       },
       dependencies: ['setup'],
-      testIgnore: /e2e[\\/]auth[\\/]/,
+      testIgnore: [/e2e[\\/]auth[\\/]/, ...budgetRealE2eSpecs],
     },
     {
       name: 'auth-chromium',
@@ -146,6 +153,14 @@ export default defineConfig({
         ...devices['Desktop Chrome'],
       },
       testMatch: /e2e[\\/]budget[\\/]budget-admin-override\.spec\.ts$/,
+    },
+    {
+      /* Real-backend budget flows: multi-user login via issue_budget_e2e_fixtures. */
+      name: 'budget-e2e',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+      testMatch: budgetRealE2eSpecs,
     },
   ],
 });

--- a/variations-studio-api/tests/support/fixtures.ts
+++ b/variations-studio-api/tests/support/fixtures.ts
@@ -130,12 +130,12 @@ async function createProject(args: {
       INSERT INTO ${tenantTable(schema, 'core_project')} (
         id, created_at, updated_at, is_deleted, name, description,
         project_type, work_model, advertising_platforms, objectives, kpis,
-        pacing_enabled, budget_config, audience_targeting,
+        pacing_enabled, ai_analysis_enabled, budget_config, audience_targeting,
         organization_id, owner_id, slug
       ) VALUES (
         ${id}, now(), now(), false, ${`Studio test ${args.label}`}, '',
         '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, '{}'::jsonb,
-        false, '{}'::jsonb, '{}'::jsonb,
+        false, true, '{}'::jsonb, '{}'::jsonb,
         ${args.organizationId}, ${BigInt(args.ownerId)}, ${slug}
       )`;
   }

--- a/variations-studio-api/tests/support/tenantRoutingFixtures.ts
+++ b/variations-studio-api/tests/support/tenantRoutingFixtures.ts
@@ -123,12 +123,12 @@ async function createProject(args: {
       INSERT INTO ${tenantTable(schema, 'core_project')} (
         id, created_at, updated_at, is_deleted, name, description,
         project_type, work_model, advertising_platforms, objectives, kpis,
-        pacing_enabled, budget_config, audience_targeting,
+        pacing_enabled, ai_analysis_enabled, budget_config, audience_targeting,
         organization_id, owner_id, slug
       ) VALUES (
         ${id}, now(), now(), false, ${`Routing ${args.label}`}, '',
         '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, '{}'::jsonb,
-        false, '{}'::jsonb, '{}'::jsonb,
+        false, true, '{}'::jsonb, '{}'::jsonb,
         ${args.organizationId}, ${BigInt(args.ownerId)}, ${slug}
       )`;
   }


### PR DESCRIPTION
## Summary
- Add `issue_budget_e2e_fixtures` management command and Playwright budget E2E specs (multi-step chain, single approver, reject/revise/resubmit, org-admin override).
- Fix V2 Task UI helpers, org-admin `make-approval` budget lookup, and double chain advance after admin override.
- Wire budget E2E into `application_test` CI with anchor provisioning, fixture generation, and Playwright trace/report artifacts on failure.
## Test plan
- [ ] `docker compose -p mediajira-v2 -f docker-compose.dev.yml exec backend pytest budget_approval/tests/test_issue_budget_e2e_fixtures.py budget_approval/tests/test_services.py -k override`
- [ ] Local E2E: generate fixtures then `cd frontend && E2E_USE_EXISTING_SERVER=1 BASE_URL=http://localhost npm run test:e2e:budget`
- [ ] CI `application_test` passes (budget Playwright step + artifact upload)
